### PR TITLE
[Enhancement] Added: define-composite-function

### DIFF
--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -73,6 +73,7 @@
 	       (:file "distributions/dense")
 	       (:file "distributions/sparse")
 	       (:file "distributions/ziggurat")
+	       (:file "distributions/weights")
 
 	       (:file "nn/package")
 	       (:file "nn/activation")

--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -116,17 +116,18 @@
 	       (:file "vm/nodes/t/parser")
 	       (:file "vm/nodes/t/shape")
 	       (:file "vm/nodes/t/nodes")
+	       (:file "vm/nodes/t/composite")
 
 	       (:file "base-impl/t/package")
 	       (:file "base-impl/t/reduction")
 	       (:file "base-impl/t/arithmetic")
 	       (:file "base-impl/t/mathematical")
 	       (:file "base-impl/t/apis")
-
-	       (:file "backends/lisp/t/package")
 	       
 	       (:file "backends/cpu/t/package")
 	       (:file "backends/cpu/t/arithmetic")
+
+	       (:file "backends/lisp/t/package")
 	       
 	       )
   :perform (test-op (o s)

--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -81,6 +81,7 @@
 	       (:file "nn/criterion")
 	       
 	       (:file "optimizers/package")
+	       (:file "optimizers/defoptimizer")
 
 	       (:file "package")
 	       (:file "utils")

--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -42,6 +42,7 @@
 	       (:file "vm/nodes/defnode")
 	       (:file "vm/nodes/defmodel")
 	       (:file "vm/nodes/utils")
+	       (:file "vm/nodes/function")
 
 	       
 	       (:file "base-impl/arithmetic")

--- a/docs/apis/distributions.lisp
+++ b/docs/apis/distributions.lisp
@@ -5,8 +5,8 @@
 
 ;; TODO: Insert Some Examples.
 (with-page *distributions* "Distributions"
-  (with-section "Samples matrices from distribution"
-    (insert "cl-waffe2 provides a package :cl-waffe2/distributions which is used to sample matrices from the distributions.")
+  (with-section "Sampling matrices from distribution"
+    (insert "cl-waffe2 provides a package `:cl-waffe2/distributions` which is used to sample matrices from the distributions.")
 
     (with-section "Common Format to the APIs"
       (insert "All sampling functions are defined in the following format via `define-tensor-initializer` macro.

--- a/docs/apis/generic-tensor.lisp
+++ b/docs/apis/generic-tensor.lisp
@@ -3,18 +3,49 @@
 
 (with-page *generic-tensor* "AbstractTensor"
   (macrolet ((with-doc (name type &body body)
-	       `(with-section (format nil "~(~a~)" (symbol-name ,name))
+	       `(progn;;with-section (format nil "~(~a~)" (symbol-name ,name))
 		  (placedoc ,name ,type)
 		  ,@body)))
 
     ;; AbstractTensor
-    (with-section "AbstractTensor"
+    (with-section "[class] AbstractTensor"
       (insert "
 [class] `AbstractTensor`
 
 ~a"
-	      (documentation (find-class 'AbstractTensor) 't))
+	      (documentation (find-class 'AbstractTensor) 't)))
 
+    (with-section "[function] tensor-vec"
+      (insert "~%`(tensor-vec tensor)`
+
+Reading the `vec` of tensor.  Not until tensor-vec is called, the new area isn't allocated."))
+    
+    (with-section "[function] mref"
+      (insert "~%`(mref tensor &rest subscripts)`~%~%~a" (documentation 'mref 'function)))
+
+    (with-section "[generic] vref"
+      (insert "~%`(vref tensor index)`~%~%~a"
+	      (documentation (car (c2mop:generic-function-methods #'vref)) 't)))
+    
+    (with-section "An form of tensors in cl-waffe2"
+      (insert "There's a two type of tensors in cl-waffe2: `InputTensor` and `ExistTensor`, each state is called `facet` and the keyword `:input` `:exist` is dispatched respectively.~%")
+
+      (insert "### ExistTensor
+`ExistTensor` means a tensor with its vec **allocated** in the memory, that is, the same tensor as tensors you got when create a new tensor in `Numpy`, `PyTorch` or something.
+
+`ExistTensor` can be created by the function `make-tensor`.
+
+~%")
+      (insert "### InputTensor
+On the other hand, `InputTensor` is a tensor with its vec **unallocated** in the memory, in other words, this can be a `Lazy-Evaluated Tensor`.
+
+`InputTensor` is created by the function `make-input`, and its shape can include a symbol.
+
+In the network, `InputTensor` plays a role in being caches in the operation, or being a tensor that one may want to change its content later. (e.g.: training data).
+~%"))
+    
+    (progn
+      ;; Making a new tensor.
       (with-doc 'make-tensor 'function
 	(with-example
 	  "(make-tensor `(10 10) :initial-element 1.0)"))
@@ -23,45 +54,28 @@
       (with-doc 'make-input 'function
 	(with-example
 	  "(make-input `(a 10) :train-x)")
-	(insert "The InputTensor named with a keyword is called `not-embodied tensor`, and can be changed its `vec` with `embody-input`"))
-      
-      ;; with-example
+	(insert "The InputTensor named with a keyword is called `not-embodied tensor`, and can be changed its `vec` with `embody-input`")))
 
-      #|
-      (with-doc 'embody-input 'function
-	(with-examples
-	  "(setq out (!add (randn `(10 10)) (make-input `(a 10) :x)))"
-	  "(with-build (fw bw vars params) out
-            (embody-input vars :x (randn `(10 10))) ;; :X = (randn `(10 10))
-            (funcall fw))"))
-      |#
-      
-      ;; with-example      
-      (with-doc 'build 'function
-	(with-examples
-	  "(setq out (!add (randn `(10 10)) (make-input `(a 10) :X)))"
-	  "(multiple-value-list (build out))"))
+    ;; Composite
+    
+    (insert "~a"
+	    (documentation (find-class 'Compiled-Composite) 't))
+    ;; with-example      
+    (with-doc 'build 'function
+      (with-examples
+	"(setq out (!add (randn `(10 10)) (make-input `(a 10) :X)))"
+	"(multiple-value-list (build out))"))
 
-      
-      ;; Accessors
-      (with-section "tensor-vec"
-	(insert "~%`(tensor-vec tensor)`
+    
+    (insert "~a"
+	    (documentation (car (c2mop:generic-function-methods #'set-input)) 't))
 
-Accessing the pointer/array the tensor has. Not until tensor-vec is called, the new area isn't allocated."))
-
-      (with-section "mref"
-	(insert "~%`(mref tensor &rest subscripts)`~%~%~a" (documentation 'mref 'function)))
-
-      (with-section "vref"
-	(insert "~%`(vref tensor index)`~%~%~a"
-		(documentation (car (c2mop:generic-function-methods #'vref)) 't))))
-
-    (with-doc 'set-save-for-backward 'function)
-    (with-doc 'read-save-for-backward 'function)
+    (insert "~a"
+	    (documentation (car (c2mop:generic-function-methods #'get-input)) 't))
 
     
     ;; Gradient Utils
-    (with-section "`*no-grad*`"
+    (with-section "[parameter] `*no-grad*`"
       (insert "[parameter] `*no-grad*`
 
 ~a" (documentation '*no-grad* 'variable)))
@@ -70,8 +84,6 @@ Accessing the pointer/array the tensor has. Not until tensor-vec is called, the 
     (with-doc 'with-no-grad 'macro)
     
     (with-doc 'parameter 'function)
-
-    (with-doc 'dtype->lisp-type 'function)
 
     (with-doc 'call-with-view 'function)
 
@@ -82,8 +94,15 @@ Accessing the pointer/array the tensor has. Not until tensor-vec is called, the 
     (with-doc 'offset-of 'function)
 
     (with-doc 'shape-equal 'function)
-
+    
     (with-doc 'force-list 'function)
+
+    (with-section "Compiling Options"
+      (insert "TODO"))
+
+    (with-section "Dtypes"
+      (insert "TODO"))
+    
     ))
 
 

--- a/docs/apis/nodes.lisp
+++ b/docs/apis/nodes.lisp
@@ -17,15 +17,19 @@ defnode  => called with `forward`
 defmodel => called with `call`
 ```
 
-Also, defnode is a fundamental unit of operation, while defmodel is consisted of a set of nodes.
+Also, defnode is a fundamental unit of operation, while defmodel is a set of nodes.
 ")
 
   (macrolet ((with-doc (name type &body body)
 	       `(with-section (format nil "~(~a~)" (symbol-name ,name))
 		  (placedoc ,name ,type)
 		  ,@body)))
-    (with-section "Shaping APIs"
+    (with-section "Shaping API"
       (insert "
+
+When defining an operation in cl-waffe2 with a `defnode` macro, the shape of the matrix used in the operation must also be defined in the `:where` keyword.
+
+This is a Shaping API, and responsible for shape inspection of all operations.
 
 ## Introducing Subscript DSL
 
@@ -229,7 +233,7 @@ b = `(1 2) // List consisted of fixnum
 
 DSL flattens the list in the subscript. (e.g.: `b=(1 2)` in `A[b]` is the equivalent to `A[1 2]`)
 
-**Note that** ~~ is a reserved word and has a special rule:
+**Note that** ~~ is a reserved word by cl-waffe2 and has a special rule:
 
 1. ~~ is used to express dimensions from 0 to N
 
@@ -324,7 +328,7 @@ Outputs:
 Example: (TODO)
 
 "))
-    
+
     (with-section "defnode"
       (insert "
 ```lisp
@@ -478,9 +482,7 @@ Step forward of the given `node`, node is a subclass of `AbstractNode`.
 
 Note that `forward` can't handle with `Composite`."))
 
-    (with-doc 'defmodel 'macro
-
-      )
+    (with-doc 'defmodel 'macro)
 
     (with-doc 'call 'function
       (insert "~%~%`[generic-function]` (call model &rest inputs)"))
@@ -512,8 +514,5 @@ Note that `forward` can't handle with `Composite`."))
 
     (with-doc 'with-instant-kernel 'macro
       )
-
-    (with-doc 'declare-local-variables 'function
-      (insert "TODO"))
 
     ))

--- a/docs/cl-waffe2-docs/docs/Tips.md
+++ b/docs/cl-waffe2-docs/docs/Tips.md
@@ -1,7 +1,7 @@
 
 # Tips
 
-## Backend/Kernel Abstraction
+## Kernel Abstraction
 
 ## Adding a new backend
 

--- a/docs/cl-waffe2-docs/docs/base-impl.md
+++ b/docs/cl-waffe2-docs/docs/base-impl.md
@@ -346,6 +346,8 @@ one of: `MoveTensorNode` `ScalarTensorNode`
 
 `tensor[AbstractTensor]` tensor to be referred.
 
+`force[boolean]` If t, the pruning of operation by cl-waffe2 will never done.
+
 ### Output
 
 Unevaluated Copied Tensor.
@@ -500,6 +502,8 @@ If `measure-time`=t, ProceedNode wraps with time macro when calling **COMPILED**
 ```
 
 An alias for (proceed tensor :measure-time t)
+
+Note that: the proceed-time function invokes forward function twice times, in order for processing system to trace compiled lisp code, and ignoring allocation time.
 ## [function] proceed-backward
 
 ```
@@ -1171,7 +1175,7 @@ OUT_{copy}\gets{loge(X)}
 ## [function] !sum
 
 ```
-(!sum tensor &key (axis t) (-> nil) (keep-repeat nil))
+(!sum tensor &key (axis t) (-> nil) (keepdims nil))
 ```
 
 The function !sum return a node which computes the sum of tensor along the given axis.
@@ -1184,7 +1188,7 @@ The function !sum return a node which computes the sum of tensor along the given
 
 `->` [AbstractTensor or nil] the place to set the result. If nil, creates a new tensor.
 
-`keep-repeat`[boolean] If t, the axis reducted is repeated.
+`dims`[boolean] If t, the axis reducted is broadcasted.
 
 Return:
 
@@ -1192,7 +1196,7 @@ Return:
 ## [function] !mean
 
 ```
-(!mean tensor &key (axis t) (-> nil) (keep-repeat nil))
+(!mean tensor &key (axis t) (-> nil) (keepdims nil))
 ```
 
 The function !mean return a node which computes the average of tensor along the given axis.
@@ -1205,7 +1209,7 @@ The function !mean return a node which computes the average of tensor along the 
 
 `->` [AbstractTensor or nil] the place to set the result. If nil, creates a new tensor.
 
-`keep-repeat`[boolean] If t, the axis reducted is repeated.
+`keepdims` [boolean] If t, the axis reducted is broadcasted.
 
 ### Return
 

--- a/docs/cl-waffe2-docs/docs/distributions.md
+++ b/docs/cl-waffe2-docs/docs/distributions.md
@@ -16,11 +16,11 @@ That is, arguments passed to the `make-tensor` function can also be passed direc
 (normal `(10 10) 0.0 1.0 :requires-grad t)
 
 {CPUTENSOR[float] :shape (10 10)  
-  ((0.35961813   -0.2059159   1.4001919    ~ 0.077898845  -0.44244626  1.0635623)                    
-   (-1.016495    1.9627005    -1.1844752   ~ 0.15047064   -0.95344716  -1.6598125)   
+  ((0.4068227    1.8300191    -0.6377239   ~ 0.6835943    1.6533868    0.37351918)                    
+   (-0.61583096  0.18741547   1.0138013    ~ 0.24394189   0.43836308   -0.042538162)   
                  ...
-   (-1.2152638   0.30550015   0.012917101  ~ -0.06799416  -0.3919469   0.2048984)
-   (0.16792156   -0.10029652  1.2373703    ~ -0.6597983   0.5364762    0.04105287))
+   (-1.7132758   2.4784043    1.2369128    ~ -0.73461443  -0.35414895  -1.3457016)
+   (-1.9569589   -1.2259408   -0.44174623  ~ 0.20416868   -1.125249    0.86147213))
   :facet :exist
   :requires-grad T
   :backward NIL}
@@ -146,9 +146,9 @@ Note: My implementation is unstable, being occurs floating-overflow constantly..
 (beta `(3 3) 5.0 1.0)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((0.69012284 0.75272816 0.8312693)
-   (0.9785166  0.80858713 0.95975447)
-   (0.6866892  0.903407   0.97475606))
+  ((0.63958657 0.9093849  0.88275766)
+   (0.9621832  0.6543163  0.95516557)
+   (0.72667587 0.4694664  0.57423055))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -170,9 +170,9 @@ p - Takes 1 with probability p and 0 with probalibity (1-p).
 (bernoulli `(3 3) 0.3)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((1.0 0.0 0.0)
-   (0.0 1.0 1.0)
-   (0.0 0.0 0.0))
+  ((0.0 1.0 1.0)
+   (0.0 0.0 0.0)
+   (0.0 1.0 0.0))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -198,9 +198,9 @@ df - degree of freedom.
 (chisquare `(3 3) 1.0)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((0.3276539    0.16197506   0.92448807)
-   (0.65705556   3.8677952e-4 0.33302397)
-   (0.30150574   0.2048448    1.2764052))
+  ((0.0057623996 0.992885     0.002366773)
+   (0.69975215   0.38161486   0.21625721)
+   (3.7606885    1.1638411    1.8734814))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -227,9 +227,9 @@ The function expotential is a family of initializer functions, and samples the e
 (expotential `(3 3))
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((2.0468602   0.42217332  0.035641003)
-   (1.5259378   0.16441894  0.5597292)
-   (4.225213    0.08620251  0.68291944))
+  ((2.3558202  0.91076595 1.2019328)
+   (2.2057514  0.81595427 0.5702252)
+   (2.5444195  3.7771025  0.4159075))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -252,9 +252,9 @@ The function gamma is a family of initializer functions, and samples matrices fr
 (gamma `(3 3) 1.0)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((0.019726882 0.37907955  0.17126423)
-   (2.2088544   0.9756858   1.9436338)
-   (4.3594155   0.21998532  0.91787076))
+  ((0.015033166 0.09699598  0.18563458)
+   (1.6348156   1.5621002   0.4823327)
+   (0.7432411   0.40036893  2.7507722))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -309,9 +309,9 @@ Input:
 (uniform-random `(3 3) 2 4)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((3.263076  3.1209097 2.6771405)
-   (2.324503  3.5176752 3.7175438)
-   (3.8339875 3.1028507 3.2144558))
+  ((2.0773187 3.716677  2.846321)
+   (3.867027  2.5273712 3.0160313)
+   (2.3836665 3.7248738 3.0614033))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -339,9 +339,9 @@ The function randn is a family of initializer functions, and samples the gaussia
 (randn `(3 3))
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((1.5321895  0.46990195 1.4406842)
-   (0.56609684 -0.5118705 0.561935)
-   (0.8702531  1.035412   -1.2831343))
+  ((-0.1354243   0.878151     -0.33400086)
+   (0.7053966    -1.0682151   0.8744093)
+   (-0.046237823 -0.17542641  -0.6609302))
   :facet :exist
   :requires-grad NIL
   :backward NIL}

--- a/docs/cl-waffe2-docs/docs/distributions.md
+++ b/docs/cl-waffe2-docs/docs/distributions.md
@@ -1,8 +1,8 @@
 
 # Distributions
 
-## Samples matrices from distribution
-cl-waffe2 provides a package :cl-waffe2/distributions which is used to sample matrices from the distributions.
+## Sampling matrices from distribution
+cl-waffe2 provides a package `:cl-waffe2/distributions` which is used to sample matrices from the distributions.
 ## Common Format to the APIs
 All sampling functions are defined in the following format via `define-tensor-initializer` macro.
 
@@ -16,11 +16,11 @@ That is, arguments passed to the `make-tensor` function can also be passed direc
 (normal `(10 10) 0.0 1.0 :requires-grad t)
 
 {CPUTENSOR[float] :shape (10 10)  
-  ((0.4068227    1.8300191    -0.6377239   ~ 0.6835943    1.6533868    0.37351918)                    
-   (-0.61583096  0.18741547   1.0138013    ~ 0.24394189   0.43836308   -0.042538162)   
-                 ...
-   (-1.7132758   2.4784043    1.2369128    ~ -0.73461443  -0.35414895  -1.3457016)
-   (-1.9569589   -1.2259408   -0.44174623  ~ 0.20416868   -1.125249    0.86147213))
+  ((0.119613      0.0696617     -0.51845974   ~ 1.7004628     0.4996423     0.4897055)                     
+   (-1.1284642    -0.0064689103 -0.846032     ~ -0.5962948    -1.575406     -0.43004805)   
+                  ...
+   (0.7994743     1.0443226     -0.4768539    ~ -0.48059216   -0.7566383    0.0051765023)
+   (0.30147827    -0.72716165   -0.75564015   ~ -1.5878669    -1.4639511    -0.8897966))
   :facet :exist
   :requires-grad T
   :backward NIL}
@@ -146,9 +146,9 @@ Note: My implementation is unstable, being occurs floating-overflow constantly..
 (beta `(3 3) 5.0 1.0)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((0.63958657 0.9093849  0.88275766)
-   (0.9621832  0.6543163  0.95516557)
-   (0.72667587 0.4694664  0.57423055))
+  ((0.95213073 0.6845968  0.89657104)
+   (0.850316   0.9831104  0.6203682)
+   (0.8839493  0.8766788  0.85749966))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -170,9 +170,9 @@ p - Takes 1 with probability p and 0 with probalibity (1-p).
 (bernoulli `(3 3) 0.3)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((0.0 1.0 1.0)
-   (0.0 0.0 0.0)
-   (0.0 1.0 0.0))
+  ((0.0 0.0 0.0)
+   (1.0 1.0 0.0)
+   (0.0 0.0 1.0))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -198,9 +198,9 @@ df - degree of freedom.
 (chisquare `(3 3) 1.0)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((0.0057623996 0.992885     0.002366773)
-   (0.69975215   0.38161486   0.21625721)
-   (3.7606885    1.1638411    1.8734814))
+  ((0.0150622325 5.014997e-4  0.4076707)
+   (0.31016153   0.75013447   0.08534716)
+   (0.33567613   0.01176333   0.14503779))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -227,9 +227,9 @@ The function expotential is a family of initializer functions, and samples the e
 (expotential `(3 3))
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((2.3558202  0.91076595 1.2019328)
-   (2.2057514  0.81595427 0.5702252)
-   (2.5444195  3.7771025  0.4159075))
+  ((0.2955058   0.044480704 2.847021)
+   (1.0309886   1.8820623   0.6307436)
+   (0.013490636 1.9426202   1.9248267))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -252,9 +252,9 @@ The function gamma is a family of initializer functions, and samples matrices fr
 (gamma `(3 3) 1.0)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((0.015033166 0.09699598  0.18563458)
-   (1.6348156   1.5621002   0.4823327)
-   (0.7432411   0.40036893  2.7507722))
+  ((4.3934636  0.48888627 0.2965439)
+   (0.22882245 0.26897842 0.5933608)
+   (0.4539856  0.19267894 0.3890769))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -309,9 +309,9 @@ Input:
 (uniform-random `(3 3) 2 4)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((2.0773187 3.716677  2.846321)
-   (3.867027  2.5273712 3.0160313)
-   (2.3836665 3.7248738 3.0614033))
+  ((2.8210456 3.1823678 2.4381611)
+   (3.0901735 3.1590753 3.1356604)
+   (2.4130378 2.8690228 2.5649626))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -339,9 +339,9 @@ The function randn is a family of initializer functions, and samples the gaussia
 (randn `(3 3))
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((-0.1354243   0.878151     -0.33400086)
-   (0.7053966    -1.0682151   0.8744093)
-   (-0.046237823 -0.17542641  -0.6609302))
+  ((-0.18318851  0.71465474   -0.4738745)
+   (0.93874615   -0.044843636 -0.30596378)
+   (0.5556831    0.8649478    -1.0314406))
   :facet :exist
   :requires-grad NIL
   :backward NIL}

--- a/docs/cl-waffe2-docs/docs/generic-tensor.md
+++ b/docs/cl-waffe2-docs/docs/generic-tensor.md
@@ -1,7 +1,7 @@
 
 # AbstractTensor
 
-## AbstractTensor
+## [class] AbstractTensor
 
 [class] `AbstractTensor`
 
@@ -24,7 +24,7 @@ The class provides the fundamental and necessary features for tensors.
 
 7. Trace Informations for JIT to create well-optimized computation node.
 
-### Create a new backend.
+### Creating a new backend.
 
 Users can create a new backend by extending this abstract class.
 
@@ -72,6 +72,18 @@ Now, the name `MyBackend` is available as a brand-new cl-waffe2 backend!
 Users can define a new implementation following `(define-impl (Name :device MyBackend) ...)`
 
 (See the examples to understand how this could be achieved at ./source/backends/lisp/tensor.lisp. or ./source/backends/cpu.)
+
+### [function] shape
+
+Returns a visible shape of tensor
+
+### [function] dims
+
+Returns the number of axes of tensor
+
+### [function] total
+
+Returns the number of total visible elements in tensor.
 
 ### [slot] orig-shape (List)
 
@@ -159,7 +171,53 @@ Tensors has a two state:
 ...
 
 
-## make-tensor
+## [function] tensor-vec
+
+`(tensor-vec tensor)`
+
+Reading the `vec` of tensor.  Not until tensor-vec is called, the new area isn't allocated.
+## [function] mref
+
+`(mref tensor &rest subscripts)`
+
+The function mref is only used to print/initialize tensors, accessing the index of subscripts **with** considering views..
+
+If you cares about performance, dont' use `mref`, but `!view`.
+
+This function is setfable.
+## [generic] vref
+
+`(vref tensor index)`
+
+`vref` is a generic-function to access the `vec` slot of specific backends tensor, and returns `index`th element on `vec` slot **without** considering views.
+
+If you added a new backend with having different ptr-type (can't be accessed by aref), override this method and `(setf vref)`.
+
+### Example
+
+```lisp
+(defmethod vref ((tensor YourBackend) index)
+    (aref (tensor-vec tensor) index))
+
+(defmethod (setf vref) (new-value (tensor YourBackend) index)
+    (setf (aref (tensor-vec tensor) index) new-value))
+```
+
+## An form of tensors in cl-waffe2
+There's a two type of tensors in cl-waffe2: `InputTensor` and `ExistTensor`, each state is called `facet` and the keyword `:input` `:exist` is dispatched respectively.
+### ExistTensor
+`ExistTensor` means a tensor with its vec **allocated** in the memory, that is, the same tensor as tensors you got when create a new tensor in `Numpy`, `PyTorch` or something.
+
+`ExistTensor` can be created by the function `make-tensor`.
+
+
+### InputTensor
+On the other hand, `InputTensor` is a tensor with its vec **unallocated** in the memory, in other words, this can be a `Lazy-Evaluated Tensor`.
+
+`InputTensor` is created by the function `make-input`, and its shape can include a symbol.
+
+In the network, `InputTensor` plays a role in being caches in the operation, or being a tensor that one may want to change its content later. (e.g.: training data).
+
 
 ## [function] make-tensor
 
@@ -206,21 +264,19 @@ Refering a first-priority of  *using-backends* (i.e.: `car` of `*using-backends*
   :backward NIL}
 ```
 
-## make-input
-
 ## [function] make-input
 
-Referring a first-priority of *using-backend* (i.e.: car part), the function make-input creates a InputTensor.
+Referring a first-priority of `*using-backend*` (i.e.: car part), the function make-input creates a InputTensor.
 
 In contrast to `make-tensor`, allocation of `vec` is lazy-evaluated, and `shape` can include symbols. (Lazy-Evaluated Shape).
 
-For example, whichever `(make-input (list 256 256 256 256 256 256) nil)` or `(make-input (list 256) nil)` is called, the memory-usage is the same until `(tensor-vec tensor)` is called but the moment `(tensor-vec tensor)` is called, the first one would cause `CUDA OUT OF MEMORY` or something :(.
+For example, whichever `(make-input (list 256 256 256 ... 256 256 256) nil)` or `(make-input (list 256) nil)` is called, the memory-usage is the same until `(tensor-vec tensor)` is called but the moment `(tensor-vec tensor)` is called, the first one would cause `CUDA OUT OF MEMORY` or something :(.
 
 ### Inputs
 
-`Shape` [list] consisted of fixnum or symbol. (e.g.: `(a 10)` is a valid shape.)
+`Shape` [list] consisted of fixnum or symbol. (e.g.: `(a 10)` is OK for make-input.)
 
-`Named` [keyword] the name of input. If nil, the tensor is regarded as just cache. If you want to change the content of inputs later (e.g.: training data), set an appropriate name.
+`Named` [keyword] the name of input. If nil, the tensor is regarded as just cache. If you want to change the content of inputs later (e.g.: training data), set an appropriate name to `InputTensor` (e.g.: `:training-data` `:train-x`).
 
 `scalar-p` [boolean] set t is the input is scalar.
 
@@ -240,50 +296,71 @@ For example, whichever `(make-input (list 256 256 256 256 256 256) nil)` or `(ma
   :backward NIL}
 ```
 The InputTensor named with a keyword is called `not-embodied tensor`, and can be changed its `vec` with `embody-input`
-## embody-input
-(embody-input variables :a tensor)
-###Example
-**REPL:**
+## [class] Compiled-Composite
+
+Compiled-Composite is a `callable` CLOS class, and holds compiled forward/backward function of all the computation node to all the endpoints from the top of the models' neural network. Also, this class holds information of all variables used in the node.
+
+It is NOT possible to construct a computation node after Compiled-Composite, If you need this, try consider using the function `cl-waffe2/base-impl:proceed`.
+
+The class will appear in your project with calling the function `build`, set the toplevel node (e.g.: the result of criterion when the task is optimizing.) to the first argument. cl-waffe2 compiler will instantly construct an lambda function of forward/backward, which is invoked by calling `(forward compiled-composite)` or `(backward compiled-composite)` method.
+
+See also: `build` `set-input` `get-input`.
+
+### Examples
+
+(TODO)
+
+
+## [function] build
+
 ```lisp
-> (setq out (!add (randn `(10 10)) (make-input `(a 10) :x)))
-```
-```
-{CPUTENSOR[float] :shape (10 10) :named ChainTMP2742 
-  :vec-state [maybe-not-computed]
-  <<Not-Embodied (10 10) Tensor>>
-  :facet :input
-  :requires-grad NIL
-  :backward <Node: ADDNODE-CPUTENSOR (A[~] B[~] -> A[~])>}
+(build toplevel
+	      &key
+		(construct-backward? (not *no-grad*))
+		(compile-mode :fastest))
 ```
 
-**REPL:**
+Receiving the toplevel node in the neural network, the function `build` constructs a optimal forward/backward function, returning `Compiled-Composite`.
+
+### The constraints of toplevel tensor.
+
+The shape of topleve mustn't include a `symbol`.
+
+For example, this cl-waffe2 operation is invaild. because the function `(!sin x)` still returns `(A B)` tensor.
+
 ```lisp
-> (with-build (fw bw vars params) out
-            (embody-input vars :x (randn `(10 10))) ;; :X = (randn `(10 10))
-            (funcall fw))
-```
-```
-{CPUTENSOR[float] :shape (10 10) :named ChainTMP2731 
-  ((1.0010146     -0.24480553   -0.9825687    ~ -1.4212608    2.7377772     0.721311)                     
-   (0.72866976    -1.5144252    0.24458039    ~ 0.26790237    -2.6994684    -0.09221876)   
-                  ...
-   (4.0055227     -0.8050267    2.0541375     ~ -2.287451     0.26688823    2.6189566)
-   (0.48146668    0.9677067     0.8550117     ~ 1.2094214     -0.9150659    -0.38464153))
-  :facet :input
-  :requires-grad NIL
-  :backward NIL}
+(build (!sin (make-input `(A B) :Input)))
 ```
 
-## build
-Return:
-    (values forward backward variables parameters)
+In order to build this operation correctly, calling `criterion` (intrinsically, `!sum` or `!mean`) is a vaild option for neural network tasks.
+
+```lisp
+(build (!sum (!sin (make-input `(A B) :input)))) ;; Passes Correctly!
+```
+
+After working with adjustable shape tensor, don't forget to embody the InputTensor!
+
+```lisp
+(let ((compiled-model (build (!sum (!sin (make-input `(A B) :input))))))
+    (set-input compiled-model :input (randn `(10 10)))
+    (forward compiled-model))
+```
+
+### Inputs
+
+`toplevel [AbstractTensor]` the end of nodes. for neural network tasks, this should be scalartensor or tensors with total elements is 1, but since cl-waffe2 is intended to be applied other tasks, cl-waffe2 never produce warning while other frameworks like PyTorch will return error if `<<(10 10)Tensor>>.backward()` is invoked for example.
+
+`construct-backward?` [boolean] If t, the backward construction won't be done.
+
+`compile-mode`[compile-mode-t] an keyword to indicate compiling option.
+
 ###Example
 **REPL:**
 ```lisp
 > (setq out (!add (randn `(10 10)) (make-input `(a 10) :X)))
 ```
 ```
-{CPUTENSOR[float] :shape (10 10) :named ChainTMP2771 
+{CPUTENSOR[float] :shape (10 10) :named ChainTMP37143 
   :vec-state [maybe-not-computed]
   <<Not-Embodied (10 10) Tensor>>
   :facet :input
@@ -296,94 +373,109 @@ Return:
 > (multiple-value-list (build out))
 ```
 ```
-(#<FUNCTION (LAMBDA ()
-              :IN
-              "/Users/hikettei/.cache/common-lisp/sbcl-2.3.3-macosx-x64/Users/hikettei/Desktop/cl-waffe-workspace/progs/develop/cl-waffe2/docs/apis/generic-tensor.fasl") {53903BCB}>
- #<FUNCTION (LAMBDA ()
-              :IN
-              "/Users/hikettei/.cache/common-lisp/sbcl-2.3.3-macosx-x64/Users/hikettei/Desktop/cl-waffe-workspace/progs/develop/cl-waffe2/docs/apis/generic-tensor.fasl") {53810D7B}>
- += [Computation Node Information] =======+
+(<Compiled-Composite
+    forward:  #<FUNCTION (LAMBDA ()
+                           :IN
+                           "/private/var/tmp/slimetgnSEO.fasl") {53A1450B}>
+    backward: #<FUNCTION (LAMBDA ()
+                           :IN
+                           "/private/var/tmp/slimetgnSEO.fasl") {53A1510B}>
+
++= [Tensors in the computation node] =======+
 
 Subscripts:
-     [A -> ?]
+     [A -> ?, max=?]
 
 
-Variables
+Variables:
  NAMES |   SIZE  | 
 ––––––––––––––––––
    X   |  (A 10) | 
 
 
- - The number of tmp variables: 4
+ - The number of tmp variables : 4
+ - The number of parameters    : 0
 +========================================+
- #S(NODEPARAMETERS
-    :PARAMETERS (omitted)
-    :ntensors 3))
+>)
 ```
 
-## tensor-vec
+## [method] set-input
 
-`(tensor-vec tensor)`
+```
+(set-input (model Compiled-Composite) input-name actual-value)
+```
 
-Accessing the pointer/array the tensor has. Not until tensor-vec is called, the new area isn't allocated.
-## mref
+Embodies an `InputTensor` in the model. All unembodied tensors in the model can be accessed by printing the model.
 
-`(mref tensor &rest subscripts)`
+`input-name` could be a keyword indicating input-tensor, `actual-value` is a `AbstractTensor` whose facet = `:exist` (created by `make-tensor`).
 
-Read-only. Only used for printing the tensor.
-Whether you cares about performance or not, this function shouldn't be used ignoring for printing tensors.
-## vref
 
-`(vref tensor index)`
 
-vref is a generic-function to access tensor's vec.
+## [method] get-input
 
-Whether you cares about performance or not, this function shouldn't be used ignoring for printing tensors.
+```
+(get-input (model Compiled-Composite) input-name)
+```
 
-If you've created a new backend with having different ptr-type (can't be accessed by aref), only you have to do is to redefine vref.
-## set-save-for-backward
-NIL
-## read-save-for-backward
-NIL
-## `*no-grad*`
+Reading all variables in the computation node, the method get-input returns an corresponding `InputTensor` of model.
+
+
+## [parameter] `*no-grad*`
 [parameter] `*no-grad*`
 
-If t, all operations don't create gradients.
-## with-no-grad
-
+If t, no gradients are made for backwards.
 ## [macro] with-no-grad
 
 ```lisp
 (with-no-grad &body body)
 ```
 
-Set `*np-grad*` `t` under the `body` execution, no gradients are made for backward.
+Under the `body` execution, the macro sets `*no-grad*` = `t`, that is, the built nodes are regarded as: no gradients are made for backwards.
 
-## parameter
-The function parameter computes all the previous nodes of the given tensor, returning the new tensor with requires-grad=t.
 
-Example:
+## [function] parameter
+
+```
+(parameter tensor)
+```
+
+The function parameter computes all the previous nodes of the given tensor if any, returning the new tensor with `requires-grad=t`.
+
+### Example
 
 ```lisp
 (parameter (randn `(3 3)))
 ```
-## dtype->lisp-type
-NIL
-## call-with-view
-NIL
-## stride-of
-NIL
-## size-of
-NIL
-## offset-of
-NIL
-## shape-equal
 
+
+## [function] call-with-view
+
+```lisp
+(call-with-view function tensors &key (at-least-dim 1))
+```
+
+The function `call-with-view` is a utility to expand view-considered `loop` iteration in the `:forward` expansion of `define-impl`.
+
+(TODO: Example/Documents)
+
+`function` [lambda] an lambda function which receives `variable1.view variable2.view ...` as arguments, returning an list being compiled.
+
+`tensors` [list of abstracttensor] tensors to be called with.
+`at-least-dim` [fixnum] ... kernel-size
+
+See also:
+
+`size-of`
+`stride-of`
+`offset-of`
+NILNILNIL
 ## [function] shape-equal
 
 a=1, b=k => T
 a=1, b=2 => NIL
 
-...
-## force-list
-Returns subscript-t if view is Subscript otherwise returns a view
+...Returns subscript-t if view is Subscript otherwise returns a view
+## Compiling Options
+TODO
+## Dtypes
+TODO

--- a/docs/cl-waffe2-docs/docs/index.md
+++ b/docs/cl-waffe2-docs/docs/index.md
@@ -11,9 +11,9 @@
     <br />
     <a href="https://github.com/hikettei/cl-waffe2/issues">Issues</a>
     ·
-    <a href="https://github.com/hikettei/cl-waffe2">Benchmarks</a>
+    <a href="./install">Installing</a>
     ·
-    <a href="https://github.com/hikettei/cl-waffe2">Tutorials</a>
+    <a href="./overview">Tutorials</a>
   </p>
 </p>
 
@@ -33,12 +33,6 @@ The primary concepts and goals of this project is following
 **Everything in this documentation is incomplete! I guess should be much more polished!**
 
 #
-
-## Install
-
-```
-Coming Soon...
-```
 
 ## Benchmarks
 

--- a/docs/cl-waffe2-docs/docs/install.md
+++ b/docs/cl-waffe2-docs/docs/install.md
@@ -1,0 +1,10 @@
+
+# Set up environments
+
+
+;; environments
+;; sbcl
+;;
+;; *cl-waffe-config*
+;; ...
+;;

--- a/docs/cl-waffe2-docs/docs/install.md
+++ b/docs/cl-waffe2-docs/docs/install.md
@@ -1,10 +1,62 @@
 
-# Set up environments
+# Setting up Environments
+
+## Are you new to Common Lisp?
+
+I know... there are few people who are attempted to do ML/DL in Common Lisp! while other languages provide a strong baseline and good platforms. However, I still believe in the clear benefits of doing such tasks on Common Lisp.
+
+I've been working with Common Lisp for the past two years, but I realise the attraction that no other language can replace it. At first glance, indeed this language has a strange syntax, and some features of the language may seem too much. but believe me! One day you will learn to use it. In fact, I guess cl-waffe2 is portable to ANSI Common Lisp, but not portable to non-lisp languages.
+
+Anyway, the first step is to set up Common Lisp Environment.
+
+I don't know which is best, and this is just my recommendations.
+
+### 1. Installing Roswell
+
+Roswell is environment manager of Common Lisp (and much more!)
+
+<https://github.com/roswell/roswell>
+
+See the `Readme.md` and install Roswell
+
+### 2. Installing SBCL
+
+There are many implementations of Common Lisp, and SBCL is one of the processing system.
+
+As of this writing(2023/07/02), some features of cl-waffe2 are SBCL-dependent, so this one is recommended.
+
+With roswell:
+
+```sh
+$ ros install sbcl
+$ ros use <Installed SBCL Version>
+$ ros run # REPL is launched.
+```
+
+should work.
+
+### 3. Setting up IDE (Optional)
+
+I guess It's a pity to write Common Lisp without REPL. There are a lot of options, but as far as I know, `Emacs with SLIME` or `Lem` is widely supported choice.
 
 
-;; environments
-;; sbcl
-;;
-;; *cl-waffe-config*
-;; ...
-;;
+## Installing cl-waffe2
+
+With roswell:
+
+```sh
+$ ros install hikettei/cl-waffe2
+```
+
+With quicklisp:
+
+It's going to take a while...
+
+## Working with OpenBLAS backend!
+
+In your init file, (e.g.: `~/.roswell/init.lisp` or `~/.sbclrc`)...
+
+(TODO)
+
+-> `*cl-waffe-config*`
+

--- a/docs/cl-waffe2-docs/docs/nodes.md
+++ b/docs/cl-waffe2-docs/docs/nodes.md
@@ -15,10 +15,14 @@ defnode  => called with `forward`
 defmodel => called with `call`
 ```
 
-Also, defnode is a fundamental unit of operation, while defmodel is consisted of a set of nodes.
+Also, defnode is a fundamental unit of operation, while defmodel is a set of nodes.
 
-## Shaping APIs
+## Shaping API
 
+
+When defining an operation in cl-waffe2 with a `defnode` macro, the shape of the matrix used in the operation must also be defined in the `:where` keyword.
+
+This is a Shaping API, and responsible for shape inspection of all operations.
 
 ## Introducing Subscript DSL
 
@@ -222,7 +226,7 @@ b = `(1 2) // List consisted of fixnum
 
 DSL flattens the list in the subscript. (e.g.: `b=(1 2)` in `A[b]` is the equivalent to `A[1 2]`)
 
-**Note that** ~ is a reserved word and has a special rule:
+**Note that** ~ is a reserved word by cl-waffe2 and has a special rule:
 
 1. ~ is used to express dimensions from 0 to N
 
@@ -508,8 +512,6 @@ defmodel is a macro used to describe the model of neural network with `Composite
   6. `on-call->` [One of: nil symbol-name function list]
      on-call-> is used to control the behaviour of *call* function.
 
-  7. `on-print-object` [null or body]
-
 ### Example
 
 ```lisp
@@ -560,7 +562,7 @@ Second case, `on-call->` is symbol-name:
    (call (ExampleLayer 10) tensor) ;; call-example-layer is used!
 ```
 
-   (Complex model assignments like ConvND, for example, can be achieved by assigning generic function names to symbols.)
+   (Complicated model assignments like ConvND, for example, can be achieved by assigning generic function names to symbols.)
 
 [Third case] `on-call->` is function (i.e.: lambda):
 
@@ -694,6 +696,3 @@ Note that (equal (with-instant-kernel a) a) is NIL, that is, the returned value 
 
 If the return value of Body can be expanded as a macro, the values are compiled together at JIT compile time. Otherwise, the given tensor is returned as is.
 
-
-## declare-local-variables
-TODO

--- a/docs/cl-waffe2-docs/mkdocs.yml
+++ b/docs/cl-waffe2-docs/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: cl-waffe2 Documentation
 
 nav:
     - Home: index.md
+    - Install: install.md
     - Tutorials: overview.md
     - Tips: Tips.md
     - cl-waffe2/vm.nodes: nodes.md

--- a/source/backends/cpu/matrix-ops.lisp
+++ b/source/backends/cpu/matrix-ops.lisp
@@ -6,7 +6,7 @@
 (declaim (ftype (function (boolean) (signed-byte 8)) trans->c))
 (defun trans->c (transpose-specifier)
   (if transpose-specifier
-      #.(char-code #\C)
+      #.(char-code #\T)
       #.(char-code #\N)))
 
 ;; TODO: 1D Gemm -> Dot Product
@@ -14,13 +14,14 @@
 ;; TODO: Transpose Tensor.
 ;; FixME: view isn't working at 1d/2d
 ;; FixME: support row-major with gemm
-(defun expand-gemm-form (a b out &key trans-a? trans-b?)
+(defun expand-gemm-form (a b out
+			 &key
+			   trans-a? trans-b?
+			 &aux
+			   (a (read-untransposed a))
+			   (b (read-untransposed b)))
   "[M N] @ [N K] -> [M K]"
-  (let ((dtype (dtype out))
-	(k (car (last (shape a))))
-	(kb (second (last (shape a) 2))))
-    (assert (shape-equal k kb) nil
-	    "expand-gemm-form: Assertion Failed with k = kb")
+  (let ((dtype (dtype out)))
     (assert (eql (order a) :column)
 	    nil
 	    "Assertion Failed with (order a) = :column (TODO: Support)")
@@ -30,14 +31,12 @@
        (call-with-view
 	#'(lambda (a-view b-view c-view)
 	    ;; Lazy-Eval when size=symbol.
-	    (let* ((a-view (if trans-a?
-			       (reverse a-view)
-			       a-view))
-		   (b-view (if trans-b?
-			       (reverse b-view)
-			       b-view))
+	    (let* ((a-view1 (if trans-a?
+				(reverse a-view)
+				a-view))
 		   (m   (size-of c-view 0))
 		   (n   (size-of c-view 1))
+		   (k   (size-of a-view1 1))
 		   (lda (size-of a-view 1))
 		   (ldb (size-of b-view 1))
 		   (ldc (size-of c-view 1)))
@@ -51,10 +50,10 @@
 		,m
 		,k
 		1.0 ;; alpha
-		(tensor-ptr ,b :offset ,(offset-of b-view 0)) ;; b
-		,ldb ;; LDA
-		(tensor-ptr ,a :offset ,(offset-of a-view 0)) ;; a
-		,lda ;; LDB
+		(tensor-ptr ,b :offset ,(offset-of b-view 0)) ;; a
+		,ldb
+		(tensor-ptr ,a :offset ,(offset-of a-view 0)) ;; b
+		,lda
 		0.0 ;; beta
 		(tensor-ptr ,out :offset ,(offset-of c-view 0))
 		,ldc)))
@@ -64,17 +63,17 @@
        (call-with-view
 	#'(lambda (a-view b-view c-view)
 	    ;; Lazy-Eval when size=symbol.
-	    (let* ((a-view (if trans-a?
-			       (reverse a-view)
-			       a-view))
-		   (b-view (if trans-b?
-			       (reverse b-view)
-			       b-view))
-		   (m (size-of c-view 0))
-		   (n (size-of c-view 1))
+	    (let* ((a-view1 (if trans-a?
+				(reverse a-view)
+				a-view))
+		   (m   (size-of c-view 0))
+		   (n   (size-of c-view 1))
+		   (k   (size-of a-view1 1))
 		   (lda (size-of a-view 1))
 		   (ldb (size-of b-view 1))
 		   (ldc (size-of c-view 1)))
+	      ;; [10 12] @ [12 13]
+	      ;; [M K] @ [K N]
 	      ;; a-view = [A.views[n-1], A.views[n]]
 	      `(blas-dgemm
 		,(trans->c trans-b?)
@@ -83,10 +82,10 @@
 		,m
 		,k
 		1.0d0 ;; alpha
-		(tensor-ptr ,b :offset ,(offset-of b-view 0)) ;; b
-		,ldb ;; LDA
-		(tensor-ptr ,a :offset ,(offset-of a-view 0)) ;; a
-		,lda ;; LDB
+		(tensor-ptr ,b :offset ,(offset-of b-view 0)) ;; a
+		,ldb
+		(tensor-ptr ,a :offset ,(offset-of a-view 0)) ;; b
+		,lda
 		0.0d0 ;; beta
 		(tensor-ptr ,out :offset ,(offset-of c-view 0))
 		,ldc)))
@@ -96,6 +95,7 @@
        (error "The dtype ~a isn't supported yet (TODO)." dtype)))))
 
 (define-impl (MatMulNode :device CPUTensor
+	                 :cache-when-compiled nil
 			 :reject-p (supported-dtypes-are 0 :float :double))
 	     :save-for-backward (t t nil)
 	     :forward

--- a/source/backends/cpu/matrix-ops.lisp
+++ b/source/backends/cpu/matrix-ops.lisp
@@ -9,6 +9,10 @@
       #.(char-code #\T)
       #.(char-code #\N)))
 
+;; Fix: Batched matmul
+;; Fix: Matmul with parameter? !t with save-for-backward is working???
+;;
+
 ;; TODO: 1D Gemm -> Dot Product
 ;; TODO: Fix it.
 ;; TODO: Transpose Tensor.

--- a/source/backends/cpu/t/package.lisp
+++ b/source/backends/cpu/t/package.lisp
@@ -13,5 +13,4 @@
 (in-package :cl-waffe2/backends.cpu.test)
 
 (def-suite :test-backends-cpu)
-(in-suite :test-backends-cpu)
 

--- a/source/backends/lisp/t/package.lisp
+++ b/source/backends/lisp/t/package.lisp
@@ -13,6 +13,7 @@
 (in-package :cl-waffe2/backends.lisp.test)
 
 (def-suite :lisp-backend-test)
+
 (in-suite  :lisp-backend-test)
 
 (add-tester LispTensor)

--- a/source/base-impl/arithmetic.lisp
+++ b/source/base-impl/arithmetic.lisp
@@ -50,9 +50,10 @@ X\\gets{X ~a Y}
 " document1 document2 document1))))))
   (define-arithmetic-node AddNode "AddNode" "+"
     ((self dout dx dy)
+     (declare (ignore dx dy))
      ;; forward: next = x + y
      ;; dx = x, dy = y
-     (values (!move dx dout) (!move dy dout))))
+     (values dout dout)))
   (define-arithmetic-node SubNode "SubNode" "-"
     ((self dout dx dy)
      (declare (ignore dx dy))

--- a/source/base-impl/fundamental.lisp
+++ b/source/base-impl/fundamental.lisp
@@ -27,30 +27,31 @@
 			    (!move dy dy-out :force t)
 			    dy-out))))
 	  :documentation "
-Move all the visible elements of `B` into visible areas of `A`.
+Moves all the visible elements of `B` into visible areas of `A`.
 
 ```math
 A\\gets{B}
 ```
 
-### Constraints
+### Behaviour
 
-In order to implement the behaviour for compilers of eliminating unused copies, all the implementations must satisfy as follows:
+All cl-waffe2 operations follow this rule: `Make a copy for now, disable later`. (e.g.: the function `(!add x y)` makes an copy of `x` and `y` for now, but this copy operation is ignored, if they're concluded not to be needed, by tracing computation node.)
 
-On forward:
+In order to disable a useless copy operations, MoveTensorNode must follow this behaviour:
 
-1. If (movetensor-ignore-me self) is t, return `B` without doing anything.
+1. Reading (movetensor-ignore-me self) in runtime, the forward makes a copy of given tensor only after the slot is `nil`.
 
-2. Otherwise, Move all the visible elements of `B` into `A`, and return `A`.
+2. Otherwise, return `B`
 
-(Note that: until `(tensor-vec A)` is called, `A` is never allocated.)
+Don't worry the allocation won't be done until `(tensor-vec A)` is called.
+
+For practical example, my impls (`./source/backends/lisp/arithmetic.lisp` for example) would be helpful!.
 
 ### Constructor
 
 `(MoveTensorNode dtype)`
 
 `dtype` dtype to use.
-
 "))
 
 (defnode (MoveScalarTensorNode (myself &key (save-for-backward nil))
@@ -109,7 +110,7 @@ one of: `MoveTensorNode` `ScalarTensorNode`
 
 `tensor[AbstractTensor]` tensor to be referred.
 
-`force[boolean]` If t, the operation is never pruned by cl-waffe2.
+`force[boolean]` If t, the pruning of operation by cl-waffe2 will never done.
 
 ### Output
 
@@ -506,7 +507,9 @@ The function ->mat receives `ScalarTensor`, returning a matrix with the number o
 			     (progn
 			       ;; TODO
 			       ;; Display Both: First-Time-Call/Second-Time-Call
-			       (forward compiled-model)
+			       (format t "Proceed-Time: First Trying~%")
+			       (time (forward compiled-model))
+			       (format t "Proceed-Time: Second Trying~%")
 			       (setf (proceed-result self) (time (forward compiled-model))))
 			     (setf (proceed-result self) (forward compiled-model)))
 			 ;; Tell cl-waffe2 VM the returned value's type
@@ -543,6 +546,8 @@ This function will be useful especially when debugging on REPL.
 ### Inputs
 
 If `measure-time`=t, ProceedNode wraps with time macro when calling **COMPILED** forward and backward propagation. Compiling time isn't included to the displayed time while (time (proceed tensor)) includes.
+
+`compile-mode` is a keyword, type of `compile-mode-t`.
 "
   (let* ((node (ProceedNode :measure-time measure-time :compile-mode compile-mode))
 	 ;; Previous Node is already compiled, so detach tensor from nodes.
@@ -565,7 +570,9 @@ If `measure-time`=t, ProceedNode wraps with time macro when calling **COMPILED**
 (proceed-time tensor)
 ```
 
-An alias for (proceed tensor :measure-time t)"
+An alias for (proceed tensor :measure-time t)
+
+Note that: the proceed-time function invokes forward function twice times, in order for processing system to trace compiled lisp code, and ignoring allocation time."
   (declare (type AbstractTensor tensor))
   (proceed tensor :measure-time t :compile-mode compile-mode))
 
@@ -621,3 +628,4 @@ Note that added axes could be broadcasted automatically when the operation calle
   (let ((out (forward (Flexible-Rank-Node) tensor)))
     (setf (tensor-flexible-p out) t)
     out))
+

--- a/source/base-impl/fundamental.lisp
+++ b/source/base-impl/fundamental.lisp
@@ -122,7 +122,7 @@ Unevaluated Copied Tensor."
       (forward (MoveTensorNode (dtype place) :save-for-backward force) place tensor)))
 
 
-(defun !copy (tensor)
+(defun !copy (tensor &key (force nil))
   "
 ## [function] !copy
 
@@ -156,7 +156,7 @@ Output: Tensor[AbstractTensor]"
 	 (out (if broadcasted-p
 		  (apply #'!view out broadcasts)
 		  out))
-	 (res (!move out tensor)))
+	 (res (!move out tensor :force force)))
     ;; Extend flexible-p, because !copy is used to make a cache before using basic-function like !add
     (extend-states res tensor)))
 

--- a/source/base-impl/fundamental.lisp
+++ b/source/base-impl/fundamental.lisp
@@ -157,7 +157,6 @@ Output: Tensor[AbstractTensor]"
 		  (apply #'!view out broadcasts)
 		  out))
 	 (res (!move out tensor)))
-    
     ;; Extend flexible-p, because !copy is used to make a cache before using basic-function like !add
     (extend-states res tensor)))
 
@@ -208,9 +207,7 @@ This function is also used to adjust memory alignment of tensor."
 			   #'!view
 			   (!move dx (apply #'!view dout inp-sub))
 			   out-sub)))
-		(values
-		 nil
-		 (!move dy res)))))
+		(values nil res))))
 
 
 (defun !view (tensor &rest subscripts)

--- a/source/base-impl/matrix-ops.lisp
+++ b/source/base-impl/matrix-ops.lisp
@@ -33,6 +33,7 @@ C\\gets{gemm(1.0, A, B, 0.0, C)}
 
 (defnode (LazyTransposeNode (self)
 	  :where (A[~ i j] -> A[~ j i])
+	  :slots ((raw-tensor :accessor raw-tensor))
 	  :documentation "LazyTransposeNode is the matmul-dedicated node which supplies the lazy-transpose feature.
 
 Internally, This Node Returns The Given A itself but taking transpose of A's shape.
@@ -43,7 +44,13 @@ If the computation node is like: [LazyTransposeNode] -> [MatmulNode], then trans
 		     (values (!t dout)))))
 
 (define-impl (LazyTransposeNode :device t)
-	     :forward ((self x) `(progn ,x)))
+	     :forward ((self x) (setf (raw-tensor self) x) `(progn ,x)))
+
+(defun read-untransposed (tensor)
+  ""
+  (if (transposed-p tensor)
+      (raw-tensor (tensor-backward tensor))
+      tensor))
 
 (defun transposed-p (tensor)
   "Return T if previous-node is LazyTransposeNode"

--- a/source/base-impl/package.lisp
+++ b/source/base-impl/package.lisp
@@ -21,6 +21,7 @@
    #:trans-b?
    #:!matmul
    #:transposed-p
+   #:read-untransposed
    #:!t
    #:A+=B)
   (:export

--- a/source/base-impl/reduction.lisp
+++ b/source/base-impl/reduction.lisp
@@ -1,30 +1,12 @@
 
 (in-package :cl-waffe2/base-impl)
 
-
-;;========================================================================
-;; !sum semantics:
-;; Let A be a 3 x 3 Tensor, the operation is to sum up A along axis=1.
-;; 1. Prepare A
-;; +++
-;; +++
-;; +++
-;; 2. Prepare A-out 3 * 1
-;; +++
-;; 3. Broadcast A-out along axis=1
-;; +++
-;; ---
-;; ---
-;; 4. Adds A and A-out element-wise.
-;; This could be applied whenever the given axis is consisted of axes of list.
-;;=========================================================================
-
-(defun !sum (tensor &key (axis t) (-> nil) (keep-repeat nil))
+(defun !sum (tensor &key (axis t) (-> nil) (keepdims nil))
   "
 ## [function] !sum
 
 ```
-(!sum tensor &key (axis t) (-> nil) (keep-repeat nil))
+(!sum tensor &key (axis t) (-> nil) (keepdims nil))
 ```
 
 The function !sum return a node which computes the sum of tensor along the given axis.
@@ -37,13 +19,13 @@ The function !sum return a node which computes the sum of tensor along the given
 
 `->` [AbstractTensor or nil] the place to set the result. If nil, creates a new tensor.
 
-`keep-repeat`[boolean] If t, the axis reducted is repeated.
+`dims`[boolean] If t, the axis reducted is broadcasted.
 
 Return:
 
 `->`[AbstractTensor] the result."
   (declare (type AbstractTensor tensor)
-	   (type boolean keep-repeat)
+	   (type boolean keepdims)
 	   (type (or t list fixnum) axis))
   (let* ((shape (copy-list (shape tensor)))
 	 (view-args (make-list (length shape) :initial-element t))
@@ -82,16 +64,16 @@ Return:
 
       ;; Main Parts
       (multiple-value-bind (out* reverser) (apply #'!view out view-args)
-	(if keep-repeat
+	(if keepdims
 	    (A+=B out* tensor)
 	    (apply #'!view (A+=B out* tensor) reverser))))))
 
-(defun !mean (tensor &key (axis t) (-> nil) (keep-repeat nil))
+(defun !mean (tensor &key (axis t) (-> nil) (keepdims nil))
   "
 ## [function] !mean
 
 ```
-(!mean tensor &key (axis t) (-> nil) (keep-repeat nil))
+(!mean tensor &key (axis t) (-> nil) (keepdims nil))
 ```
 
 The function !mean return a node which computes the average of tensor along the given axis.
@@ -104,12 +86,12 @@ The function !mean return a node which computes the average of tensor along the 
 
 `->` [AbstractTensor or nil] the place to set the result. If nil, creates a new tensor.
 
-`keep-repeat`[boolean] If t, the axis reducted is repeated.
+`keepdims` [boolean] If t, the axis reducted is broadcasted.
 
 ### Return
 
 `->`[AbstractTensor] the result."
-  (let* ((result (!sum tensor :axis axis :-> -> :keep-repeat keep-repeat))
+  (let* ((result (!sum tensor :axis axis :-> -> :keepdims keepdims))
 	 (dims (length (shape tensor)))
 	 (reducted-elements 1))
     

--- a/source/base-impl/t/apis.lisp
+++ b/source/base-impl/t/apis.lisp
@@ -2,8 +2,6 @@
 
 (in-package :cl-waffe2/base-impl.test)
 
-(in-suite :base-impl-test)
-
 ;; Testing APIs provides by cl-waffe2/base-impl
 
 ;; !add !sub !mul !div
@@ -16,6 +14,8 @@
 ;; =============================================================
 ;; Testing general-purpose arithmetic APIs: !add !sub !mul !div.
 ;; =============================================================
+
+(in-suite :base-impl-test)
 
 (test test-add-form
   ;; Scalar And Scalar

--- a/source/base-impl/t/arithmetic.lisp
+++ b/source/base-impl/t/arithmetic.lisp
@@ -1,8 +1,6 @@
 
 (in-package :cl-waffe2/base-impl.test)
 
-(in-suite :base-impl-test)
-
 ;; == Here, we provide testing framework. ========
 ;;
 ;; You can perform tests like:
@@ -101,11 +99,6 @@
   (define-ss-tester ss-mul-tester !mul * 1 1)
   (define-ss-tester ss-div-tester !div / 1 -1))
 
-(ss-add-tester nil)
-(ss-sub-tester nil)
-(ss-mul-tester nil)
-(ss-div-tester nil)
-
 (define-tester matmul-tester :dense
   (let* ((a (ax+b `(3 3) 1 0 :order :column))
  	 (b (ax+b `(3 3) 1 0 :order :column))
@@ -149,3 +142,10 @@
        (matmul-tester-mnk1 ,backend)
        (matmul-both-transposed ,backend))))
 
+(in-suite :base-impl-test)
+
+
+(ss-add-tester nil)
+(ss-sub-tester nil)
+(ss-mul-tester nil)
+(ss-div-tester nil)

--- a/source/base-impl/t/mathematical.lisp
+++ b/source/base-impl/t/mathematical.lisp
@@ -1,8 +1,6 @@
 
 (in-package :cl-waffe2/base-impl.test)
 
-(in-suite :base-impl-test)
-
 ;; == Here, we provide testing framework. ========
 ;;
 ;; You can perform tests like:

--- a/source/base-impl/t/package.lisp
+++ b/source/base-impl/t/package.lisp
@@ -19,7 +19,6 @@
 ;;
 
 (def-suite :base-impl-test)
-(in-suite :base-impl-test)
 
 (defparameter *dense-types*  `(:float :double))
 (defparameter *sparse-types* `(:int8 :int16 :int32))

--- a/source/base-impl/t/reduction.lisp
+++ b/source/base-impl/t/reduction.lisp
@@ -1,8 +1,6 @@
 
 (in-package :cl-waffe2/base-impl.test)
 
-(in-suite :base-impl-test)
-
 ;; sum
 ;; -> = view, α=broadcast_auto, β=0
 ;; sum(x, out) = ->(->(out, α) += x, β)
@@ -49,6 +47,8 @@
 	    :backward)))))
 
 ;;(sum-tester cl-waffe2/backends.lisp:LispTensor)
+
+(in-suite :base-impl-test)
 
 ;; Working on LispTensor is enough for testing !mean
 (mean-tester cl-waffe2/backends.lisp:LispTensor)

--- a/source/distributions/dense.lisp
+++ b/source/distributions/dense.lisp
@@ -59,6 +59,8 @@
 	   (type utype a0)
 	   (type (utype 0e0) a b))
 
+  ;;(warn "[FIXME] cl-waffe2:beta with (min a b) <= 1 is unstable...")
+  
   (unless (<= (min a b) 1.0)
     (error "cl-waffe:!beta failed because of (min a b) <= 1."))
 

--- a/source/distributions/package.lisp
+++ b/source/distributions/package.lisp
@@ -2,7 +2,7 @@
 (in-package :cl-user)
 
 (defpackage :cl-waffe2/distributions
-  (:use :cl :cl-waffe2/vm.generic-tensor :cl-waffe2/threads)
+  (:use :cl :cl-waffe2/vm.generic-tensor :cl-waffe2/threads :cl-waffe2/base-impl)
   (:export #:define-tensor-initializer))
 
 (in-package :cl-waffe2/distributions)

--- a/source/distributions/weights.lisp
+++ b/source/distributions/weights.lisp
@@ -1,0 +1,31 @@
+
+(in-package :cl-waffe2/distributions)
+
+;; Including compiling time ugh...
+
+;; sampling initializer function
+
+
+(define-tensor-initializer
+    xavier-uniform
+    nil
+    (let* ((in-features  (car    (last shape 2)))
+	   (out-features (second (last shape 2)))
+	   (coeff (sqrt (/ 6 (+ in-features out-features)))))
+      #'(lambda (i)
+	  (declare (ignore i))
+	  (* coeff (sample-uniform-random -1.0 1.0))))
+    "")
+
+(define-tensor-initializer
+    xavier-gaussian
+    nil
+    (let* ((in-features  (car    (last shape 2)))
+	   (out-features (second (last shape 2)))
+	   (stddev (sqrt (/ 2 (+ in-features out-features))))
+	   (sampler (get-randn-sampler (dtype tensor))))
+      #'(lambda (i)
+	  (declare (ignore i))
+	  (* stddev (funcall sampler))))
+    "")
+

--- a/source/distributions/weights.lisp
+++ b/source/distributions/weights.lisp
@@ -22,10 +22,11 @@
     nil
     (let* ((in-features  (car    (last shape 2)))
 	   (out-features (second (last shape 2)))
-	   (stddev (sqrt (/ 2 (+ in-features out-features))))
-	   (sampler (get-randn-sampler (dtype tensor))))
+	   (stddev (coerce (sqrt (/ 2 (+ in-features out-features))) 'double-float)))
       #'(lambda (i)
 	  (declare (ignore i))
-	  (* stddev (funcall sampler))))
+	  (coerce (cl-randist:random-normal-ziggurat 0.0d0 stddev) (dtype->lisp-type (dtype tensor)))))
     "")
+
+;; He/Orthogonal
 

--- a/source/nn/activation.lisp
+++ b/source/nn/activation.lisp
@@ -27,7 +27,7 @@
   "
 ## [function] !softmax
 "
-  (let* ((x1 (!sub x (!mean x  :axis 1 :keep-repeat t)))
-	 (z  (!sum   (!exp x1) :axis 1 :keep-repeat t)))
+  (let* ((x1 (!sub x (!mean x  :axis 1 :keepdims t)))
+	 (z  (!sum   (!exp x1) :axis 1 :keepdims t)))
     (!div (!exp x1) z)))
 

--- a/source/optimizers/defoptimizer.lisp
+++ b/source/optimizers/defoptimizer.lisp
@@ -1,0 +1,12 @@
+
+(in-package :cl-waffe2/optimizers)
+
+;; Gradientを足し合わせる時にまとめて
+
+#|
+(defmacro defoptimizer (name))
+
+(defoptimier SGD ()
+  :slots
+  :step ((parameter)
+	 |#

--- a/source/optimizers/package.lisp
+++ b/source/optimizers/package.lisp
@@ -5,3 +5,4 @@
   (:use :cl))
 
 (in-package :cl-waffe2/optimizers)
+

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -124,6 +124,8 @@ See also: `set-input`"
 	(maphash
 	 #'(lambda (key value)
 	     (let ((max-val (gethash key maxsize)))
+	       
+	       #|
 	       (when (and (not (null max-val))
 			  (> value max-val))
 		 (error "Error: Can't embody tensor because ~a = ~a is given but ~a must <= ~a"
@@ -131,6 +133,7 @@ See also: `set-input`"
 			value
 			key
 			max-val))
+	       |#
 
 	       (when (null max-val)
 		 (setf (gethash key maxsize) value))))

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -398,7 +398,7 @@ Compiled-Composite is a `callable` CLOS class, and holds compiled forward/backwa
 
 It is NOT possible to construct a computation node after Compiled-Composite, If you need this, try consider using the function `cl-waffe2/base-impl:proceed`.
 
-The class will appear in your project with calling the function `build`, set the toplevel node (e.g.: the result of criterion when the task is optimizing.) to the first argument. cl-waffe2 compiler will instantly construct an lambda function of forward/backward, which is called by `(forward compiled-composite)` or `(backward compiled-composite)` method.
+The class will appear in your project with calling the function `build`, set the toplevel node (e.g.: the result of criterion when the task is optimizing.) to the first argument. cl-waffe2 compiler will instantly construct an lambda function of forward/backward, which is invoked by calling `(forward compiled-composite)` or `(backward compiled-composite)` method.
 
 See also: `build` `set-input` `get-input`.
 

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -481,7 +481,8 @@ Reading all variables in the computation node, the method get-input returns an c
 (defun build (toplevel
 	      &key
 		(construct-backward? (not *no-grad*))
-		(compile-mode :fastest))
+		(compile-mode :fastest)
+		(use-setinput-form nil))
   "
 ## [function] build
 
@@ -530,11 +531,13 @@ After working with adjustable shape tensor, don't forget to embody the InputTens
   
   (multiple-value-bind (forward-kernel vars set-input-forms) (compile-forward-kernel toplevel :compile-mode compile-mode)
     ;; Vars - All Variables (including ChainTMP) used in forward.
-    (make-instance 'Compiled-Composite
-		   :variables  (construct-variables-table vars)
-		   :compiled-forward forward-kernel
-		   :compiled-backward (when construct-backward?
-					(compile-backward-kernel toplevel :compile-mode compile-mode :set-input-forms set-input-forms)))))
+    (values (make-instance 'Compiled-Composite
+			   :variables  (construct-variables-table vars)
+			   :compiled-forward forward-kernel
+			   :compiled-backward (when construct-backward?
+						(compile-backward-kernel toplevel :compile-mode compile-mode :set-input-forms set-input-forms)))
+	    
+	    (when use-setinput-form set-input-forms))))
 
 (defmethod print-object ((model Compiled-Composite) stream)
   (format stream "<Compiled-Composite

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -1,7 +1,11 @@
 
 (in-package :cl-waffe2/vm.generic-tensor)
 
-(defparameter *no-grad* nil "If t, all operations don't create gradients.")
+;;
+;; acceptor.lisp provides an compiler of given nodes, and general-purpose APIs to handle with cl-waffe2 nodes.
+;;
+
+(defparameter *no-grad* nil "If t, no gradients are made for backwards.")
 
 (defmacro with-no-grad (&body body)
   "
@@ -11,7 +15,7 @@
 (with-no-grad &body body)
 ```
 
-Set `*np-grad*` `t` under the `body` execution, no gradients are made for backward.
+Under the `body` execution, the macro sets `*no-grad*` = `t`, that is, the built nodes are regarded as: no gradients are made for backwards.
 "
   `(let ((*no-grad* t))
      ,@body))
@@ -54,7 +58,7 @@ Set `*np-grad*` `t` under the `body` execution, no gradients are made for backwa
 	 (table (make-print-table)))
     (format
      stream
-     "+= [NodeVariables Information] =======+
+     "+= [Tensors in the computation node] =======+
 
 Subscripts:
 ~a
@@ -92,9 +96,10 @@ Variables:
      (length (nodevariables-parameters node)))))
 
 
-;; Rewrite
 (defun embody-input (nodevars variable-name actual-tensor)
-  "(embody-input variables :a tensor)"
+  "(embody-input variables :a tensor)
+
+See also: `set-input`"
   (declare (type NodeVariables nodevars))
   
   (let ((input-tensor (gethash variable-name (nodevariables-variables nodevars))))
@@ -208,14 +213,14 @@ Variables:
 	  (push tensor *node-parameters-tmp*)))))
 
 ;; ==============================================================================
-;; Kernel Constructor
+;; Kernel Constructor | General-Purpose APIs
 ;; ==============================================================================
 
 (defun compile-forward-chain (toplevel &key (stop-me nil))
   "
 ## [function] compile-forward-chain
 
-Tracing until one of variables reached a toplevel tensor (detach-p is t or no backwards), returning an S-expression which can be compiled.
+Tracing until one of variables reached a toplevel tensor (detach-p is t or no backwards), returning an S-expression which can be compiled by processing systems.
 "
   (declare (type AbstractTensor toplevel))
 
@@ -287,8 +292,6 @@ Tracing until one of variables reached a toplevel tensor (detach-p is t or no ba
       ;; Rewrite
       
       ;; Memo: All backward nodes, are ends with MoveTensorNode
-
-
       
       `(let (,@(loop for var in (tensor-variables toplevel)
 		     for kernel in outs
@@ -307,6 +310,7 @@ Tracing until one of variables reached a toplevel tensor (detach-p is t or no ba
 		   collect (compile-backward-chain var var))))))
 
 ;; Toplevel
+;; This is not for users.
 (defun compile-forward-kernel (toplevel
 			       &key
 				 (compile-mode :default))
@@ -376,33 +380,78 @@ Tracing until one of variables reached a toplevel tensor (detach-p is t or no ba
     (compile nil `(lambda () ,(place-cached-kernels body)))))
 
 ;; ==========================================
-;; Rewriting
+;; General-Purpose APIs
 ;; ==========================================
 
+;; In acceptor.lisp:
+;; Compiled-Composite forward backward set-input get-input is all you need!
 
 (defclass Compiled-Composite ()
   ((compiled-forward :initarg :compiled-forward :type function :reader compiled-forward)
    (compiled-backward :initarg :compiled-backward :type (or null function) :reader compiled-backward)
    (variables :initarg :variables :reader compiled-variables)
-   (first-call-p :initform nil :accessor composite-first-call-p :type boolean)))
+   (first-call-p :initform nil :accessor composite-first-call-p :type boolean))
+  (:documentation "
+## [class] Compiled-Composite
+
+Compiled-Composite is a `callable` CLOS class, and holds compiled forward/backward function of all the computation node to all the endpoints from the top of the models' neural network. Also, this class holds information of all variables used in the node.
+
+It is NOT possible to construct a computation node after Compiled-Composite, If you need this, try consider using the function `cl-waffe2/base-impl:proceed`.
+
+The class will appear in your project with calling the function `build`, set the toplevel node (e.g.: the result of criterion when the task is optimizing.) to the first argument. cl-waffe2 compiler will instantly construct an lambda function of forward/backward, which is called by `(forward compiled-composite)` or `(backward compiled-composite)` method.
+
+See also: `build` `set-input` `get-input`.
+
+### Examples
+
+(TODO)
+
+"))
+
+(defun all-embodied? (model)
+  "Invokes an simple-error when model has still unembodied tensor"
+  (declare (type Compiled-Composite model))
+  (let ((vars (nodevariables-variables (compiled-variables model)))
+	(unembodied))
+    (loop for key being the hash-keys in vars using (hash-value val)
+	  if (null (vec val))
+	    do (push (cons key val) unembodied))
+
+    (when unembodied
+      (error "Can't call forward of the given model,
+because there's still unembodied tensors:
+~a"
+	     (with-output-to-string (out)
+	       (dolist (k unembodied) (format out "~% :~a - ~a Tensor." (car k) (shape (cdr k)))))))))
+
 
 (defmethod cl-waffe2/vm.nodes:forward ((model Compiled-Composite) &rest inputs &key &allow-other-keys)
-  ;; Keywords :A A :B B ...
-  ;; forward
   (when inputs
-    (warn "forward: Inputs are ignored"))
-  
+    (warn "forward: Inputs for compiled-composite are ignored"))
+
+  ;; Check if all the inputs are embodied?
+  (all-embodied? model)
+
   (funcall (compiled-forward model)))
 
 (defmethod cl-waffe2/vm.nodes:backward ((model Compiled-Composite) &rest inputs)
 
   (when inputs
-    (warn "backward: Inputs are ignored"))
+    (warn "backward: Inputs for compiled-composite are ignored"))
   (funcall (compiled-backward model)))
 
 (defmethod set-input ((model Compiled-Composite) input-name actual-value)
   "
 ## [method] set-input
+
+```
+(set-input (model Compiled-Composite) input-name actual-value)
+```
+
+Embodies an `InputTensor` in the model. All unembodied tensors in the model can be accessed by printing the model.
+
+`input-name` could be a keyword indicating input-tensor, `actual-value` is a `AbstractTensor` whose facet = `:exist` (created by `make-tensor`).
+
 
 "
   (embody-input (compiled-variables model) input-name actual-value))
@@ -411,6 +460,12 @@ Tracing until one of variables reached a toplevel tensor (detach-p is t or no ba
   "
 ## [method] get-input
 
+```
+(get-input (model Compiled-Composite) input-name)
+```
+
+Reading all variables in the computation node, the method get-input returns an corresponding `InputTensor` of model.
+
 "
   (gethash input-name (nodevariables-variables (compiled-variables model))))
 
@@ -418,8 +473,52 @@ Tracing until one of variables reached a toplevel tensor (detach-p is t or no ba
 	      &key
 		(construct-backward? (not *no-grad*))
 		(compile-mode :fastest))
+  "
+## [function] build
+
+```lisp
+(build toplevel
+	      &key
+		(construct-backward? (not *no-grad*))
+		(compile-mode :fastest))
+```
+
+Receiving the toplevel node in the neural network, the function `build` constructs a optimal forward/backward function, returning `Compiled-Composite`.
+
+### The constraints of toplevel tensor.
+
+The shape of topleve mustn't include a `symbol`.
+
+For example, this cl-waffe2 operation is invaild. because the function `(!sin x)` still returns `(A B)` tensor.
+
+```lisp
+(build (!sin (make-input `(A B) :Input)))
+```
+
+In order to build this operation correctly, calling `criterion` (intrinsically, `!sum` or `!mean`) is a vaild option for neural network tasks.
+
+```lisp
+(build (!sum (!sin (make-input `(A B) :input)))) ;; Passes Correctly!
+```
+
+After working with adjustable shape tensor, don't forget to embody the InputTensor!
+
+```lisp
+(let ((compiled-model (build (!sum (!sin (make-input `(A B) :input))))))
+    (set-input compiled-model :input (randn `(10 10)))
+    (forward compiled-model))
+```
+
+### Inputs
+
+`toplevel [AbstractTensor]` the end of nodes. for neural network tasks, this should be scalartensor or tensors with total elements is 1, but since cl-waffe2 is intended to be applied other tasks, cl-waffe2 never produce warning while other frameworks like PyTorch will return error if `<<(10 10)Tensor>>.backward()` is invoked for example.
+
+`construct-backward?` [boolean] If t, the backward construction won't be done.
+
+`compile-mode`[compile-mode-t] an keyword to indicate compiling option.
+"
   (declare (type AbstractTensor toplevel))
-  
+
   (when (some #'symbolp (shape toplevel))
     (error "Can't construct forward, because the shape of tensor is undetermined: ~a" (shape toplevel)))
   

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -125,15 +125,16 @@ See also: `set-input`"
 	 #'(lambda (key value)
 	     (let ((max-val (gethash key maxsize)))
 	       
-	       #|
 	       (when (and (not (null max-val))
 			  (> value max-val))
-		 (error "Error: Can't embody tensor because ~a = ~a is given but ~a must <= ~a"
-			key
-			value
-			key
-			max-val))
-	       |#
+		 
+		 ;;(error "Error: Can't embody tensor because ~a = ~a is given but ~a must <= ~a"
+		;;	key
+		;;	value
+		;;	key
+		;;	max-val)
+		 (setf (gethash key maxsize) value))
+	       
 
 	       (when (null max-val)
 		 (setf (gethash key maxsize) value))))

--- a/source/vm/generic-tensor/call-with-view.lisp
+++ b/source/vm/generic-tensor/call-with-view.lisp
@@ -204,8 +204,24 @@ Return: (values offsets-place form)"
   "
 ## [function] call-with-view
 
-(TODO)
+```lisp
+(call-with-view function tensors &key (at-least-dim 1))
+```
 
+The function `call-with-view` is a utility to expand view-considered `loop` iteration in the `:forward` expansion of `define-impl`.
+
+(TODO: Example/Documents)
+
+`function` [lambda] an lambda function which receives `variable1.view variable2.view ...` as arguments, returning an list being compiled.
+
+`tensors` [list of abstracttensor] tensors to be called with.
+`at-least-dim` [fixnum] ... kernel-size
+
+See also:
+
+`size-of`
+`stride-of`
+`offset-of`
 "
   
   (declare ;;(optimize (speed 3))

--- a/source/vm/generic-tensor/call-with-view.lisp
+++ b/source/vm/generic-tensor/call-with-view.lisp
@@ -20,8 +20,8 @@
 	collect
 	;; offset += stride * start-points
 	`(incf ,(nth k offset-places)
-	       (%* ,(nth k start-points)
-		   ,(nth k stride-places)))))
+	        (%* ,(nth k start-points)
+		    ,(nth k stride-places)))))
 
 (defun expand-view-stride-adder (offset-places
 				 stride-places
@@ -70,7 +70,8 @@ Set 2 if the operation is matmul for example.
 	       (some #'(lambda (v)
 			 ;; non-reductable dim is: NOT(T) or NOT (:BROADCAST)
 			 (or (not (eql (force-list v) t))
-			     (not (eql (force-list v) :broadcast))))
+			     (not (eql (force-list v) :broadcast))
+			     ))
 		     views))))
     ;; If tensors are consisted of non-projected-tensor...?
     (not (some #'not-reductable-p tensors))))
@@ -79,7 +80,7 @@ Set 2 if the operation is matmul for example.
 (defun expand-funcall-with-view (function tensors offsets-place target-dim rest-dims)
   ""
   ;; (apply function view1 view2 view3 ...)
-  
+
   (apply function
 	 (loop for kth-tensor upfrom 0
 	       for tensor in tensors
@@ -127,7 +128,7 @@ Set 2 if the operation is matmul for example.
 	   for k upfrom 0
 	   collect (let ((view (make-viewinstruction
 				(nth k offset-place)
-				(read-adjustable-symbol (nth k sizes))
+				`(read-adjustable-symbol ,(nth k sizes))
 				`(compute-stepby
 				  (subscript-view (nth ,target-dim (tensor-view ,tensor)))))))
 		     (list view))))))

--- a/source/vm/generic-tensor/call-with-view.lisp
+++ b/source/vm/generic-tensor/call-with-view.lisp
@@ -90,8 +90,8 @@ Set 2 if the operation is matmul for example.
 		       below (+ rest-dims target-dim)
 		     collect (make-viewinstruction
 			      (nth kth-tensor offsets-place)
-			      `(nth ,target-dim-n (shape ,tensor))
-			      (let ((stride `(nth ,target-dim-n (tensor-stride ,tensor)))
+			      `(read-adjustable-symbol (nth ,target-dim-n (shape ,tensor)))
+			      (let ((stride `(nth ,target-dim-n (list ,@(tensor-stride tensor))))
 				    (view   `(subscript-view (nth ,target-dim-n (tensor-view ,tensor)))))
 				(lazy* stride `(compute-stepby ,view))))))))
 
@@ -127,7 +127,7 @@ Set 2 if the operation is matmul for example.
 	   for k upfrom 0
 	   collect (let ((view (make-viewinstruction
 				(nth k offset-place)
-				(nth k sizes)
+				(read-adjustable-symbol (nth k sizes))
 				`(compute-stepby
 				  (subscript-view (nth ,target-dim (tensor-view ,tensor)))))))
 		     (list view))))))
@@ -177,7 +177,7 @@ Return: (values offsets-place form)"
 	 (ith (gensym)))
      `(let* (,@(loop for stride-place in stride-places ;; (place <- stride)
 		    for tensor in ,tensors
-		    collect `(,stride-place (nth ,,target-dim (tensor-stride ,tensor))))
+		    collect `(,stride-place (nth ,,target-dim (list ,@(tensor-stride tensor)))))
 	    (,',endpoint-place ,(car ,end-points))
 	    (,',endpoint-place (if (symbolp ,',endpoint-place)
 				   (read-adjustable-symbol ,',endpoint-place)
@@ -293,7 +293,7 @@ See also:
 		    (let ((stride-places (tensor-gensym-list tensors)))
 		      `(let (,@(loop for stride-place in stride-places
 				     for tensor in tensors
-				     collect `(,stride-place (nth ,target-dim (tensor-stride ,tensor)))))
+				     collect `(,stride-place (nth ,target-dim (list ,@(tensor-stride tensor))))))
 			 ,@(expand-first-offset-adder
 			    tensors
 			    offsets-place

--- a/source/vm/generic-tensor/call-with-view.lisp
+++ b/source/vm/generic-tensor/call-with-view.lisp
@@ -70,7 +70,7 @@ Set 2 if the operation is matmul for example.
 	       (some #'(lambda (v)
 			 ;; non-reductable dim is: NOT(T) or NOT (:BROADCAST)
 			 (or (not (eql (force-list v) t))
-			     (not (eql (force-list v) :broadcast))
+			     ;;(not (eql (force-list v) :broadcast))
 			     ))
 		     views))))
     ;; If tensors are consisted of non-projected-tensor...?

--- a/source/vm/generic-tensor/call-with-view.lisp
+++ b/source/vm/generic-tensor/call-with-view.lisp
@@ -165,7 +165,7 @@ Return: (values offsets-place form)"
 			   (push s used-symbols)))
 		     (shape tensor)))
 	   ,tensors)
-     `(with-let-adjustable-symbols (,@used-symbols)
+     `(progn
 	(let ((,',used-symbol-binding ',used-symbols))
 	  (declare (ignorable ,',used-symbol-binding))
 	  ,,@body))))
@@ -318,4 +318,3 @@ See also:
     (with-shape-det-form tensors used-symbols
       (with-expand-init-tmp-form offset-place tensors
 	(explore dims offset-place used-symbols)))))
-

--- a/source/vm/generic-tensor/call-with-view.lisp
+++ b/source/vm/generic-tensor/call-with-view.lisp
@@ -112,7 +112,7 @@ Set 2 if the operation is matmul for example.
 			 (loop for i upfrom dim-start-from below (length s)
 			       unless (eql (force-list (nth i v)) t)
 				 do (error "Internal Error: call-with-view-1dkernel is only applied to view=t axes.")
-			       collect `(nth ,i (shape ,tensor))))
+			       collect `(read-symbol (nth ,i (shape ,tensor)))))
 		     tensors))
 	 (sizes (map 'list #'(lambda (x) (apply #'lazy-mulup x)) size-list)))
 

--- a/source/vm/generic-tensor/memory-pool.lisp
+++ b/source/vm/generic-tensor/memory-pool.lisp
@@ -96,7 +96,7 @@ After the body exists, all the temporary tensors in the pool is freed."
   (declare (type Temporary-Room room)
 	   (type AbstractTensor tensor)
 	   (optimize (speed 3)))
-  (let ((required-size (apply #'* (translate-adjustable-shape (shape tensor))))
+  (let ((required-size (apply #'* (translate-adjustable-shape (actual-shape tensor))))
 	(vec           (vec (temporary-room-cache-tensor room))))
     ;; Checking required-size, is done at toplevel.
     ;; Use (max-size) x (max-size) vec as if they're (required-size) x (required-size) vec.

--- a/source/vm/generic-tensor/memory-pool.lisp
+++ b/source/vm/generic-tensor/memory-pool.lisp
@@ -20,7 +20,7 @@
 		   (shape-first (shape input-tensor)))))
   ;; Adjustable Tensor Size
   (shape-first shape-first :type list)
-  (size (apply #'* (shape input-tensor)) :type fixnum)
+  (size (apply #'* (translate-adjustable-shape (shape input-tensor))) :type fixnum)
   (cache-tensor input-tensor :type AbstractTensor))
 
 (defun print-current-memory-pool (&key (stream t))

--- a/source/vm/generic-tensor/memory-pool.lisp
+++ b/source/vm/generic-tensor/memory-pool.lisp
@@ -147,12 +147,14 @@ Reading the *adjustable-shape-table*, the function returns an list consisted of 
 If there's any undetermined one, returns an error (TODO: Add Conditions)"
   (declare (type list shape)
 	   (optimize (speed 3)))
-  (loop for s in shape
-	collect (typecase s
-		  (fixnum s)
-		  (symbol
-		   (or (gethash s *adjustable-shape-table*)
-		       (error "translate-adjustable-shape: encountered unknown symbol: ~a" s))))))
+  (map 'list #'read-adjustable-symbol shape))
+
+(defun read-adjustable-symbol (s)
+  (typecase s
+    (fixnum s)
+    (symbol
+     (or (gethash s *adjustable-shape-table*)
+	 (error "translate-adjustable-shape: encountered unknown symbol: ~a" s)))))
 
 (defmacro with-adjustable-symbol ((symbol-name symbol-value) &body body)
   "Adding an element: symbol-name -> symbol-value to *adjustable-shape-table*, which can be read by translate-adjustable-shape function.

--- a/source/vm/generic-tensor/package.lisp
+++ b/source/vm/generic-tensor/package.lisp
@@ -46,6 +46,8 @@
    #:parameter
    #:*with-printing-tensor-omitted*
    #:tensor-id
+
+   #:compile-option-t
    )
 
   (:export

--- a/source/vm/generic-tensor/package.lisp
+++ b/source/vm/generic-tensor/package.lisp
@@ -102,6 +102,8 @@
   ;; Backends / Tensor API
   (:export
    #:shape
+   #:total
+   #:dims
    #:make-input
    #:make-tensor
    #:*using-backend*))

--- a/source/vm/generic-tensor/package.lisp
+++ b/source/vm/generic-tensor/package.lisp
@@ -86,6 +86,7 @@
   (:export
    #:make-vm-function
    #:compile-forward-chain)
+  
   (:export
    #:movetensor-p
    #:shape-equal)
@@ -93,6 +94,7 @@
   (:export
    #:embody-input
    #:embody-actual-tensor
+   #:compiled-composite
    #:build
    #:set-input
    #:get-input)

--- a/source/vm/generic-tensor/package.lisp
+++ b/source/vm/generic-tensor/package.lisp
@@ -8,6 +8,7 @@
    ;;#:*cache-directory*
    #:with-memory-pool
    #:print-current-memory-pool
+   #:free-current-memory-pool
    #:make-compiled-kernel
    #:*memory-pool*)
   ;; Tensor classes

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -498,8 +498,9 @@ This function is setfable."
 	(apply #'+
 	       (map 'list
 		    #'(lambda (stride s view shape)
+			(declare (ignore shape))
 			(* stride (compute-stepby (subscript-view view))
-			   (+ s (compute-visible-start-idx (subscript-view view) shape))))
+			   (+ s (compute-visible-start-idx (subscript-view view)))))
 		    (tensor-stride tensor)
 		    subscripts
 		    (tensor-view tensor)
@@ -517,8 +518,9 @@ This function is setfable."
 	      (apply #'+
 		     (map 'list
 			  #'(lambda (stride s view shape)
+			      (declare (ignore shape))
 			      (* stride (compute-stepby (subscript-view view))
-				 (+ s (compute-visible-start-idx (subscript-view view) shape))))
+				 (+ s (compute-visible-start-idx (subscript-view view)))))
 			  (tensor-stride tensor)
 			  subscripts
 			  (tensor-view tensor)

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -591,6 +591,27 @@ If you added a new backend with having different ptr-type (can't be accessed by 
 	)
   t)
 
+(defun embody-tensor-vec (input-tensor actual-tensor)
+  "Moves actual-tensor(ExistTensor) -> input-tensor(InputTensor) but shape/strides"
+  (declare (type AbstractTensor input-tensor actual-tensor))
+  
+  (assert (vec actual-tensor)
+	  nil
+	  "Assertion Failed because the given actual-tensor doesn't have a existing vec.")
+
+  (when (and (numberp (vec input-tensor))
+	     (numberp (vec actual-tensor)))
+    (setf (tensor-vec input-tensor) (tensor-vec actual-tensor))
+    (return-from embody-tensor-vec t))
+
+  ;; Offsets?
+  (setf (tensor-vec input-tensor) (tensor-vec actual-tensor)
+	(slot-value input-tensor 'orig-shape) (translate-adjustable-shape (original-shape actual-tensor))
+	(tensor-view input-tensor) (tensor-view actual-tensor)
+	(tensor-visible-shape input-tensor) (translate-adjustable-shape (tensor-visible-shape actual-tensor))
+	;;(tensor-stride input-tensor) (eval `(list ,@(tensor-stride actual-tensor)))
+	(slot-value input-tensor 'projected-p) (slot-value actual-tensor 'projected-p)))
+
 (defun view (tensor &rest subscripts)
   "The function view creates a view of given tensor.
 Note that the function *view* doesn't records ANY NODES, while the function *!view* does.

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -329,9 +329,7 @@ Note:
     (setf (slot-value tensor 'orig-shape)  orig-shape)
     (setf (slot-value tensor 'projected-p) (getf initargs :projected-p))
 
-    (setf (slot-value tensor 'ancestor-param-p)
-	  (or (ancestor-param-p tensor)
-	      (eql (tensor-facet tensor) :exist)))
+    (setf (slot-value tensor 'ancestor-param-p) (ancestor-param-p tensor))
     
     (cond
       ((eql (getf initargs :facet) :input)
@@ -589,6 +587,7 @@ If you added a new backend with having different ptr-type (can't be accessed by 
 	(tensor-stride input-tensor) (tensor-stride actual-tensor)
 	(tensor-visible-shape input-tensor) (tensor-visible-shape actual-tensor)
 
+	(slot-value input-tensor 'projected-p) (slot-value actual-tensor 'projected-p)
 	)
   t)
 
@@ -753,7 +752,6 @@ The function parameter computes all the previous nodes of the given tensor if an
       (setf (save-for-backward-space result) tensor)
       ;; result = space-tmp
       result)))
-
 
 ;; read-save-for-backward is actually working, but the problem is movetensor doesn't tell the variable well.
 (defun read-save-for-backward (tensor)

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -276,10 +276,17 @@ Note:
 2. this function is setfable
 "
   (declare (type AbstractTensor tensor))
-  (if (or (null (tensor-name tensor))
-	  (vec tensor))
-      (vec tensor) ;; tensor is created by make-tensor
-      (get-from-memory-pool tensor)))
+
+  (cond
+    ((and
+      (not (scalar-p tensor))
+      (stringp (tensor-name tensor))) ;; ChainTMP Vector -> get-from-memory-pool is MUST
+     (get-from-memory-pool tensor))
+    (T
+     (if (or (null (tensor-name tensor))
+	     (vec tensor))
+	 (vec tensor) ;; tensor is created by make-tensor
+	 (get-from-memory-pool tensor)))))
 
 (defun (setf tensor-vec) (new-value tensor)
   (declare (type AbstractTensor tensor))

--- a/source/vm/generic-tensor/utils.lisp
+++ b/source/vm/generic-tensor/utils.lisp
@@ -17,13 +17,19 @@
                            :initial-value (apply fn1 args))))
       #'identity))
 
+(defun wrap-x (x)
+  (typecase x
+    (number `(the fixnum ,x))
+    (symbol `(the fixnum (read-symbol ',x)))
+    (T `(the fixnum ,x))))
+
 (defun lazy* (x y)
-  (if (and (typep x 'number)
-	   (typep y 'number))
+  (if (and (numberp x)
+	   (numberp y))
       (* x y)
       `(the fixnum
-	    (* (the fixnum ,x)
-	       (the fixnum ,y)))))
+	    (* ,(wrap-x x)
+	       ,(wrap-x y)))))
 
 (defun lazy-mulup (&rest args)
   (let ((res 1))

--- a/source/vm/generic-tensor/view.lisp
+++ b/source/vm/generic-tensor/view.lisp
@@ -91,50 +91,53 @@
 (defun compute-visible-start-idx (view)
   "Given view, this function returns a offset at the dimension."
   (declare (optimize (speed 3)))
-  (case (viewtype view)
-    (:index view)
-    (:t     0)
-    (:slice      (car view))
-    (:slice-step (if (> (the fixnum (third view)) 0)
-		     (min (the fixnum (car view)) (the fixnum (second view)))
-		     (max (the fixnum (car view)) (the fixnum (second view)))))
-    (:indices 0)
-    (:tflist  0)
-    (:broadcast 0)
-    (T (error "unknown viewtype: ~a" view))))
+  (read-symbol
+   (case (viewtype view)
+     (:index view)
+     (:t     0)
+     (:slice      (car view))
+     (:slice-step (if (> (the fixnum (third view)) 0)
+		      (min (the fixnum (car view)) (the fixnum (second view)))
+		      (max (the fixnum (car view)) (the fixnum (second view)))))
+     (:indices 0)
+     (:tflist  0)
+     (:broadcast 0)
+     (T (error "unknown viewtype: ~a" view)))))
 
 (declaim (ftype (function (subscript-t (or list symbol fixnum)) (or list symbol fixnum)) compute-visible-end-idx))
 (defun compute-visible-end-idx (view size)
   "Given view and size, this function returns a size at the dimension."
-  (case (viewtype view)
-    (:index (1+ (the fixnum view)))
-    (:t     size)
-    (:slice (the fixnum (second view)))
-    ;; FIXME: Should be divided :slice-step
-    (:slice-step
-     (the fixnum
-	  (round (/ (if (> (third view) 0)
-			(max (car view) (second view))
-			(min (car view) (second view)))
-		    (abs (third view))))))
-    (:indices (length (cdr view)))
-    (:tflist  size)
-    (:broadcast (second view))
-    (T (error "unknwon view: ~a" view))))
+  (read-symbol
+   (case (viewtype view)
+     (:index (1+ (the fixnum view)))
+     (:t     size)
+     (:slice (the fixnum (second view)))
+     ;; FIXME: Should be divided :slice-step
+     (:slice-step
+      (the fixnum
+	   (round (/ (if (> (third view) 0)
+			 (max (car view) (second view))
+			 (min (car view) (second view)))
+		     (abs (third view))))))
+     (:indices (length (cdr view)))
+     (:tflist  size)
+     (:broadcast (second view))
+     (T (error "unknwon view: ~a" view)))))
 
 (defun compute-visible-end-idx-actual (view size)
-  (case (viewtype view)
-    (:index (1+ view))
-    (:t     size)
-    (:slice (second view))
-    (:slice-step
-     (round (/ (if (> (third view) 0)
-		   (max (car view) (second view))
-		   (min (car view) (second view)))
-	       (abs (third view)))))
-    (:indices (length (cdr view)))
-    (:tflist  size)
-    (:broadcast 1)))
+  (read-symbol
+   (case (viewtype view)
+     (:index (1+ view))
+     (:t     size)
+     (:slice (second view))
+     (:slice-step
+      (round (/ (if (> (third view) 0)
+		    (max (car view) (second view))
+		    (min (car view) (second view)))
+		(abs (third view)))))
+     (:indices (length (cdr view)))
+     (:tflist  size)
+     (:broadcast 1))))
 
 (defun force-list (view)
   "Returns subscript-t if view is Subscript otherwise returns a view"

--- a/source/vm/generic-tensor/view.lisp
+++ b/source/vm/generic-tensor/view.lisp
@@ -536,6 +536,7 @@ a=1, b=2 => NIL
   (every #'shape-equal list1 list2))
 
 
+(declaim (ftype (function (subscript-t) fixnum) compute-stepby))
 (defun compute-stepby (view)
   ;; view ... list
   (case (viewtype view)

--- a/source/vm/nodes/defmodel.lisp
+++ b/source/vm/nodes/defmodel.lisp
@@ -76,6 +76,8 @@ The generic function call is also used to step forward of AbstractNode, that is,
 (defmethod call ((model AbstractNode) &rest inputs)
   (apply #'forward model inputs))
 
+(defmethod call ((model cl-waffe2/vm.generic-tensor:Compiled-Composite) &rest inputs)
+  (apply #'forward model inputs))
 
 (defmacro define-forward-function (model forward-function)
   "forward-function = funcallable function"

--- a/source/vm/nodes/defmodel.lisp
+++ b/source/vm/nodes/defmodel.lisp
@@ -459,18 +459,27 @@ An constructor function for ~a."
 			       &key
 				 (dtype :float)
 				 (order :column)
-				 (scalar-p nil))
+				 (scalar-p-list nil))
   "Returns (make-input)"
   (declare (type Composite composite)
 	   (type list ~))
-  (let ((input-shape (composite-input-size composite)))
-    (loop for i upfrom 0
-	  for x in input-shape
-	  collect (make-input (where-arg->shape ~ x)
-			      (->keyword (nth-subscript i))
-			      :scalar-p scalar-p
-			      :dtype dtype
-			      :order order))))
+  (flet ((read-state (state nth)
+	   (if (keywordp state)
+	       state
+	       (nth nth state)))
+	 (read~      (~ nth)
+	   (if (listp (car ~))
+	       (nth nth ~)
+	       ~)))
+    
+    (let ((input-shape (composite-input-size composite)))
+      (loop for i upfrom 0
+	    for x in input-shape
+	    collect (make-input (where-arg->shape (read~ ~ i) x)
+				(->keyword (nth-subscript i))
+				:scalar-p (read-state scalar-p-list i)
+				:dtype (read-state dtype i)
+				:order order)))))
 
 (defun where-arg->shape (~ shape)
   (flatten

--- a/source/vm/nodes/defmodel.lisp
+++ b/source/vm/nodes/defmodel.lisp
@@ -167,6 +167,8 @@ Here's a list of reports:
   "
 ## [function] composite-where
 
+Predicts next output given inputs.
+
 ### Inputs
 
 `inputs` ... nil or list
@@ -180,6 +182,7 @@ Here's a list of reports:
   ;; (funcall Linter-Function model nil   input-state1 input-state2)
   ;; Fixnums
   ;; (funcall Linter-Function model shape input-state1 input-state2)
+  
   (with-slots ((linter-function subscript-linter)
 	       (state1 linter-state1)
 	       (state2 linter-state2))
@@ -363,6 +366,9 @@ An constructor function for ~a."
 				   `(multiple-value-list (subscript ,where :fixed :t :allow-symbol t :constructor-args ,constructor-arguments)))))
 	   (declare (ignorable ,subscript-p1 ,subscript-p2))
 	   (labels ((,test-subscript-p (,self-place1 ,inputs ,inputs1 ,inputs2)
+		      ;; inputs  = 
+		      ;; inputs1 = 
+		      ;; inputs2 = 
 		      (declare (ignorable ,self-place1 ,inputs ,inputs1 ,inputs2))
 		      ,(if use-linter-p
 			   `(multiple-value-bind (,try-out ,try-err ,try-rank-error ,input-size)
@@ -474,3 +480,17 @@ An constructor function for ~a."
 	 else
 	   collect s)))
 
+
+(defun shape-compatible? (composite &rest inputs)
+  "
+## [function] shape-compatible?
+
+Returns t if inputs are compatible with given composite, otherwise return an error.
+
+Inputs: An list of input tensors
+Return: (values output-shape input-shape-determined)
+
+"
+  (let ((linter-function (composite-linter-f composite))
+	(inputs (map 'list #'shape inputs)))
+    (funcall linter-function composite inputs inputs inputs)))

--- a/source/vm/nodes/defmodel.lisp
+++ b/source/vm/nodes/defmodel.lisp
@@ -475,11 +475,13 @@ An constructor function for ~a."
     (let ((input-shape (composite-input-size composite)))
       (loop for i upfrom 0
 	    for x in input-shape
-	    collect (make-input (where-arg->shape (read~ ~ i) x)
-				(->keyword (nth-subscript i))
-				:scalar-p (read-state scalar-p-list i)
-				:dtype (read-state dtype i)
-				:order order)))))
+	    collect
+	    (let ((res (make-input (where-arg->shape (read~ ~ i) x)
+				   (->keyword (nth-subscript i))
+				   :scalar-p (read-state scalar-p-list i)
+				   :dtype (read-state dtype i)
+				   :order order)))
+	      res)))))
 
 (defun where-arg->shape (~ shape)
   (flatten

--- a/source/vm/nodes/defmodel.lisp
+++ b/source/vm/nodes/defmodel.lisp
@@ -257,8 +257,6 @@ defmodel is a macro used to describe the model of neural network with `Composite
   6. `on-call->` [One of: nil symbol-name function list]
      on-call-> is used to control the behaviour of *call* function.
 
-  7. `on-print-object` [null or body]
-
 ### Example
 
 ```lisp
@@ -309,7 +307,7 @@ Second case, `on-call->` is symbol-name:
    (call (ExampleLayer 10) tensor) ;; call-example-layer is used!
 ```
 
-   (Complex model assignments like ConvND, for example, can be achieved by assigning generic function names to symbols.)
+   (Complicated model assignments like ConvND, for example, can be achieved by assigning generic function names to symbols.)
 
 [Third case] `on-call->` is function (i.e.: lambda):
 

--- a/source/vm/nodes/function.lisp
+++ b/source/vm/nodes/function.lisp
@@ -7,6 +7,7 @@
 ;; Node      <-> Function
 ;;
 
+;; TODO:
 ;; 1. Composite Functionを作る
 ;; Issuesを解消する
 
@@ -18,38 +19,37 @@
 		       (cl-waffe2/base-impl:!sum (cl-waffe2/base-impl:!mul x y)))))
 
 (defmodel (DotProduct-2D (self)
-	   :where ([a b] [a b] -> [scal] where scal = 1)
+	   :where (A[a b] B[a b] -> [scal] where scal = 1)
 	   :on-call-> ((self x y)
 		       (declare (ignore self))
 		       (cl-waffe2/base-impl:!sum (cl-waffe2/base-impl:!mul x y)))))
 
+
+;; One composite -> a single defun form.
+;; In order to implemenet "GENERIC" behaviour, we need to wrap composite->defun by higher-order function.
 (defun composite->defun (~ composite function-name
 			 &key
 			   (dtype :float)
 			   (order :column)
-			   (scalar-p nil)
+			   (scalar-p-list nil)
 			   (compile-mode :default))
   "
 ## [function] composite->function
 
-Tracing definition of given composite, the function `composite->function` returns a compiled-lambda function.
+Tracing definition of given composite, the function `composite->function` returns a defun forms.
 
-Return: (values input-names lambda-function)
+[One ~ value, one :dtype, one scalar-p-list state -> single defun form.]
+
+dtype/scalar-p-list = list is ok
+
+Return: defun form
 "
 
-  ;; Reading where
-  ;; where as shape
-  ;; set ~ = given ~ (NIL IS OK)
 
-  ;; Tracing
-  ;; Building
-  ;; Lambda Encapsulate
-
-  ;; Receives Input Tensors
   (let* ((inputs (composite-input-tensor composite ~
 					 :dtype dtype
 					 :order order
-					 :scalar-p scalar-p))
+					 :scalar-p-list scalar-p-list))
 	 (namelist (or (composite-symbol-names composite)
 		       (loop for i upfrom 0 below (length inputs)
 			     collect (nth-subscript i))))
@@ -65,14 +65,8 @@ Return: (values input-names lambda-function)
 	 (mname     (gensym)))
     (with-no-grad
       (let ((compiled-kernel (cl-waffe2/vm.generic-tensor:build result :compile-mode compile-mode)))
-	
-	`(progn
-	   ;; Model Caller
-	   (defun ,function-name  (,@namelist)
-	     (let ((,mname (,model-name)))
-	       (shape-compatible? ,mname ,@namelist)
-	       (call ,mname ,@namelist)))
 
+	`(progn
 	   ;; Main Body
 	   (defun ,tmp-fname (,self ,@namelist)
 	     (declare (ignore ,self))
@@ -83,55 +77,147 @@ Return: (values input-names lambda-function)
 
 	   (defmodel (,model-name (self)
 		      :where ,(read-where composite)
-		      :on-call-> ,tmp-fname)))))))
+		      :on-call-> ,tmp-fname))
 
-(defun composite->generic (composite function-name)
+	   (defun ,function-name  (,@namelist)
+	     (let ((,mname (,model-name)))
+	       (shape-compatible? ,mname ,@namelist)
+	       (call ,mname ,@namelist)))
+		   
+	   #',function-name)))))
 
-  )
+(defun ->key (&rest inputs)
+  (apply #'symb (map 'list #'tensor-keyname inputs)))
 
+;; dispatch with ~
+;; set dtype
+(defun dispatch-method (polymorphic-table
+			inputs
+			composite
+			function-name
+			~state
+			&key 
+			  (compile-mode :default)
+			  (order :column))
 
-(defmacro define-composite-solid-function (composite-init-form function-name)
+  (let* ((key (apply #'symb
+		     (map 'list #'->key inputs)))
+	 (key (if ~state
+		  (symb key (intern (format nil "~a" ~state)))
+		  key))
+	 (~state (loop for i upfrom 0
+		       for ~s in ~state
+		       collect (dim->input-shape ~s))))
+
+    (or (gethash key polymorphic-table)
+	(let* ((defun-form (composite->defun
+			    ~state
+			    composite
+			    (symb function-name key)
+			    :dtype (map 'list #'dtype inputs)
+			    :order order
+			    :scalar-p-list (map 'list #'scalar-p inputs)
+			    :compile-mode compile-mode))
+	       (compiled-f (eval defun-form)))
+	  (setf (gethash key polymorphic-table) compiled-f)
+	  compiled-f))))
+
+(defun composite->generic (composite function-name
+			   &key
+			     (adjustable-size t)
+			     (compile-mode :default)
+			     (order :column))
+  "Polymorphic dispatching kernel"
+  (let ((polymorphic-table (make-hash-table))
+	(kernel-place (gensym (format nil "~a-state-" function-name)))
+	(namelist (or (composite-symbol-names composite)
+		      (loop for i upfrom 0 below (length (composite-input-size composite))
+			    collect (nth-subscript i))))
+	(target-function (gensym))
+	(input-det-n-list (input-det-n-list composite))
+	(~length-place (gensym))) ;; the number of subscripts list...
+    
+    `(progn
+       (defparameter ,kernel-place ,polymorphic-table)
+
+       (defun ,function-name (,@namelist)
+	 (let* ((,~length-place ,(when adjustable-size
+				   `(map 'list #'(lambda (x y) (- (cl-waffe2/vm.generic-tensor:dims x) y)) (list ,@namelist) (list ,@input-det-n-list))))
+		(,target-function (dispatch-method
+				   ,kernel-place (list ,@namelist)
+				   ,composite ',function-name
+				   ,~length-place
+				   :compile-mode ,compile-mode
+				   :order ,order)))
+	   (funcall ,target-function ,@namelist))))))
+
+(defun composite-function (composite
+			   function-name
+			   &key
+			     (compile-mode :default)
+			     (scalar-p-list nil)
+			     (order :column)
+			     (dtype t))
   "
-## [macro] define-composite-solid-function
+## [function] composite-function
 
+Returns an defun form that can be evaluated by (eval ...).
+
+On the condition where composite should be defined as polymorphic, returns generic definition/dispatching.
+
+On the condition where composite should be defined as normal defun, returns a single defun form.
+
+Input:
+   dtype[t or keyword] If t, creates a hash-table that can be all definiton on dtype is stored.
+                       If keyword, a single definition of the given dtype is created.
+
+   scalar-p-list [list] the corresponding position of argument is interpreted as a scalartensor.
 "
 
-  `(eval (composite->defun nil ,composite-init-form ',function-name)))
+  (when (null (read-where composite))
+    (error "Failed to define composite-function, because :where form of ~a isn't declared yet." composite))
 
-(define-composite-solid-function (DotProduct-2D) !dot2d)
+  (let ((including~? (include~p composite)))
+    (cond
+      ((and (keywordp dtype)
+	    (null including~?))
+       ;; A facet of function is determined as one.
+       (composite->defun nil composite function-name
+			 :dtype dtype
+			 :order order
+			 :compile-mode compile-mode
+			 :scalar-p-list scalar-p-list))
+      (T
+       (composite->generic composite function-name
+			   :adjustable-size including~?
+			   :order order
+			   :compile-mode compile-mode)))))
 
-(define-composite-det-function (DotProduct) !dotproduct)
 
-;; define-composite-undetermined-function
-;; define-composite-function
-
-  
-(defun test-composite-f ()
-  (let ((model (DotProduct)))
-    (composite->function
-     (dim->input-shape 2)
-     model)))
-
-(defmacro def-composite->function (composite-name function-name)
+(defmacro define-composite-function (composite-init-form
+				     function-name
+				     &key
+				       (dtype t)
+				       (order :column)
+				       (compile-mode :default))
   "
-## [macro] composite->function
-
-The macro `define-composite-function` traces the computation node of given Composite, `composite-name`, defining a function."
-
-  ;; Is there ~ parameter?
-  ;; If True -> We need a method in order to dispatch the appropriate dim
-  ;; Otherwise -> We need a single function
-
-  
-  
-  
-  
-  )
+## [macro] define-composite-function
 
 
-(defmacro define-as-operation (toplevel)
-  "
-## [macro] define-as-operation
-AsNode but defines the function TOPLEVEL.
+
 "
-  )
+  (declare (type (or t keyword) dtype)
+	   (type keyword order)
+	   (type compile-option-t compile-mode))
+
+  `(eval (composite-function ,composite-init-form ',function-name
+			     :compile-mode ,compile-mode
+			     :dtype ,dtype
+			     :order ,order)))
+
+(define-composite-function (DotProduct-2D) !dot2d-float :dtype :float)
+
+(define-composite-function (DotProduct-2D) !dot2d)
+
+(define-composite-function (DotProduct) !dotproduct)
+

--- a/source/vm/nodes/function.lisp
+++ b/source/vm/nodes/function.lisp
@@ -1,0 +1,98 @@
+
+(in-package :cl-waffe2/vm.nodes)
+
+;; The file function.lisp provides a system on interacting Lazy-Evaluated Nodes and Toplevel functions:
+;;
+;; Composite <-> Function
+;; Node      <-> Function
+;;
+
+(defmodel (DotProduct (self)
+	   :where ([~] [~] -> [~])
+	   :on-call-> ((self x y)
+		       (declare (ignore self))
+		       (cl-waffe2/base-impl:!sum (cl-waffe2/base-impl:!mul x y)))))
+
+(defun composite->function (~ composite function-name
+			    &key
+			      (dtype :float)
+			      (order :column)
+			      (scalar-p nil)
+			      (compile-mode :default))
+  "
+## [function] composite->function
+
+Tracing definition of given composite, the function `composite->function` returns a compiled-lambda function.
+
+Return: (values input-names lambda-function)
+"
+
+  ;; Reading where
+  ;; where as shape
+  ;; set ~ = given ~ (NIL IS OK)
+
+  ;; Tracing
+  ;; Building
+  ;; Lambda Encapsulate
+
+  ;; Receives Input Tensors
+  (let* ((inputs (composite-input-tensor composite ~
+					 :dtype dtype
+					 :order order
+					 :scalar-p scalar-p))
+	 (namelist (or (composite-symbol-names composite)
+		       (loop for i upfrom 0 below (length inputs)
+			     collect (nth-subscript i))))
+	 (result (apply #'call composite inputs)))
+    (with-no-grad
+      (let ((compiled-kernel (cl-waffe2/vm.generic-tensor:build result :compile-mode compile-mode)))
+	`(defun ,function-name (,@namelist)
+	   ,@(loop for tensor in inputs
+		   for name in namelist
+		   collect `(set-input ,compiled-kernel ,(tensor-name tensor) ,name))
+	   (forward ,compiled-kernel))))))
+
+
+(defmacro define-composite-det-function (composite-init-form function-name)
+  "
+## [macro] define-composite-det-function
+
+"
+
+  `(eval (composite->function `(a b) ,composite-init-form ',function-name)))
+
+(define-composite-det-function (DotProduct) !dotproduct)
+
+;; define-composite-undetermined-function
+;; define-composite-function
+
+  
+(defun test-composite-f ()
+  (let ((model (DotProduct)))
+    (composite->function
+     (dim->input-shape 2)
+     model)))
+
+(defmacro def-composite->function (composite-name function-name)
+  "
+## [macro] composite->function
+
+The macro `define-composite-function` traces the computation node of given Composite, `composite-name`, defining a function."
+
+  ;; Is there ~ parameter?
+  ;; If True -> We need a method in order to dispatch the appropriate dim
+  ;; Otherwise -> We need a single function
+
+  
+  
+  
+  
+  )
+
+
+(defmacro define-as-operation (toplevel)
+  "
+## [macro] define-as-operation
+AsNode but defines the function TOPLEVEL.
+"
+  )

--- a/source/vm/nodes/function.lisp
+++ b/source/vm/nodes/function.lisp
@@ -7,24 +7,6 @@
 ;; Node      <-> Function
 ;;
 
-;; TODO:
-;; 1. Composite Functionを作る
-;; Issuesを解消する
-
-
-(defmodel (DotProduct (self)
-	   :where ([~] [~] -> [~])
-	   :on-call-> ((self x y)
-		       (declare (ignore self))
-		       (cl-waffe2/base-impl:!sum (cl-waffe2/base-impl:!mul x y)))))
-
-(defmodel (DotProduct-2D (self)
-	   :where (A[a b] B[a b] -> [scal] where scal = 1)
-	   :on-call-> ((self x y)
-		       (declare (ignore self))
-		       (cl-waffe2/base-impl:!sum (cl-waffe2/base-impl:!mul x y)))))
-
-
 ;; One composite -> a single defun form.
 ;; In order to implemenet "GENERIC" behaviour, we need to wrap composite->defun by higher-order function.
 (defun composite->defun (~ composite function-name
@@ -203,7 +185,7 @@ Input:
   "
 ## [macro] define-composite-function
 
-
+Tracing the `on-call->` form of a given composite-init-form, the macro `define-composite-function` defines a function of calling `on-call->` statically.
 
 "
   (declare (type (or t keyword) dtype)
@@ -214,10 +196,4 @@ Input:
 			     :compile-mode ,compile-mode
 			     :dtype ,dtype
 			     :order ,order)))
-
-(define-composite-function (DotProduct-2D) !dot2d-float :dtype :float)
-
-(define-composite-function (DotProduct-2D) !dot2d)
-
-(define-composite-function (DotProduct) !dotproduct)
 

--- a/source/vm/nodes/function.lisp
+++ b/source/vm/nodes/function.lisp
@@ -13,12 +13,18 @@
 		       (declare (ignore self))
 		       (cl-waffe2/base-impl:!sum (cl-waffe2/base-impl:!mul x y)))))
 
-(defun composite->function (~ composite function-name
-			    &key
-			      (dtype :float)
-			      (order :column)
-			      (scalar-p nil)
-			      (compile-mode :default))
+(defmodel (DotProduct-2D (self)
+	   :where ([a b] [a b] -> [scal] where scal = 1)
+	   :on-call-> ((self x y)
+		       (declare (ignore self))
+		       (cl-waffe2/base-impl:!sum (cl-waffe2/base-impl:!mul x y)))))
+
+(defun composite->defun (~ composite function-name
+			 &key
+			   (dtype :float)
+			   (order :column)
+			   (scalar-p nil)
+			   (compile-mode :default))
   "
 ## [function] composite->function
 
@@ -52,14 +58,20 @@ Return: (values input-names lambda-function)
 		   collect `(set-input ,compiled-kernel ,(tensor-name tensor) ,name))
 	   (forward ,compiled-kernel))))))
 
+(defun composite->generic (composite function-name)
 
-(defmacro define-composite-det-function (composite-init-form function-name)
+  )
+
+
+(defmacro define-composite-solid-function (composite-init-form function-name)
   "
-## [macro] define-composite-det-function
+## [macro] define-composite-solid-function
 
 "
 
-  `(eval (composite->function `(a b) ,composite-init-form ',function-name)))
+  `(eval (composite->defun nil ,composite-init-form ',function-name)))
+
+(define-composite-solid-function (DotProduct-2D) !dot2d)
 
 (define-composite-det-function (DotProduct) !dotproduct)
 

--- a/source/vm/nodes/node.lisp
+++ b/source/vm/nodes/node.lisp
@@ -119,6 +119,7 @@ Here's a list of reports.
 
 ;; Enhancement: !t is matmul-dedicated, therefore (!add (!t x) y) is invaild.
 ;; Enhancement: A[~] -> B[~] <- replace A with input-name.
+
 (defmethod forward :around ((node AbstractNode) &rest inputs)
   ;; Update Computation Nodes
 
@@ -340,14 +341,15 @@ Use the define-impl macro to give definitions for the node and forward them.
 
 (defun adjust-bw-place (bw-node place)
   "If the bw-node ends with MoveTensorNode, return itself, otherwise add MoveTensorNode."
+  
   (when bw-node
     (if (movetensor-p (tensor-backward bw-node))
 	bw-node
 	(with-shape-checkpoint (:moving nil)
 	  (let ((out (cl-waffe2/base-impl:!move place bw-node :force t)))
 	    (if (eql (cl-waffe2/vm.generic-tensor::tensor-attribute place) :chain)
-		out
-		bw-node))))))
+		out ;; In-place
+		bw-node)))))) ;; Make-copy
 
 (defun expand-backward (node dout &rest inputs-in)
   "

--- a/source/vm/nodes/package.lisp
+++ b/source/vm/nodes/package.lisp
@@ -13,11 +13,13 @@
 		#:tensor-id
 		#:tensor-variables
 		#:tensor-state
+		#:tensor-name
 		#:tensor-out-n
 		#:tensor-vec
 		#:tensor-view
 		#:make-tensor
 		#:make-input
+		#:set-input
 		#:movetensor-p
 		#:shaping-error
 		#:shape-equal

--- a/source/vm/nodes/package.lisp
+++ b/source/vm/nodes/package.lisp
@@ -20,6 +20,7 @@
 		#:make-tensor
 		#:make-input
 		#:set-input
+		#:compile-option-t
 		#:movetensor-p
 		#:shaping-error
 		#:shape-equal
@@ -37,6 +38,7 @@
   (:export
    #:create-subscript-p
    #:composite-where
+   #:define-composite-function
    #:forward
    #:backward
    #:expand-backward

--- a/source/vm/nodes/shape.lisp
+++ b/source/vm/nodes/shape.lisp
@@ -38,7 +38,7 @@
 		  :msg (format nil "The token anticipated to come is: [
 However, got ~a.
 When: ~a
-At  : ~ath symbol, ~a"
+At  : ~a symbol, ~a"
 			       exp
 			       exps
 			       pointer
@@ -205,6 +205,15 @@ Return:
 		      (bnf-parse-variables output-part)
 		      (bnf-parse-let-phase (cdr let-part))))))))))
 
+(defun preprocess-list (subscripts)
+  (read-from-string
+   (regex-replace-all "\\]"
+		      (regex-replace-all
+		       "\\["
+		       (format nil "~a" subscripts)
+		       " [ ")
+		      " ] ")))
+
 ;; export
 (defun parse-subscript (subscripts &key (fixed nil))
   "Subscripts are following format:
@@ -240,14 +249,7 @@ batch-size <- スコープが上位の変数も参照できるようにしたい
   ;; replace [a b] into [ a b ] (couldn't intepreted as a separated token)
   (multiple-value-bind (inputs outputs first-state out-state let-binding)
       (bnf-parse-subscripts-toplevel
-       (let ((out
-	       (read-from-string
-		(regex-replace-all "\\]"
-				   (regex-replace-all
-				    "\\["
-				    (format nil "~a" subscripts)
-				    " [ ")
-				   " ] "))))
+       (let ((out (preprocess-list subscripts)))
 	 (if fixed
 	     (loop for s in out
 		   unless (symbol-eq s '~)

--- a/source/vm/nodes/t/composite.lisp
+++ b/source/vm/nodes/t/composite.lisp
@@ -1,0 +1,111 @@
+
+(in-package :cl-waffe2/vm.nodes.test)
+
+(defun M= (tensor1 tensor2)
+  (every #'= (tensor-vec tensor1) (tensor-vec tensor2)))
+
+(defmodel (SumUpComposite (self)
+	   :where ([~] -> [scal] where scal = 1)
+	   :on-call-> ((self x)
+		       (declare (ignore self))
+		       (!sum x))))
+
+(defmodel (SumUp2DComposite (self)
+	   :where (X[a b] -> [scal] where scal = 1)
+	   :on-call-> ((self x)
+		       (declare (ignore self))
+		       (!sum x))))
+
+;; This case: The dispatching of function settles on a pattern
+(define-composite-function (SumUp2DComposite) !sumup-2d-float :dtype :float)
+
+(define-composite-function (SumUpComposite) !sumup-float :dtype :float)
+
+(define-composite-function (SumUpComposite) !sumup-generic)
+
+
+(defun composite-fundamental-function-test ()
+  (let ((a (randn `(10 10))))
+    (M= (proceed (!sum a))
+	(!sumup-2d-float a))))
+
+(defun composite-rank-dispatch (rank)
+  (let* ((shape (loop for r upfrom 0 below rank
+		      collect 10))
+	 (a (randn shape)))
+    (M= (proceed (!sum a))
+	(!sumup-float a))))
+
+(defun composite-dtype-dispatch (dtype)
+  (let* ((a (ax+b `(10 10) 0 1 :dtype dtype)))
+    (M= (proceed (!sum a))
+	(!sumup-generic a))))
+
+(test composite-function
+  (is (composite-fundamental-function-test)))
+
+(test composite-rank-dispatching-test
+  (is (composite-rank-dispatch 1))
+  (is (composite-rank-dispatch 2))
+  (is (composite-rank-dispatch 3))
+  (is (composite-rank-dispatch 4))
+  (is (composite-rank-dispatch 5))
+  (is (composite-rank-dispatch 6))
+  (is (composite-rank-dispatch 7))
+  (is (composite-rank-dispatch 8))
+  (is (composite-rank-dispatch 9)))
+
+(test composite-dtype-dispatching-test
+  (is (composite-dtype-dispatch :double))
+  (is (composite-dtype-dispatch :float))
+  (is (composite-dtype-dispatch :uint32))
+  (is (composite-dtype-dispatch :int32))
+  (is (composite-dtype-dispatch :int16))
+  (is (composite-dtype-dispatch :uint16))
+  (is (composite-dtype-dispatch :uint8))
+  (is (composite-dtype-dispatch :int8)))
+  
+
+;; Complex Node Test
+
+(defun composed-node (x y)
+  (!mul
+   (!sin (!add x y))
+   (!cos (!add x y))))
+
+(defmodel (ComposedFunction (self)
+	   :where (A[~] B[~] -> [~])
+	   :on-call-> ((self x y)
+		       (declare (ignore self))
+		       (composed-node x y))))
+
+(define-composite-function (ComposedFunction) !composed)
+
+;; Add: Dtype Checker
+;; どこかのCopyがResetされていない・・・？
+(defun test-composed-function (a b a1 b1)
+    (M= (proceed (composed-node a b))
+        (!composed a1 b1)))
+
+;; No Side Effects?
+(test test-composed-function
+  (is (test-composed-function
+       (ax+b `(3 3) 0 1)
+       (ax+b `(3 3) 0 1)
+       (ax+b `(3 3) 0 1)
+       (ax+b `(3 3) 0 1)
+       ))
+  (is (test-composed-function
+       (ax+b `(3 3) 0 1)
+       (ax+b `(3 3) 0 1)
+       (ax+b `(3 3) 0 1)
+       (ax+b `(3 3) 0 1)
+       ))
+  (is (test-composed-function
+       (ax+b `(3 3) 0 1)
+       (ax+b `(3 3) 0 1)
+       (ax+b `(3 3) 0 1)
+       (ax+b `(3 3) 0 1)
+       )))
+
+;; composite-function -> composite-function Test

--- a/source/vm/nodes/t/package.lisp
+++ b/source/vm/nodes/t/package.lisp
@@ -5,7 +5,9 @@
   (:use :cl :cl-waffe2/vm.generic-tensor
 	:cl-waffe2/vm.nodes
         :cl-waffe2/backends.cpu
-	:fiveam))
+        :cl-waffe2/base-impl
+        :fiveam
+        :cl-waffe2/distributions))
 
 (in-package :cl-waffe2/vm.nodes.test)
 

--- a/source/vm/nodes/utils.lisp
+++ b/source/vm/nodes/utils.lisp
@@ -126,3 +126,18 @@ Return:
 	      :order (order tensor)
 	      :scalar-p (scalar-p tensor)))
 
+(defun nth-subscript (nth)
+  "Returns nth alphabet"
+  (intern (format nil "Input-~a" (code-char (+ 65 (mod nth 26))))))
+
+(defun ->keyword (symbol)
+  (intern (format nil "~a" symbol) "KEYWORD"))
+
+(defun dim->input-shape (dim)
+  "3 -> (a b c) 2 -> (a b)"
+
+  (when (>= dim 27)
+    (error "Assertion Failed: dim < 27, butgot: ~a" dim))
+  
+  (loop for i upfrom 0 below dim
+	collect (nth-subscript i)))

--- a/source/vm/nodes/utils.lisp
+++ b/source/vm/nodes/utils.lisp
@@ -120,12 +120,6 @@ Return:
   (setf (cl-waffe2/vm.generic-tensor::detach-p tensor) state)
   tensor)
 
-(defun make-clone (tensor)
-  (make-input (shape tensor) nil
-	      :dtype (dtype tensor)
-	      :order (order tensor)
-	      :scalar-p (scalar-p tensor)))
-
 (defun nth-subscript (nth)
   "Returns nth alphabet"
   (intern (format nil "Input-~a" (code-char (+ 65 (mod nth 26))))))

--- a/source/vm/nodes/utils.lisp
+++ b/source/vm/nodes/utils.lisp
@@ -141,3 +141,26 @@ Return:
   
   (loop for i upfrom 0 below dim
 	collect (nth-subscript i)))
+
+(defun include~p (composite)
+  "Returns t if composite's input definiton has ~"
+  (some #'(lambda (x) (some #'(lambda (x) (symbol-eq '~ x)) x)) (composite-input-size composite)))
+    
+
+
+(defun tensor-keyname (tensor)
+  (symb ;; {BackendName[Dtype]}
+   '{
+   (class-name (class-of tensor))
+   '[
+   (intern (symbol-name (dtype tensor)))
+   ']
+   '}))
+
+
+(defun input-det-n-list (composite)
+  "returns the number of subscripts ignored ~"
+  (loop for i in (composite-input-size composite)
+	collect (- (length i) (count '~ i :test #'symbol-eq))))
+
+


### PR DESCRIPTION

Introducing new macro `define-composite-function`:

```lisp
(defmodel (ComposedFunction (self)
	   :where (A[~] B[~] -> [~])
	   :on-call-> ((self x y)
		       (declare (ignore self))
		       (!mul (!sin (!add x y)) (!cos (!add x y)))))

(define-composite-function (ComposedFunction) !composed)

(!composed (randn `(10 10)) (randn `(10 10))) ;; first call includes compiling time...
(!composed (randn `(10 10)) (randn `(10 10))) ;; second call is inlined and works fast.
```