### PR TITLE
[BugFix] the toplevel tensor of `build` function never reset.

### DIFF
--- a/examples/mnist.lisp
+++ b/examples/mnist.lisp
@@ -52,6 +52,10 @@
 	     (LinearLayer hidden-dim out-features)
 	     (asnode #'!softmax))
 
+(defsequence LinearModel (in-features)
+	     (LinearLayer in-features 30)
+	     (asnode #'!relu))
+
 (defun train ()
   (let ((model (MLP-Sequence 784 256 10)))
     (with-build (forward backward vars params)

--- a/source/optimizers/defoptimizer.lisp
+++ b/source/optimizers/defoptimizer.lisp
@@ -23,10 +23,10 @@
 (define-composite-function (ComposedFunction) !composed)
 
 (defmodel (Sin-Inlined (self)
-	   :where (X[~] OUT[~] -> [~])
-	   :on-call-> ((self x out)
+	   :where (X[~] -> [~])
+	   :on-call-> ((self x)
 		       (declare (ignore self))
-		       (forward (SinNode) x out))))
+		       (!sin x))))
 
 (define-composite-function (Sin-Inlined) !sin-inline)
 

--- a/source/optimizers/defoptimizer.lisp
+++ b/source/optimizers/defoptimizer.lisp
@@ -1,8 +1,6 @@
 
 (in-package :cl-waffe2/optimizers)
 
-;; Gradientを足し合わせる時にまとめて
-
 #|
 (defmacro defoptimizer (name))
 
@@ -10,3 +8,26 @@
   :slots
   :step ((parameter)
 	 |#
+
+(defun composed-node (x y)
+  (!mul
+   (!sin (!add x y))
+   (!cos (!add x y))))
+
+(defmodel (ComposedFunction (self)
+	   :where (A[~] B[~] -> [~])
+	   :on-call-> ((self x y)
+		       (declare (ignore self))
+		       (composed-node x y))))
+
+(define-composite-function (ComposedFunction) !composed)
+
+(defmodel (Sin-Inlined (self)
+	   :where (X[~] OUT[~] -> [~])
+	   :on-call-> ((self x out)
+		       (declare (ignore self))
+		       (forward (SinNode) x out))))
+
+(define-composite-function (Sin-Inlined) !sin-inline)
+
+

--- a/source/optimizers/package.lisp
+++ b/source/optimizers/package.lisp
@@ -2,7 +2,7 @@
 (in-package :cl-user)
 
 (defpackage :cl-waffe2/optimizers
-  (:use :cl))
+  (:use :cl :cl-waffe2 :cl-waffe2/base-impl :cl-waffe2/vm.generic-tensor :cl-waffe2/vm.nodes :cl-waffe2/distributions))
 
 (in-package :cl-waffe2/optimizers)
 

--- a/source/optimizers/package.lisp
+++ b/source/optimizers/package.lisp
@@ -2,7 +2,7 @@
 (in-package :cl-user)
 
 (defpackage :cl-waffe2/optimizers
-  (:use :cl :cl-waffe2 :cl-waffe2/base-impl :cl-waffe2/vm.generic-tensor :cl-waffe2/vm.nodes :cl-waffe2/distributions))
+  (:use :cl :cl-waffe2/base-impl :cl-waffe2/vm.generic-tensor :cl-waffe2/vm.nodes :cl-waffe2/distributions))
 
 (in-package :cl-waffe2/optimizers)
 

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -344,6 +344,7 @@ Tracing until one of variables reached a toplevel tensor (detach-p is t or no ba
 	      `(lambda ()
 		 (declare ,(compile-option-form compile-mode))
 		 ,@(map 'list #'(lambda (x) `(state-reset! ,x)) *node-parameters-tmp*)
+		 (state-reset! ,toplevel)
 		 ,(place-cached-kernels
 		   `(with-adjustable-symbols (,@set-input-forms)
 		      ,body))))

--- a/source/vm/generic-tensor/call-with-view.lisp
+++ b/source/vm/generic-tensor/call-with-view.lisp
@@ -226,7 +226,7 @@ Return: (values offsets-place form)"
 (call-with-view function tensors &key (at-least-dim 1))
 ```
 
-The function `call-with-view` is a utility to expand view-considered `loop` iteration in the `:forward` expansion of `define-impl`.
+`call-with-view` is a general-purpose interface to iterate multi-dimensional tensor with considering offsets.
 
 (TODO: Example/Documents)
 


### PR DESCRIPTION

The problem was that:
```lisp
(defmodel (Sin-Inlined (self)
	   :where (X[~] -> [~])
	   :on-call-> ((self x)
		       (declare (ignore self))
		       (!sin x))))

(define-composite-function (Sin-Inlined) !sin-inline)
;; The first call is valid, but the second call was invaild.
```

This is due to the last value of `build` never reset its state