### PR TITLE
[BugFix] A table key conflicts regardless of strides when reading cached function.

### DIFF
--- a/docs/cl-waffe2-docs/docs/nodes.md
+++ b/docs/cl-waffe2-docs/docs/nodes.md
@@ -411,9 +411,9 @@ Depending on `*using-backend*`, the implementation to use is determined at node-
 ```math
 g(dout, dx_{in}, dy_{in}, ..., dn_{in}) \triangleq \\
  Move(dx_{out}, {dout} \times {dx_{grad}}),\\
- Move(dx_{out}, {dout} \times {dy_{grad}}),\\
+ Move(dy_{out}, {dout} \times {dy_{grad}}),\\
  ...,\\
- Move(dx_{out}, {dout} \times {dn_{grad}})
+ Move(dn_{out}, {dout} \times {dn_{grad}})
 ```
 
 ```lisp

--- a/source/nn/activation.lisp
+++ b/source/nn/activation.lisp
@@ -31,12 +31,4 @@
   
   (let* ((x1 (!sub x (!mean x  :axis 1 :keepdims t)))
 	 (z  (!sum   (!exp x1) :axis 1 :keepdims t)))
-    (!div (!exp x1) (with-instant-kernel z
-		      `(progn
-			 ;; cacheの作り方が悪いかも？
-			 (print ,z)
-			 (print (tensor-vec ,z))
-			 ;; #(31.786076 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0)
-			 ;; Called with MLP Sequence...
-			 ,z
-			 )))))
+    (!div (!exp x1) z)))

--- a/source/vm/generic-tensor/cache.lisp
+++ b/source/vm/generic-tensor/cache.lisp
@@ -111,7 +111,7 @@ TensorViewNameN depicts the path call-with-view traced.
 	      do (push (template dim) name-list))
       ;; call-with-view traces following
       ;; n-1 n-2 ... 2 1 0th dim.
-      (apply #'symb (reverse name-list) (list (intern (format nil "~a" (shape tensor))))))))
+      (apply #'symb (reverse name-list) (list (intern (format nil "~a" (actual-shape tensor))))))))
 
 (defun kernel-name (compiled-kernel)
   (symb
@@ -146,7 +146,6 @@ Reading *kernel-storeroom*, the function expands the form below.
   (let ((caches (make-hash-table)))
     (dolist (fn *kernel-storeroom*)
       (setf (gethash (kernel-name fn) caches) (cache-kernel-form fn)))
-
     `(labels (,@(loop for body being the hash-values in caches
 		      collect body))
        ,@body)))


### PR DESCRIPTION
now `!softmax` works