### PR TITLE
[BugFix] backward definition of define-static-node

### DIFF
--- a/docs/apis/reference.lisp
+++ b/docs/apis/reference.lisp
@@ -137,7 +137,8 @@
     (caller-doc !rankup)
     (caller-doc ->scal)
     (caller-doc ->mat)
-
+    (caller-doc ->contiguous)
+    
     (caller-doc proceed)
     (caller-doc proceed-time)
     (caller-doc proceed-backward)

--- a/source/nn/t/criterion.lisp
+++ b/source/nn/t/criterion.lisp
@@ -10,17 +10,20 @@
 
 
 
+;; Tests for define-static-node's backward.
 (defun softmax-cross-entropy-test1 ()
   (let ((a (parameter (randn `(10 10))))
 	(b (parameter (randn `(10 10)))))
-    ;; Tests differentiable composite node
-    ;; And... Maybe it is now workig :(
-    (proceed-backward (!sum (!add (!relu a) (!relu b))))
-    (values (grad a) (grad b))))
+
+    (proceed-backward (!sum (softmax-cross-entropy (!relu a) (!relu b))))
+    (and
+     (some #'(lambda (x) (not (= x 0))) (tensor-vec (grad a)))
+     (some #'(lambda (x) (not (= x 0))) (tensor-vec (grad b))))))
     
 
-(test softmax-cross-entropy
+(test softmax-cross-entropy-and-static-node-backward
   (is (softmax-cross-entropy-test))
   (is (softmax-cross-entropy-test1)))
+
 
 

--- a/source/vm/nodes/static-node.lisp
+++ b/source/vm/nodes/static-node.lisp
@@ -323,7 +323,13 @@ But what if one wants to save the given tensors for a future call of backward? Y
 							   (or (nth nth ,',result-tmp) arg)))
 					       (nth 0 (backward-result ,,(car backward-args)))))))))
 
+       ;; Note:
+       ;; 1. define-static-node内でbackwardを(values nil tensor1)とする
+       ;; 2. 遅延評価しながらBackwardを構築するとき、コンパイル時に上の関数の返り値がわからない
+       ;; 3. とりあえず入力と同じTensorを用いてBackwardを構築する
+       ;; 4. ↑ はPruneされると思うけど... 万一計算のーどが繋がっちゃった時にWarningを出す必要がある。
        ;; This is a main part of composite-node.
+       
        (define-and-impl-node (,name (,self-name ,@constructor-args)
 			      :device t
 			      :where ,where


### PR DESCRIPTION
```lisp
(defun softmax-cross-entropy-test1 ()
  (let ((a (parameter (randn `(10 10))))
	(b (parameter (randn `(10 10)))))

    (proceed-backward (!sum (softmax-cross-entropy (!relu a) (!relu b))))
    (and
     (some #'(lambda (x) (not (= x 0))) (tensor-vec (grad a)))
     (some #'(lambda (x) (not (= x 0))) (tensor-vec (grad b))))))
```

define-static-node with multiple variables is now working.