### PR TITLE
[BugFix] The function permute* produces side effects and stride/shape/view is destructed.

### DIFF
--- a/benchmarks/package.lisp
+++ b/benchmarks/package.lisp
@@ -1,0 +1,24 @@
+
+(in-package :cl-user)
+
+(defpackage :cl-waffe2/benchmark
+  (:use :cl
+        :cl-waffe2
+	:cl-waffe2/vm.generic-tensor
+        :cl-waffe2/vm.nodes
+        :cl-waffe2/base-impl
+   :cl-waffe2/distributions))
+
+(in-package :cl-waffe2/benchmark)
+
+(defun mm-bench (n &key (times 1000))
+  (with-no-grad
+    (let ((model (build (!matmul (randn `(,n ,n))
+				 (randn `(,n ,n)))
+			:compile-mode :fastest)))
+      (let ((t1 (get-internal-real-time)))
+	(dotimes (i times)
+          (forward model))
+	(let ((t2 (get-internal-real-time)))
+	  (float (/ (- t2 t1) internal-time-units-per-second)))))))
+

--- a/examples/mnist.lisp
+++ b/examples/mnist.lisp
@@ -36,7 +36,7 @@
 				       (call
 					(model self)
 					(make-input `(batch-size ,in-class)  :X))
-				       (make-input `(batch-size  ,out-class) :Y)))))
+				       (make-input  `(batch-size ,out-class) :Y)))))
 
 		       
 		       out))
@@ -45,49 +45,29 @@
 			 (let ((loss (forward     (model self))))
 			   (format t "Loss: ~a~%" (tensor-vec loss)))
 			 (backward    (model self))
-			 (optimize!   (model self)))
+			 (optimize!   (model self))
+			 )
 	     :set-inputs ((self x y)
 			  (set-input (model self) :X x)
 			  (set-input (model self) :Y y))
 	     :predict ((self x)
 		       (call (model self) x))))
-
-(deftrainer (MLPTrainer-Test (self in-class out-class
-			      &key
-			      (hidden-size 256)
-			      (activation #'!tanh))
-	     :model     (MLP-Sequence in-class hidden-size out-class :activation activation)
-	     :optimizer (cl-waffe2/optimizers:SGD :lr 1e-2)
-	     :build ((self)
-		     (let ((out (!sum (!mul
-				 (call
-				  (model self)
-				  (make-input `(batch-size ,in-class)  :X))
-				 (make-input `(batch-size  ,out-class) :Y)))))
-
-		       
-		       out))
-	     :minimize! ((self)
-			 (zero-grads! (model self))
-			 (let ((loss (forward     (model self))))
-			   (format t "Loss: ~a~%" (tensor-vec loss)))
-			 (backward    (model self))
-			 (optimize!   (model self)))
-	     :set-inputs ((self x y)
-			  (set-input (model self) :X x)
-			  (set-input (model self) :Y y))
-	     :predict ((self x)
-		       (call (model self) x))))
-
 ;; TODO: Batch-Size 10 -> 1
 
 (defun perform-test ()
   (let ((trainer (MLPTrainer 50 10 :hidden-size 30 :activation #'!relu)))
+    
     (set-inputs trainer (randn `(3 50)) (bernoulli `(3 10) 0.1))
     
     (minimize!  trainer)
+
+    (set-inputs trainer (randn `(3 50)) (bernoulli `(3 10) 0.1))
+    
     (minimize!  trainer)
-    (minimize!  trainer)
+
+    ;;(set-inputs trainer (randn `(3 50)) (bernoulli `(3 10) 0.1))
+    
+    ;;(minimize!  trainer)
     
 
    ;; (time
@@ -97,18 +77,5 @@
    ;;    ))    
     trainer))
 
-(defun perform-test1 ()
-  (let ((trainer (MLPTrainer-Test 50 10 :hidden-size 30 :activation #'!tanh)))
-    (set-inputs trainer (randn `(30 50)) (bernoulli `(30 10) 0.1))
-    
-    (minimize!  trainer)
-    (minimize!  trainer)
-    (minimize!  trainer)
-    
+(perform-test)
 
-   ;; (time
-   ;;  (progn
-       ;;(set-inputs trainer (randn `(10 784)) (randn `(10 10)))
-   ;;    (minimize!  trainer)
-   ;;    ))    
-    trainer))

--- a/examples/mnist.lisp
+++ b/examples/mnist.lisp
@@ -29,7 +29,7 @@
 			      (hidden-size 256)
 			      (activation #'!tanh))
 	     :model     (MLP-Sequence in-class hidden-size out-class :activation activation)
-	     :compile-mode :default
+	     :compile-mode :safety
 	     :optimizer (cl-waffe2/optimizers:SGD :lr 1e-2)
 	     :build ((self)
 		     (let ((out (!mean (softmax-cross-entropy
@@ -65,9 +65,9 @@
     
     (minimize!  trainer)
 
-    ;;(set-inputs trainer (randn `(3 50)) (bernoulli `(3 10) 0.1))
+    (set-inputs trainer (randn `(3 50)) (bernoulli `(3 10) 0.1))
     
-    ;;(minimize!  trainer)
+    (minimize!  trainer)
     
 
    ;; (time
@@ -77,5 +77,6 @@
    ;;    ))    
     trainer))
 
-(perform-test)
+(dotimes (I 10)
+(perform-test))
 

--- a/source/base-impl/fundamental.lisp
+++ b/source/base-impl/fundamental.lisp
@@ -791,8 +791,7 @@ Note that the case when only the last two aces are subject to be swapped, we ret
   ;;		  (proceed-backward (!matmul a (randn `(10 3))))
   ;;		  a)
   ;;
-  (let* (;(tensor (!copy tensor)) ;; Ignore if tenosr is inputtensor
-	 (new-tensor (apply #'permute* tensor orders))
+  (let* ((new-tensor (apply #'permute* tensor orders))
 	 (diff       (list-diff (cl-waffe2/vm.generic-tensor::tensor-permute-order tensor)
 				(cl-waffe2/vm.generic-tensor::tensor-permute-order new-tensor)))
 	 (lazy-p (and (every #'(lambda (x) x) (butlast diff 2))

--- a/source/base-impl/fundamental.lisp
+++ b/source/base-impl/fundamental.lisp
@@ -704,11 +704,11 @@ dout   ... dout values"
 		       :slots ((permute-old :initform nil :initarg :permute-old :reader permute-old))
 		       :where (Old[before] New[after] -> New[after])
 		       :forward ((self a out)
-				 `(progn
+				 `(let ((out1 (cl-waffe2/vm.generic-tensor::detach-and-clone1 ,out)))
 				    (embody-actual-tensor
-				     ,out
-				     ,a)
-				    ,out))
+				     out1
+				     ,a)				    
+				    out1))
 		       :backward ((self dout a out)
 				  (declare (ignore a out))
 				  (let ((out (apply #'!permute dout (permute-old self))))

--- a/source/base-impl/fundamental.lisp
+++ b/source/base-impl/fundamental.lisp
@@ -707,7 +707,7 @@ dout   ... dout values"
 				 `(let ((out1 (cl-waffe2/vm.generic-tensor::detach-and-clone1 ,out)))
 				    (embody-actual-tensor
 				     out1
-				     ,a)				    
+				     ,a)		    
 				    out1))
 		       :backward ((self dout a out)
 				  (declare (ignore a out))
@@ -785,7 +785,14 @@ Note that the case when only the last two aces are subject to be swapped, we ret
 "
   ;; If only the last two axes are subject to swapped.
   ;; Return a special node LazyTranspose instead.
-  (let* ((new-tensor (apply #'permute* tensor orders))
+
+  ;; BugCode:
+  ;; (let ((a (parameter (print (ax+b `(3 10) 1 0)))))
+  ;;		  (proceed-backward (!matmul a (randn `(10 3))))
+  ;;		  a)
+  ;;
+  (let* (;(tensor (!copy tensor)) ;; Ignore if tenosr is inputtensor
+	 (new-tensor (apply #'permute* tensor orders))
 	 (diff       (list-diff (cl-waffe2/vm.generic-tensor::tensor-permute-order tensor)
 				(cl-waffe2/vm.generic-tensor::tensor-permute-order new-tensor)))
 	 (lazy-p (and (every #'(lambda (x) x) (butlast diff 2))

--- a/source/base-impl/fundamental.lisp
+++ b/source/base-impl/fundamental.lisp
@@ -707,7 +707,7 @@ dout   ... dout values"
 				 `(let ((out1 (cl-waffe2/vm.generic-tensor::detach-and-clone1 ,out)))
 				    (embody-actual-tensor
 				     out1
-				     ,a)		    
+				     ,a)
 				    out1))
 		       :backward ((self dout a out)
 				  (declare (ignore a out))

--- a/source/base-impl/matrix-ops.lisp
+++ b/source/base-impl/matrix-ops.lisp
@@ -72,7 +72,7 @@ Transposes the last two axes of the given tensor.
 
 When called with !matmul, the operation is ignored.
 "
-  
+
   (extend-states (!permute tensor :~ 0 1) tensor))
 
 (defun !matmul (x y

--- a/source/optimizers/impls/sgd.lisp
+++ b/source/optimizers/impls/sgd.lisp
@@ -28,5 +28,6 @@ Param_{new}\\gets{Param - Param_{grad}\\times{lr}}
   (let* ((lr    (make-tensor (sgd-lr optimizer)))
 	 (param (read-parameter optimizer))
 	 (grad  (grad param)))
+
     (step-sgd param grad lr)))
 

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -97,40 +97,86 @@ Variables:
      (length (nodevariables-parameters node)))))
 
 
+;; ==============================================================================================================================
+;; [FixME] Someone destructs (tensor-input-shape tensor) in toplevel (destructs = permute* shuffles the order of it)
+;; I tried harder, but I couldn't find which function shuffles it, but I've confirmed other slots (strides, visible-shape, views...) are NEVER affected.
+;; I know this solution is literally UGLY, but decided to create a LUT (*shape-input-table*, id->first input-shape), and ignore
+;; destructed input-shape.
+;; This sometime may result an unexcepted behaviour, but:
+;; tensor-id is created by (gensym), so assured that never conflicts.
+;; (i.e.: Once the tensor(id=A) is initialized as `(A B), no one can create another tensor whose id=A)
+;; As long as we don't add any strange features, I think we'll be fine.
+;; One of my concern is that: when allocating a cache tensor for InputTensor, we must not use input-shape.
+;; ==============================================================================================================================
+
+(defparameter *shape-input-table* (make-hash-table) "Things to be deleted in the future release.")
+
 (defun embody-input (nodevars variable-name actual-tensor)
   "(embody-input variables :a tensor)
 
+InputTensor[A x B] <- ExistTensor[10 x 10] for example.
 See also: `set-input`"
   (declare (type NodeVariables nodevars))
   
   (let ((input-tensor (gethash variable-name (nodevariables-variables nodevars))))
-
+    
     (when (null input-tensor)
       (error "The InputTensor named ~a weren't appeared in the computation node" variable-name))
 
+    (when (not (= (dims input-tensor) (dims actual-tensor)))
+      (error "embody-input: ranks does not match: ~a and ~a" input-tensor actual-tensor))
+    
     (let ((symbols-changed (make-hash-table)))
-      ;;(print "====")
-      ;;(print (tensor-input-shape input-tensor))
-      ;;(print (shape actual-tensor))
-      (loop for place in (tensor-input-shape input-tensor)
+      (loop for place in (or (gethash (tensor-id input-tensor) *shape-input-table*)
+			     (tensor-input-shape input-tensor))
 	    for value in (shape actual-tensor)
+	    for rank upfrom 0
 	    if (and (not (symbolp place))
 		    (not (= place value)))
-	      do (error "embody-input: Can't embody ~a into fixed place, ~a.
+	      do (error "embody-input: The ~ath rank is a fixed dimension.
+So the corresponding shape must be ~a but got ~a.
+
+Shapes: Input_Place <- Actual_Tensor
+-----------------------------------------------
+Shapes:   ~a~a  <-  ~a
+
 input-tensor:
 ~a
 
+Strides       : ~a
+permute-order : ~a
+
 actual-tensor:
-~a"
-			value place input-tensor actual-tensor)
+~a
+
+Strides       : ~a
+permute-order : ~a
+"
+			rank value place
+			variable-name
+			(tensor-input-shape input-tensor)
+			(shape actual-tensor)
+			input-tensor
+			(tensor-stride input-tensor)
+			(tensor-permute-order input-tensor)
+			actual-tensor
+			(tensor-stride actual-tensor)
+			(tensor-permute-order actual-tensor))
 	    if (symbolp place)
 	      do (setf (gethash place symbols-changed) value))
+      
+      (if (null (gethash (tensor-id input-tensor) *shape-input-table*))
+	  (setf (gethash (tensor-id input-tensor) *shape-input-table*) (copy-list (tensor-input-shape input-tensor))))
 
       ;; Checking if the new size never beyonds memory-pool.
 
+      ;; No need to check.
+      
+      #|
       (let ((maxsize (nodevariables-adjustable-symbol nodevars)))
 	(maphash
 	 #'(lambda (key value)
+	     (declare (ignore value))
 	     (let ((max-val (gethash key maxsize)))
 	       
 	       (when (and (not (null max-val))
@@ -138,22 +184,24 @@ actual-tensor:
 			  )
 		 
 		 ;;(error "Error: Can't embody tensor because ~a = ~a is given but ~a must <= ~a"
-		;;	key
-		;;	value
-		;;	key
-		;;	max-val)
-		 (setf (gethash key maxsize) value))
+		 ;;	key
+		 ;;	value
+		 ;;	key
+		 ;;	max-val)
+		 ;;(setf (gethash key maxsize) value)
+		 )
 	       
 
 	       (when (null max-val)
-		 (setf (gethash key maxsize) value))))
-	 symbols-changed))
+		 ;; (setf (gethash key maxsize) value)
+		 )))
+      symbols-changed))
+      |#
       
       ;; InputTensor <- Actual-Tensor
       (embody-actual-tensor input-tensor actual-tensor)
 
       ;; Apply hash-table
-
       (maphash
        #'(lambda (key value)
 	   (setf (getf (nodevariables-symbols nodevars) key) value))
@@ -302,6 +350,8 @@ Tracing until one of variables reached a toplevel tensor (detach-p is t or no ba
 	(if (equal (shape toplevel) (shape past-dy))
 	    `(add-grads ,toplevel ,(tensor-id past-dy))
 	    (progn
+	      ;; MEMO: Couldn't detect the gradient is permuted at compile-time
+	      ;; we need to re-compile gradient adder.
 	      ;; Create Gradient-Adder again
 	      (setf (gradient-adder toplevel) nil)
 

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -109,12 +109,19 @@ See also: `set-input`"
       (error "The InputTensor named ~a weren't appeared in the computation node" variable-name))
 
     (let ((symbols-changed (make-hash-table)))
+      ;;(print "====")
+      ;;(print (tensor-input-shape input-tensor))
+      ;;(print (shape actual-tensor))
       (loop for place in (tensor-input-shape input-tensor)
 	    for value in (shape actual-tensor)
 	    if (and (not (symbolp place))
 		    (not (= place value)))
-	      do (error "Can't embody ~a into fixed place, ~a.
-~a and ~a"
+	      do (error "embody-input: Can't embody ~a into fixed place, ~a.
+input-tensor:
+~a
+
+actual-tensor:
+~a"
 			value place input-tensor actual-tensor)
 	    if (symbolp place)
 	      do (setf (gethash place symbols-changed) value))

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -343,7 +343,12 @@ Tracing until one of variables reached a toplevel tensor (detach-p is t or no ba
     (return-from compile-backward-chain
       (when (slot-value toplevel 'requires-grad)
 	(init-optimizer-utils! toplevel)
-	(if (not (permuted-p past-dy))
+	;; We receive gradients as vec permuted (see MoveTensorNode)
+	`(add-grads ,toplevel ,(tensor-id past-dy)))))
+
+  ;; Not anymore used.
+  #|
+	(if t;(not (permuted-p past-dy))
 	    `(add-grads ,toplevel ,(tensor-id past-dy))
 	    (progn
 	      ;; The function gradient-adder is compiler for default permutation tensors
@@ -357,7 +362,7 @@ Tracing until one of variables reached a toplevel tensor (detach-p is t or no ba
 	      ;; X.grad += permute*(value, 0 1 ...)
 	      ;; ^ recompiling is needed!
 	      `(add-grads ,toplevel ,(tensor-id past-dy)))))))
- 
+ |#
 
   ;; with-shape-checkout: at where node, the backward error was occured?
   (cl-waffe2/vm.nodes:with-shape-checkpoint (:backward (tensor-backward toplevel))

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -109,7 +109,7 @@ Variables:
 ;; One of my concern is that: when allocating a cache tensor for InputTensor, we must not use input-shape.
 ;; ==============================================================================================================================
 
-(defparameter *shape-input-table* (make-hash-table) "Things to be deleted in the future release.")
+;;(defparameter *shape-input-table* (make-hash-table) "Things to be deleted in the future release.")
 
 (defun embody-input (nodevars variable-name actual-tensor)
   "(embody-input variables :a tensor)
@@ -127,7 +127,7 @@ See also: `set-input`"
       (error "embody-input: ranks does not match: ~a and ~a" input-tensor actual-tensor))
     
     (let ((symbols-changed (make-hash-table)))
-      (loop for place in (or (gethash (tensor-id input-tensor) *shape-input-table*)
+      (loop for place in (or ;;(gethash (tensor-id input-tensor) *shape-input-table*)
 			     (tensor-input-shape input-tensor))
 	    for value in (shape actual-tensor)
 	    for rank upfrom 0
@@ -165,8 +165,8 @@ permute-order : ~a
 	    if (symbolp place)
 	      do (setf (gethash place symbols-changed) value))
       
-      (if (null (gethash (tensor-id input-tensor) *shape-input-table*))
-	  (setf (gethash (tensor-id input-tensor) *shape-input-table*) (copy-list (tensor-input-shape input-tensor))))
+      ;;(if (null (gethash (tensor-id input-tensor) *shape-input-table*))
+;;	  (setf (gethash (tensor-id input-tensor) *shape-input-table*) (copy-list (tensor-input-shape input-tensor))))
 
       ;; Checking if the new size never beyonds memory-pool.
 

--- a/source/vm/generic-tensor/memory-pool.lisp
+++ b/source/vm/generic-tensor/memory-pool.lisp
@@ -283,7 +283,8 @@ Usage:
 	 (let ((out (gethash symbol *adjustable-shape-table*)))
 	   (if (null out)
 	       symbol ;; No result?
-	       (if (symbolp out)
+	       (if (and (symbolp out)
+			(not (eq symbol out))) ;; A -> A ...
 		   ;; A = BATCH_SIZE = 10
 		   (read-symbol out)
 		   out))))

--- a/source/vm/generic-tensor/memory-pool.lisp
+++ b/source/vm/generic-tensor/memory-pool.lisp
@@ -45,7 +45,9 @@
 ;;
 
 
-(defparameter *thread-memory-pool* (tg:make-weak-hash-table :weakness :key) "A weak-hash-table which restores: [Thread-IDX] -> [Memory-Pool]")
+(defparameter *thread-memory-pool*
+  (make-hash-table);;(tg:make-weak-hash-table :weakness :key)
+  "A weak-hash-table which restores: [Thread-IDX] -> [Memory-Pool]")
 (defvar       *thread-pool-lock*   (make-lock "thread cache lock"))
 
 (defvar *adjustable-shape-table* nil "An hash-table: Symbol -> Size.") ;; (A -> 10, B -> 10)
@@ -137,7 +139,7 @@
   ;; TODO:
   ;; (maphash ... tensor-delete)
   ;; Maybe:: CUDA Foreign Pointers aren't gc-reachable??
-  (setf *thread-memory-pool* (tg:make-weak-hash-table :weakness :key))
+  (setf *thread-memory-pool* (make-hash-table));;(tg:make-weak-hash-table :weakness :key))
   #+sbcl(sb-ext:gc :full t)
   )
 
@@ -149,7 +151,7 @@ Creates a new scope of memory-pool.
 
 After the body exists, all the temporary tensors in the pool is freed.
 "
-  `(let ((*thread-memory-pool* (tg:make-weak-hash-table :weakness :key)))
+  `(let ((*thread-memory-pool* (make-hash-table)));;(tg:make-weak-hash-table :weakness :key)))
      (unwind-protect (progn ,@body)
        (free-current-memory-pool))))
 

--- a/source/vm/generic-tensor/memory-pool.lisp
+++ b/source/vm/generic-tensor/memory-pool.lisp
@@ -67,7 +67,6 @@
   (let ((current-keys (loop for symbol being the hash-keys   in *adjustable-shape-table* collect symbol))
 	(current-vals (loop for size   being the hash-values in *adjustable-shape-table* collect size))
 	(old-table    (adjustable-shape-state-state old-state)))
-    ;; (not some
     (not (some #'(lambda (target-symbol current-val)
 		   (let ((val (gethash target-symbol old-table)))
 		     (if (and (typep val 'fixnum)
@@ -236,18 +235,24 @@ Usage:
 
 (with-adjustable-symbols (('a 1) ('b 1))
     (with-let-adjustable-symbols (a b)
-        (print a)
-        (print b)))
+        (print a)   ;; = 1
+        (print b))) ;; = 1
 
 "
 
   `(let* ((*adjustable-shape-table* (or *adjustable-shape-table* (make-hash-table)))
 	  (*current-shape-state*    (make-adjustable-shape-state)))
      
+     ;;(print "========")
+     ;;(maphash #'(lambda (key val)
+     ;;		  (format t "KEY: ~a   VAL: ~a~%" key val))
+     ;;	      *adjustable-shape-table*)
+     
      ;;(unless (typep ,symbol-value 'fixnum)
      ;;  (error "with-adjustalbe-symbol: Attempted to register an symbol, ~a (TODO More clear error)" ,symbol-value))
-     
+
      (setf (gethash ,symbol-name *adjustable-shape-table*) ,symbol-value)
+	 
      ,@body))
 
 (defmacro with-adjustable-symbols ((&rest forms) &body body)
@@ -259,10 +264,11 @@ Usage:
     (expand-form forms)))
 
 (defmacro with-let-adjustable-symbol (symbol-name &body body)
+  ;; TO DELETE: Binding with symbol-name
   `(let ((,symbol-name (gethash ',symbol-name *adjustable-shape-table*)))
      (declare (type fixnum ,symbol-name)
-	      
 	      (ignorable ,symbol-name))
+     
      (declare (ignore symbol-name))
      ,@body))
 

--- a/source/vm/generic-tensor/t/backward.lisp
+++ b/source/vm/generic-tensor/t/backward.lisp
@@ -71,8 +71,8 @@
   (is (chain-test3))
   (is (chain-test4))
   (is (chain-test5))
-  (is (chain-test6))
-  (is (chain-test7)))
+  (is (chain-test7))
+  (is (chain-test6)))
 
 (test backward-side-effect-test
   (is (backward-being-not-destructed)))

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -74,7 +74,7 @@ PriorityN must be a subclass of cl-waffe2/vm.generic-tensor:AbstractTensor")
 
    (allocate-time-state :initform nil :type (or null Adjustable-Shape-State) :accessor tensor-alloc-state)
    (protect-me :initform nil :accessor tensor-protect-me) ;; If t, cache never ignored.
-   (input-shape :initarg :input-shape :initform nil :accessor tensor-input-shape))
+   (input-shape :initarg :input-shape :initform nil :reader tensor-input-shape))
   (:documentation "
 AbstractTensor is a primal class for all devices. Each devices (e.g.: `ScalarTensor` `LispTensor` `CPUTensor` etc...) is a subclass of this.
 
@@ -256,7 +256,8 @@ Tensors has a two state:
     (apply-permute (slot-value tensor 'visible-shape) tensor)
     (apply-permute (slot-value tensor 'orig-shape) tensor)
     (when (slot-value tensor 'input-shape)
-      (apply-permute (slot-value tensor 'input-shape) tensor))))	
+      (apply-permute (slot-value tensor 'input-shape) tensor)
+      )))	
 
 (defun total (tensor)
   (declare (type AbstractTensor tensor))
@@ -275,7 +276,6 @@ Tensors has a two state:
   (declare (type AbstractTensor)
 	   (optimize (speed 3)))
   (let ((a (copy-list (tensor-permute-order tensor))))
-    
     (not (equal (sort a #'>) (tensor-permute-order tensor)))))
 	   
 
@@ -487,7 +487,8 @@ Note:
 	(tensor-stride to) (tensor-stride from)
 	(tensor-view to) (tensor-view from)
 	(tensor-permute-order to) (tensor-permute-order from)
-	(slot-value to 'input-shape) (slot-value from 'input-shape))
+	;;(slot-value to 'input-shape) (slot-value from 'input-shape)
+	)
   nil)
   
 

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -1063,7 +1063,7 @@ The function parameter computes all the previous nodes of the given tensor if an
 (defun system-lazy-set-save-for-backward (tensor)
   ;; FIXME: How to ignore save-for-backward when predicting? compiling again?
 
-  (let ((space-tmp (make-clone tensor)))
+  (let ((space-tmp (make-clone tensor nil t)))
     (let* ((result (cl-waffe2/base-impl:!move space-tmp tensor :force t)))
       ;; If tensor is arguments (of toplevel)...
       (setf (save-for-backward-space result) tensor)

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -65,7 +65,6 @@ PriorityN must be a subclass of cl-waffe2/vm.generic-tensor:AbstractTensor")
    (gradient-resetter :accessor gradient-resetter)
 
    (save-for-backward-space       :initform nil :accessor save-for-backward-space)
-   (save-for-backward-space-cache :initform nil :accessor save-for-backward-space-cache)
    (save-for-backward-cloner :initform nil :accessor save-for-backward-cloner)
    
    (requires-grad :initform nil :initarg :requires-grad :reader requires-grad :type boolean)
@@ -1063,17 +1062,15 @@ The function parameter computes all the previous nodes of the given tensor if an
 (defun system-lazy-set-save-for-backward (tensor)
   ;; FIXME: How to ignore save-for-backward when predicting? compiling again?
 
-  (let ((space-tmp (make-clone tensor nil t)))
+  (let ((space-tmp (make-clone tensor nil nil)))
     (let* ((result (cl-waffe2/base-impl:!move space-tmp tensor :force t)))
       ;; If tensor is arguments (of toplevel)...
       (setf (save-for-backward-space result) tensor)
-      (setf (save-for-backward-space-cache result) space-tmp)
+      ;; !! Before and after save4bw, result == tensor.
       result)))
 	
-(defun system-lazy-read-save-for-backward (tensor &key (cache-place nil))
-  (if cache-place
-      (save-for-backward-space-cache tensor)
-      (save-for-backward-space tensor)))
+(defun system-lazy-read-save-for-backward (tensor)
+  (save-for-backward-space tensor))
 
 ;; Exports
 (defun hook-optimizer! (tensor optimizer)

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -785,7 +785,6 @@ Note that view is only created for Tensors, not a Scalar.
 		   :create-from tensor
 		   :dtype (dtype tensor)
 		   :order (order tensor)
-		   ;; A view of tensor requires NO GRADINET on some conditions!!! -> use detach-and-clone
 		   :requires-grad (slot-value tensor 'requires-grad)
 		   :shape         (slot-value tensor 'orig-shape)
 		   :projected-p   t

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -809,6 +809,20 @@ Note that view is only created for Tensors, not a Scalar.
 		 :named (tensor-name tensor)
 		 :vec (vec tensor)))
 
+(defun detach-and-clone1 (tensor)
+  (make-instance (car *using-backend*)
+		 :create-from tensor
+		 :scalar-p (scalar-p tensor)
+		 :dtype (dtype tensor)
+		 :order (order tensor)
+		 :shape (copy-list (slot-value tensor 'orig-shape))
+		 :projected-p t
+		 :past-view (copy-list (tensor-view tensor))
+		 :input-shape (copy-list (tensor-input-shape tensor))
+		 :facet (tensor-facet tensor)
+		 :named (tensor-name tensor)
+		 :vec (vec tensor)))
+
 (defun permute-computable-p (old-order new-order)
   (equal (sort (copy-list old-order) #'<)
 	 (sort (copy-list new-order) #'<)))

--- a/source/vm/nodes/function.lisp
+++ b/source/vm/nodes/function.lisp
@@ -18,8 +18,8 @@
 		:dtype (dtype tensor)
 		:order (order tensor)
 		:scalar-p (scalar-p tensor))))
-
     (cl-waffe2/vm.generic-tensor::embody-tensor-vec place tensor)
+    ;; set facet = :exist?
     place))
 
 (defun composite->defun (~ composite function-name
@@ -60,16 +60,15 @@ Return: defun form
 	 (mname     (gensym)))
     (with-no-grad
       (multiple-value-bind (compiled-kernel set-input-forms) (cl-waffe2/vm.generic-tensor:build result :compile-mode compile-mode :use-setinput-form t)
-
 	`(progn
-	   
 	   ;; Main Body
 	   (defun ,tmp-fname (,self ,@namelist)
 	     (declare (ignore ,self))
+	     
 	     ,@(loop for tensor in inputs
 		     for name in namelist
 		     collect `(set-input ,compiled-kernel ,(tensor-name tensor) ,name))
-
+	     
 	     (let ((outputs (multiple-value-list (forward ,compiled-kernel))))
 	       (cl-waffe2/vm.generic-tensor::with-adjustable-symbols (,@set-input-forms)
 		 (apply #'values (map 'list #'eliminate-undetermined-size outputs)))))
@@ -235,6 +234,7 @@ On the condition where composite should be defined as polymorphic, the function 
 	   (type keyword order)
 	   (type compile-option-t compile-mode))
 
+  
   `(eval (composite-function ,composite-init-form
 			     ',function-name
 			     #'(lambda ()
@@ -245,4 +245,3 @@ On the condition where composite should be defined as polymorphic, the function 
 			     :compile-mode ,compile-mode
 			     :dtype ,dtype
 			     :order ,order)))
-

--- a/source/vm/nodes/node.lisp
+++ b/source/vm/nodes/node.lisp
@@ -356,6 +356,7 @@ Use the define-impl macro to give definitions for the node and forward them.
 		  :scalar-p (scalar-p place))
       place))
 
+
 (defun adjust-bw-place (bw-node place argn nth-trying)
   "If the bw-node ends with MoveTensorNode, return itself, otherwise add MoveTensorNode."
   
@@ -405,6 +406,7 @@ inputs      ... inputs called with
   ;;FIX: REDUCE COMPILE TIME!
   
   ;; Collecting x_in
+
   (detach dout t)
   (let* ((inputs-in (loop for input in inputs-out
 			  collect (detach (or (system-lazy-read-save-for-backward input) input) t)))
@@ -417,7 +419,7 @@ inputs      ... inputs called with
 			    for y in inputs-out
 			    for i upfrom 0
 			    collect (adjust-bw-place x y argn i))))
-
+    
     (loop for kernel in out-kernels
 	  collect
 	  (when kernel

--- a/source/vm/nodes/node.lisp
+++ b/source/vm/nodes/node.lisp
@@ -369,7 +369,7 @@ Use the define-impl macro to give definitions for the node and forward them.
 		      :force t)))
 	    ;; F(x, y, ...)
 	    ;; x.state = :chain / :input?
-	    
+
 	    (if (eql (cl-waffe2/vm.generic-tensor::tensor-attribute place) :chain)
 		out
 		;; when bw-node... -> chain not connected well...?
@@ -425,10 +425,12 @@ inputs      ... inputs called with
 	      (cons
 	       out
 	       `(named-lambda ,(symb (class-name (class-of node)) '-backward) (,dout-place)
-		  
+		  ;;(print "=======")
+		  ;;(print ,dout)
 		  (cl-waffe2/vm.generic-tensor:embody-actual-tensor
 		   ,dout
 		   ,dout-place)
+		  ;;(print ,dout)
 		  
 		  ,(with-no-grad
 		     (cl-waffe2/vm.generic-tensor:make-vm-function kernel)))))))))


### PR DESCRIPTION
<img width="300" src="https://github.com/hikettei/cl-waffe2/assets/88639579/d8a7ff72-2702-40b6-b3e4-5edc06e11870">

When calling `permute*`, someone has to make a copy of strides/shapes/view of given tensors, because shuffling orders also modify the given tensor. This pull request fixed the problem and accordingly deleted the re-compiling of the gradient adder.

I've confirmed all tests passed without SegFault, and a simple three-layer MLP model is now working well.