### PR TITLE
[BugFix] Backward

### DIFF
--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -96,6 +96,7 @@
 	       (:file "optimizers/defoptimizer")
 
 	       (:file "optimizers/impls/sgd")
+	       (:file "optimizers/impls/adam")
 
 	       (:file "package")
 	       (:file "array-converter")

--- a/examples/mlp_sin_wave.lisp
+++ b/examples/mlp_sin_wave.lisp
@@ -1,0 +1,63 @@
+
+(in-package :cl-user)
+
+(defpackage :cl-waffe2-example1
+  (:use
+   :cl
+   :cl-waffe2
+   :cl-waffe2/nn
+   :cl-waffe2/distributions
+   :cl-waffe2/base-impl
+   :cl-waffe2/vm.generic-tensor
+   :cl-waffe2/vm.nodes
+   :cl-waffe2/optimizers))
+
+(in-package :cl-waffe2-example1)
+
+(defsequence Simple-MLP (in-features hidden-dim)
+	     (LinearLayer in-features hidden-dim t)
+	     (asnode #'!sigmoid)
+	     (LinearLayer hidden-dim 1 t))
+
+;; Naming:... set-input VS set-inputs
+;; allow: (forward self)
+;; make trainer forwardable
+
+(deftrainer (MLPTrainer (self in-features hidden-dim &key (lr 1e-1))
+	     :model (Simple-MLP in-features hidden-dim)
+	     :optimizer (SGD :lr lr)
+	     :build ((self)
+		     (MSE
+		      (make-input `(batch-size 1) :TrainY)
+		      (call (model self) (make-input `(batch-size ,in-features) :TrainX))))
+	     
+	     :set-inputs ((self x y)
+			  (set-input (model self) :TrainX x)
+			  (set-input (model self) :TrainY y))
+	     :minimize! ((self)
+			 (zero-grads! (model self))
+			 (let ((loss (forward (model self))))
+			   (format t "Training Loss: ~a~%" (tensor-vec loss)))
+			 (backward  (model self))
+			 (optimize! (model self)))
+	     :predict ((self x)
+		       (call (model self) x))))
+			 
+			 
+		     
+			 
+	   
+;; Training sin wave from random noises
+;; If we forget to call proceed when making training data?
+;; -> set-input must return error.
+(defun train (&key
+		(batch-size 100)
+		(iter-num 1))
+  (let* ((X (proceed (!sin (ax+b `(,batch-size 100) 0.01 0.1))))
+ 	 (Y (proceed (!cos (ax+b `(,batch-size 1)   0.01 0.1))))
+	 (trainer (MLPTrainer 100 10 :lr 1e-1)))
+
+    (loop for nth-epoch fixnum upfrom 0 below iter-num
+	  do (set-inputs trainer X Y)
+	     (minimize! trainer))))
+

--- a/source/base-impl/fundamental.lisp
+++ b/source/base-impl/fundamental.lisp
@@ -27,7 +27,7 @@
 					 `(progn
 					    (setf (tensor-vec ,out) (tensor-vec ,dout))
 					    ,out)))
-				     (!copy dout :force t))))) 
+				     (!copy dout :force t)))))
 		       (values nil dy-out)))
 	  :documentation "
 Moves all the visible elements of `B` into visible areas of `A`.

--- a/source/nn/criterion.lisp
+++ b/source/nn/criterion.lisp
@@ -102,7 +102,7 @@ In addition, reading the value of a `:reduction` keyword (one of `:mean` `:sum` 
 			       (with-setting-save4bw ((x x) (labels labels)) self
 				 (static-softmax-cross-entropy-forward x labels)))
 		     :backward ((self dout)
-				(with-reading-save4bw ((x x) (labels labels)) self				  
+				(with-reading-save4bw ((x x) (labels labels)) self
 				  (static-softmax-cross-entropy-backward
 				   dout
 				   x

--- a/source/nn/criterion.lisp
+++ b/source/nn/criterion.lisp
@@ -63,10 +63,10 @@ In addition, reading the value of a `:reduction` keyword (one of `:mean` `:sum` 
   (let ((l (!sub x y)))
     (case reduction
       (:sum
-       (!sum (!mul l l)))
+       (!sum  (!square l)))
       (:mean
-       (!mean (!mul l l)))
-      (T (!mul l l)))))
+       (!mean (!square l)))
+      (T      (!square l)))))
 
 
 (defmodel (Softmax-Cross-Entropy-Forward (self &key (delta 1e-7) (avoid-overflow t))

--- a/source/optimizers/impls/adam.lisp
+++ b/source/optimizers/impls/adam.lisp
@@ -1,0 +1,105 @@
+
+(in-package :cl-waffe2/optimizers)
+
+
+(defoptimizer (Adam (self param
+			  &key
+			  (lr 1e-3)
+			  (eps 1e-7)
+			  (beta1 0.9)
+			  (beta2 0.999))
+		    :documentation "
+### Inputs
+
+A simple Adam
+
+(TODO)
+"
+		    :slots ((lr :initarg :lr :reader lr-of :type single-float)
+			    (eps :initarg :eps :reader eps-of :type single-float)
+			    (beta1 :initarg :beta1 :reader beta1-of :type single-float)
+			    (beta2 :initarg :beta2 :reader beta2-of :type single-float)
+			    (N :initform 0 :type fixnum :accessor adam-n)
+			    (M :accessor adam-m)
+			    (V :accessor adam-V)))
+    
+
+    (setf (adam-m self)
+	  (make-tensor (shape param)
+		       :dtype (dtype param)
+		       :order (order param)))
+
+    (setf (adam-v self)
+  	  (make-tensor (shape param)
+		       :dtype (dtype param)
+		       :order (order param))))
+
+(defmodel (Adam-Step-M (self)
+	         ;;  M    Grad       beta1
+	   :where (M[~] X.grad[~] decay-rate[scal] -> M[~] where scal = 1)
+	   :on-call-> ((self m x-grad decay-rate)
+		       (declare (ignore self))
+		       (A+=B m (!mul (!sub x-grad m)
+				     (!sub 1.0 decay-rate))))))
+
+(defmodel (Adam-Step-V (self)
+	   ;;      V      Grad      beta2
+	   :where (V[~] X.grad[~] decay-rate[scal] -> V[~] where scal = 1)
+	   :on-call-> ((self v x-grad decay-rate)
+		       (declare (ignore self))
+		       (A+=B v (!mul (!sub 1.0 decay-rate)
+				     (!sub (!square x-grad) v))))))
+
+(defmodel (Adam-Step-Param (self)
+	   :where (M[~] V[~] Param[~] Lr-t[scal] Eps[scal] -> Param[~] where scal = 1)
+	   :on-call-> ((self m v param lr-t eps)
+		       (declare (ignore self))
+		       (A-=B param
+			     (!div (!mul lr-t m)
+				   (!add eps (!sqrt v)))))))
+
+(define-composite-function (Adam-Step-M) apply-adam-step-m)
+(define-composite-function (Adam-Step-V) apply-adam-step-v)
+(define-composite-function (Adam-Step-Param) apply-adam-step-param)
+
+(defun adam-step-lr (adam)
+  (declare (type Adam adam)
+	   (optimize (speed 3)))
+  (incf (the fixnum (adam-n adam)) 1)
+  (let ((n  (adam-n adam))
+	(lr (lr-of adam))
+	(b1 (beta1-of adam))
+	(b2 (beta2-of adam)))
+    (declare (type single-float lr b1 b2)
+	     (type fixnum n))
+
+    (* lr
+       (/ (sqrt (the (single-float 0e0) (- 1.0 (expt b2 n))))
+	  (- 1.0 (expt b1 n))))))
+
+
+(defmethod step-optimize ((optimizer Adam))
+  (let* ((lr-t (adam-step-lr optimizer))
+	 (param (read-parameter optimizer))
+	 (grad  (grad param)))
+
+    ;; TODO: Cache?
+    (apply-adam-step-m
+     (adam-m optimizer)
+     grad
+     (make-tensor (beta1-of optimizer)))
+
+    (apply-adam-step-v
+     (adam-v optimizer)
+     grad
+     (make-tensor (beta2-of optimizer)))
+
+    (apply-adam-step-param
+     (adam-m optimizer)
+     (adam-v optimizer)
+     param
+     (make-tensor lr-t)
+     (make-tensor (eps-of optimizer)))
+    nil))
+
+

--- a/source/optimizers/impls/sgd.lisp
+++ b/source/optimizers/impls/sgd.lisp
@@ -20,7 +20,7 @@ Param_{new}\\gets{Param - Param_{grad}\\times{lr}}
 	   :on-call-> ((self param grad lr)
 		       (declare (ignore self))
 		       ;; Composite Function: Side Effects on Param?
-		       (A-=B param (!mul lr grad)))))
+		       (A-=B param (!scalar-mul lr grad)))))
 
 (define-composite-function (SGD-Compute-Form) step-sgd)
 
@@ -28,6 +28,5 @@ Param_{new}\\gets{Param - Param_{grad}\\times{lr}}
   (let* ((lr    (make-tensor (sgd-lr optimizer)))
 	 (param (read-parameter optimizer))
 	 (grad  (grad param)))
-
     (step-sgd param grad lr)))
 

--- a/source/optimizers/package.lisp
+++ b/source/optimizers/package.lisp
@@ -10,7 +10,8 @@
    #:step-optimize)
 
   (:export
-   #:SGD))
+   #:SGD
+   #:Adam))
 
 (in-package :cl-waffe2/optimizers)
 

--- a/source/vm/generic-tensor/scheduling.lisp
+++ b/source/vm/generic-tensor/scheduling.lisp
@@ -79,6 +79,9 @@ tensor-ref-n indicates that how many times the tensor was used in the node."
 
 	       (not (tensor-protect-me (car past-variables)))
 	       (not (cl-waffe2/base-impl:movetensor-save-for-backward current-node))
+	       (or *no-grad*
+		   ;; TODO: Simplify save-for-backward, (compile statically workign kernel?)
+		   (ancestor-param-p (car past-variables)))
 	       
 	       ;; (!copy place past-out) i.e. (!copy Chain Past-Out)
 
@@ -112,6 +115,7 @@ Computation Time: O(total_nodes * 2)"
 	   (type (and keyword (member :speed :memory)) major)
 	   (type fixnum n-cores)
 	   (optimize (speed 3)))
+  
   (when (tensor-traced-p out-tensor)
     (return-from optimize-computation-node!))
   

--- a/source/vm/generic-tensor/t/backward.lisp
+++ b/source/vm/generic-tensor/t/backward.lisp
@@ -65,14 +65,57 @@
        (= (vref a 0) 3.0)
        (= (vref b 0) 6.0)))))
 
+(defun chain-test8 ()
+  (let ((a (parameter (cl-waffe2/distributions:ax+b `(3 3) 0 3)))
+	(b (parameter (cl-waffe2/distributions:ax+b `(3 3) 0 2)))
+	(c (parameter (cl-waffe2/distributions:ax+b `(3 3) 0 1))))
+    (Proceed-backward (!sum (!add (!mul a b) c)))
+    ;;(with-no-grad
+    ;;(let ((a (!sum (!add (!mul a b) c))))
+    ;;  (with-no-grad (build a))
+    ;;  (cl-waffe2/viz:viz-computation-node a "./assets/hoge.dot")))
+    ;;(print (grad a))
+    ;;(print (grad b))
+    ;;(print (grad c))
+    (and
+     (= (vref (grad a) 0) 2)
+     (= (vref (grad b) 0) 3)
+     (= (vref (grad c) 0) 1))))
+
+(defun chain-test9 ()
+  (let ((a (parameter (cl-waffe2/distributions:ax+b `(3 3) 0 3)))
+	(b (parameter (cl-waffe2/distributions:ax+b `(3 3) 0 2)))
+	(c (parameter (cl-waffe2/distributions:ax+b `(3 3) 0 1)))
+	(a1 (parameter (cl-waffe2/distributions:ax+b `(3 3) 0 2)))
+	(c1 (parameter (cl-waffe2/distributions:ax+b `(3 3) 0 1))))
+
+    (let ((prev-layer (!add (!mul a b) c)))
+      (proceed-backward (!sum (!add (!mul a1 prev-layer) c1))))
+
+    (and
+     (= (vref (grad a)  0) 6)
+     (= (vref (grad b)  0) 9)
+     (= (vref (grad c)  0) 3)
+     (= (vref (grad a1) 0) 7)
+     (= (vref (grad c1) 0) 1))
+    
+    (list
+     (grad a)
+     (grad b)
+     (grad c))))
+    
+     
+     
+
 (test chain-rule-test
   (is (chain-test1))
   (is (chain-test2))
   (is (chain-test3))
   (is (chain-test4))
   (is (chain-test5))
+  (is (chain-test6))
   (is (chain-test7))
-  (is (chain-test6)))
+  (is (chain-test8)))
 
 (test backward-side-effect-test
   (is (backward-being-not-destructed)))

--- a/source/vm/generic-tensor/t/backward.lisp
+++ b/source/vm/generic-tensor/t/backward.lisp
@@ -93,16 +93,11 @@
       (proceed-backward (!sum (!add (!mul a1 prev-layer) c1))))
 
     (and
-     (= (vref (grad a)  0) 6)
-     (= (vref (grad b)  0) 9)
-     (= (vref (grad c)  0) 3)
+     (= (vref (grad a)  0) 4)
+     (= (vref (grad b)  0) 6)
+     (= (vref (grad c)  0) 2)
      (= (vref (grad a1) 0) 7)
-     (= (vref (grad c1) 0) 1))
-    
-    (list
-     (grad a)
-     (grad b)
-     (grad c))))
+     (= (vref (grad c1) 0) 1))))
     
      
      
@@ -115,7 +110,8 @@
   (is (chain-test5))
   (is (chain-test6))
   (is (chain-test7))
-  (is (chain-test8)))
+  (is (chain-test8))
+  (is (chain-test9)))
 
 (test backward-side-effect-test
   (is (backward-being-not-destructed)))

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -1104,6 +1104,6 @@ The function parameter computes all the previous nodes of the given tensor if an
   (when (slot-value tensor 'requires-grad)
     (if (gradient-resetter tensor)
 	(funcall (gradient-resetter tensor))
-	(warn "Couldn't reset gradients of tenso, because gradient-resetter for tensor ~a is nil. The result may be wrong." tensor))))
+	(warn "Couldn't reset gradients of tensor, because gradient-resetter for tensor ~a is nil. The result may be wrong." tensor))))
 
 

--- a/source/vm/nodes/function.lisp
+++ b/source/vm/nodes/function.lisp
@@ -70,7 +70,7 @@ Return: defun form
 	     ,@(loop for tensor in inputs
 		     for name in namelist
 		     collect `(set-input ,compiled-kernel ,(tensor-name tensor) ,name))
-	     
+
 	     (let ((outputs (multiple-value-list (forward ,compiled-kernel))))
 	       (cl-waffe2/vm.generic-tensor::with-adjustable-symbols (,@set-input-forms)
 		 (apply #'values (map 'list #'eliminate-undetermined-size outputs)))))

--- a/source/vm/nodes/node.lisp
+++ b/source/vm/nodes/node.lisp
@@ -371,6 +371,7 @@ Use the define-impl macro to give definitions for the node and forward them.
 		      (select-return-place place argn nth-trying)
 		      bw-node
 		      :force t)))
+	    
 	    ;; F(x, y, ...)
 	    ;; x.state = :chain / :input?
 

--- a/source/vm/nodes/node.lisp
+++ b/source/vm/nodes/node.lisp
@@ -18,6 +18,7 @@
    (uprank-state :initform nil :initarg :uprank-state :reader uprank-state :type list)
    (transmission-state :initarg :transmission-state :reader transmission-state :type list)
    (ignore-shape-error :initform nil :accessor ignore-shape-error)
+   (excepted-output-shape :initform nil :type list :accessor node-output-shape)
    (passed-at-least-once :initform nil :accessor node-passed-p :type boolean))
   (:documentation "The class AbstractNode is a fundamental object of describing computation nodes in cl-waffe.
 
@@ -222,6 +223,8 @@ Here's a list of reports.
       ;; Memo: Sharing Allocated memory between f and b
       ;; can be realised with self ...
       ;; recompute grad
+
+      (setf (node-output-shape node) out-state)
 
       (let* ((forward-form (call-next-method))
 	     (next-tensor

--- a/source/vm/nodes/package.lisp
+++ b/source/vm/nodes/package.lisp
@@ -40,6 +40,7 @@
 		#:system-lazy-read-save-for-backward
 		#:scalar-p)
   (:export
+   #:node-output-shape
    #:create-subscript-p
    #:composite-where
    #:define-composite-function


### PR DESCRIPTION
Fixed bugs related to backwards:

1. save-for-backwards is destructed with [AddNode] -> [MulNode]

2. The built Backward is ignored by the computation node from the second time onwards.