### PR TITLE
[Enhancement] An example of JIT Compiler: cl-waffe2 -> Common Lisp Code

### DIFF
--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -78,6 +78,9 @@
 	       (:file "backends/cpu/arithmetic")
 	       (:file "backends/cpu/matrix-ops")
 
+	       (:file "backends/JITLispTensor/package")
+	       (:file "backends/JITLispTensor/tensor")
+
 	       (:file "distributions/package")
 	       (:file "distributions/generic")
 	       (:file "distributions/randomness")

--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -80,6 +80,8 @@
 
 	       (:file "backends/JITLispTensor/package")
 	       (:file "backends/JITLispTensor/tensor")
+	       (:file "backends/JITLispTensor/jit")
+	       (:file "backends/JITLispTensor/delayed-node-impls")
 
 	       (:file "distributions/package")
 	       (:file "distributions/generic")

--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -40,8 +40,9 @@
 	       (:file "vm/generic-tensor/memory-pool")
 
 	       (:file "optimizers/package")
-	       (:file "vm/generic-tensor/tensor")
+	       
 	       (:file "vm/generic-tensor/acceptor")
+	       (:file "vm/generic-tensor/tensor")
 	       
 	       (:file "vm/generic-tensor/scheduling")
 
@@ -88,9 +89,9 @@
 	       (:file "distributions/weights")
 
 	       (:file "backends/JITLispTensor/package")
+	       (:file "backends/JITLispTensor/compiler")
 	       (:file "backends/JITLispTensor/tensor")
 	       (:file "backends/JITLispTensor/jit")
-	       (:file "backends/JITLispTensor/compiler")
 	       (:file "backends/JITLispTensor/delayed-node-impls")
 
 	       (:file "nn/package")
@@ -162,12 +163,13 @@
 	       
 	       )
   :perform (test-op (o s)
+		    (symbol-call :fiveam :run! :jit-lisp-test)
 		    (symbol-call :fiveam :run! :test-nodes)
 		    (symbol-call :fiveam :run! :test-tensor)
 		    (symbol-call :fiveam :run! :base-impl-test)
 		    (symbol-call :fiveam :run! :lisp-backend-test)
 		    (symbol-call :fiveam :run! :test-backends-cpu)
-		    (symbol-call :fiveam :run! :nn-test)
+		    (symbol-call :fiveam :run! :nn-test)		    
 		    ))
 
 

--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -78,11 +78,6 @@
 	       (:file "backends/cpu/arithmetic")
 	       (:file "backends/cpu/matrix-ops")
 
-	       (:file "backends/JITLispTensor/package")
-	       (:file "backends/JITLispTensor/tensor")
-	       (:file "backends/JITLispTensor/jit")
-	       (:file "backends/JITLispTensor/delayed-node-impls")
-
 	       (:file "distributions/package")
 	       (:file "distributions/generic")
 	       (:file "distributions/randomness")
@@ -91,6 +86,12 @@
 	       (:file "distributions/sparse")
 	       (:file "distributions/ziggurat")
 	       (:file "distributions/weights")
+
+	       (:file "backends/JITLispTensor/package")
+	       (:file "backends/JITLispTensor/tensor")
+	       (:file "backends/JITLispTensor/jit")
+	       (:file "backends/JITLispTensor/compiler")
+	       (:file "backends/JITLispTensor/delayed-node-impls")
 
 	       (:file "nn/package")
 	       (:file "nn/activation")

--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -152,6 +152,9 @@
 
 	       (:file "backends/lisp/t/package")
 
+	       (:file "backends/JITLispTensor/t/package")
+	       (:file "backends/JITLispTensor/t/compiler")
+
 	       (:file "nn/t/package")
 	       (:file "nn/t/activation")
 	       (:file "nn/t/criterion")

--- a/docs/apis/nodes.lisp
+++ b/docs/apis/nodes.lisp
@@ -594,6 +594,9 @@ The moment `forward` is called, the computation node is constructed for building
     (insert "~a" (documentation (macro-function 'with-setting-save4bw) 'function))
     (insert "~a" (documentation (macro-function 'with-reading-save4bw) 'function))
 
+    (insert "~a" (documentation #'on-finalizing-compiling 't))
+
+
     (with-section "[class] Composite"
       (insert
        "

--- a/docs/cl-waffe2-docs/docs/distributions.md
+++ b/docs/cl-waffe2-docs/docs/distributions.md
@@ -16,11 +16,11 @@ That is, arguments passed to the `make-tensor` function can also be passed direc
 (normal `(10 10) 0.0 1.0 :requires-grad t)
 
 {CPUTENSOR[float] :shape (10 10)  
-  ((0.25687835   -0.18780856  -0.5215087   ~ -0.2232769   0.8626933    -0.73606986)                    
-   (0.9395986    1.18661      -0.5300193   ~ 0.13923728   1.7223272    -0.7161909)   
+  ((-1.5514485   -0.15205708  -0.13327505  ~ 0.41438892   -0.42857015  0.34229413)                    
+   (-0.22225893  0.95376945   -0.29402852  ~ -0.08328378  -0.77037257  -1.2152638)   
                  ...
-   (-1.4421227   1.0396162    1.1563039    ~ 0.10034409   1.0762292    0.24231103)
-   (-0.10666413  -0.080322996 -0.98340964  ~ -0.1939432   -0.54753405  -1.2767937))
+   (-0.45337996  0.3841458    0.3456047    ~ -0.042464282 0.26905498   -0.7697575)
+   (1.2483683    -1.2158309   -1.7512152   ~ -1.1419474   -1.6627157   0.77674264))
   :facet :exist
   :requires-grad T
   :backward NIL}
@@ -146,9 +146,9 @@ Note: My implementation is unstable, being occurs floating-overflow constantly..
 (beta `(3 3) 5.0 1.0)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((0.9693388  0.9990203  0.892123)
-   (0.9941258  0.9491998  0.9466048)
-   (0.96712095 0.96197826 0.7885056))
+  ((0.8157067  0.9232255  0.899816)
+   (0.7185194  0.6799847  0.8119843)
+   (0.9786967  0.87914246 0.8273518))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -170,9 +170,9 @@ p - Takes 1 with probability p and 0 with probalibity (1-p).
 (bernoulli `(3 3) 0.3)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((1.0 0.0 0.0)
-   (0.0 0.0 1.0)
-   (1.0 0.0 0.0))
+  ((0.0 0.0 0.0)
+   (0.0 0.0 0.0)
+   (0.0 0.0 1.0))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -198,9 +198,9 @@ df - degree of freedom.
 (chisquare `(3 3) 1.0)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((0.014499394 0.996114    0.012677135)
-   (0.21840791  0.007435741 8.378968e-6)
-   (0.31903785  0.002086476 0.54705083))
+  ((0.1493935    0.5407175    0.02016675)
+   (0.033066973  0.3652003    2.0401833)
+   (0.8453221    0.0037849548 0.0639598))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -227,9 +227,9 @@ The function expotential is a family of initializer functions, and samples the e
 (expotential `(3 3))
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((1.0899258  0.4159635  0.13038297)
-   (2.3604307  3.1505432  0.22231168)
-   (1.74327    0.8136045  0.5927167))
+  ((1.0694143  1.2324458  0.25228998)
+   (2.2682042  0.14011215 2.2821996)
+   (0.17256868 0.7531291  0.6230249))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -252,9 +252,9 @@ The function gamma is a family of initializer functions, and samples matrices fr
 (gamma `(3 3) 1.0)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((0.56344384 0.83925277 1.8232629)
-   (1.8615552  0.5576556  3.826378)
-   (0.400064   0.565714   1.4157976))
+  ((0.021583809 0.45859683  0.5169546)
+   (1.0653111   1.0348873   0.1409976)
+   (4.6941614   0.31769347  0.7149003))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -309,9 +309,9 @@ Input:
 (uniform-random `(3 3) 2 4)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((2.8597643 3.0313845 2.5040612)
-   (3.3266609 3.2024531 2.6089358)
-   (3.3231497 3.3920305 3.6547754))
+  ((2.7596219 2.9263775 3.6062858)
+   (3.955591  3.6531625 2.4962401)
+   (2.680609  2.716542  3.196207))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -339,9 +339,9 @@ The function randn is a family of initializer functions, and samples the gaussia
 (randn `(3 3))
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((-1.2074199  1.2937814   -0.99467057)
-   (1.1203806   0.8192181   -2.081931)
-   (0.5127554   -0.09887868 0.2238861))
+  ((0.74503636  0.81005955  0.46400705)
+   (0.4577372   1.4554738   -0.9307548)
+   (-1.4271485  0.104422756 0.6545818))
   :facet :exist
   :requires-grad NIL
   :backward NIL}

--- a/docs/cl-waffe2-docs/docs/generic-tensor.md
+++ b/docs/cl-waffe2-docs/docs/generic-tensor.md
@@ -359,7 +359,7 @@ After working with adjustable shape tensor, don't forget to embody the InputTens
 > (setq out (!add (randn `(10 10)) (make-input `(a 10) :X)))
 ```
 ```
-{CPUTENSOR[float] :shape (10 10) :named ChainTMP12987 
+{CPUTENSOR[float] :shape (10 10) :named ChainTMP1295 
   :vec-state [maybe-not-computed]
   <<Not-Embodied (10 10) Tensor>>
   :facet :input
@@ -375,10 +375,10 @@ After working with adjustable shape tensor, don't forget to embody the InputTens
 (<Compiled-Composite
     forward:  #<FUNCTION (LAMBDA ()
                            :IN
-                           "/Users/hikettei/.cache/common-lisp/sbcl-2.3.4-macosx-x64/Users/hikettei/Desktop/cl-waffe-workspace/progs/develop/cl-waffe2/docs/apis/generic-tensor.fasl") {53B2A4CB}>
+                           "/Users/hikettei/.cache/common-lisp/sbcl-2.3.3-macosx-x64/Users/hikettei/Desktop/cl-waffe-workspace/progs/develop/cl-waffe2/docs/apis/generic-tensor.fasl") {53A4361B}>
     backward: #<FUNCTION (LAMBDA ()
                            :IN
-                           "/Users/hikettei/.cache/common-lisp/sbcl-2.3.4-macosx-x64/Users/hikettei/Desktop/cl-waffe-workspace/progs/develop/cl-waffe2/docs/apis/generic-tensor.fasl") {53B2B3BB}>
+                           "/Users/hikettei/.cache/common-lisp/sbcl-2.3.3-macosx-x64/Users/hikettei/Desktop/cl-waffe-workspace/progs/develop/cl-waffe2/docs/apis/generic-tensor.fasl") {53A4161B}>
 
 += [Tensors in the computation node] =======+
 
@@ -392,7 +392,7 @@ Variables:
    X   |  (A 10) | 
 
 
- - The number of tmp variables : 4
+ - The number of tmp variables : 6
  - The number of parameters    : 0
 +========================================+
 >

--- a/docs/cl-waffe2-docs/docs/nn.md
+++ b/docs/cl-waffe2-docs/docs/nn.md
@@ -13,13 +13,13 @@ ReLU(x) = max(x, 0)
 ```lisp
 (proceed (!relu (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (10 10) :named ChainTMP13108 
+{CPUTENSOR[float] :shape (10 10) :named ChainTMP1417 
   :vec-state [computed]
-  ((-0.0        -0.0        -0.0        ~ 0.2979711   -0.0        0.77263427)                   
-   (1.6693149   -0.0        -0.0        ~ 0.22997802  1.289548    1.6337485)   
+  ((-0.0        -0.0        1.975988    ~ 2.6147454   1.2552326   -0.0)                   
+   (0.76103824  0.080851234 -0.0        ~ 0.1685591   -0.0        -0.0)   
                 ...
-   (0.10559099  0.1584125   -0.0        ~ 1.0346866   0.32413962  -0.0)
-   (1.9992205   1.6432109   -0.0        ~ 0.8558499   0.7596627   -0.0))
+   (1.8325363   0.27987656  -0.0        ~ -0.0        -0.0        -0.0)
+   (0.2005611   -0.0        0.052415702 ~ 0.25025347  -0.0        -0.0))
   :facet :input
   :requires-grad NIL
   :backward <Node: PROCEEDNODE-T (A[~] -> A[~])>}
@@ -42,13 +42,13 @@ Sigmoid(x) = \frac{1}{1 + exp(-x)}
 ```lisp
 (proceed (!sigmoid (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (10 10) :named ChainTMP13408 
+{CPUTENSOR[float] :shape (10 10) :named ChainTMP1730 
   :vec-state [computed]
-  ((0.7712369  0.08284816 0.43262917 ~ 0.23829551 0.3080795  0.6284006)                  
-   (0.32359025 0.3921803  0.3027691  ~ 0.44983754 0.88687694 0.27936012)   
+  ((0.71292    0.6855479  0.7652124  ~ 0.5553089  0.17005274 0.21288207)                  
+   (0.33826295 0.6008625  0.28127894 ~ 0.41916075 0.1272022  0.43307915)   
                ...
-   (0.4514993  0.6484144  0.4318265  ~ 0.23674174 0.7804215  0.8317024)
-   (0.6750185  0.5297069  0.2650835  ~ 0.42000595 0.52054065 0.45882672))
+   (0.27530894 0.9130255  0.28226978 ~ 0.7711161  0.75187397 0.4225798)
+   (0.66495955 0.18262608 0.42268223 ~ 0.656544   0.40799212 0.76683646))
   :facet :input
   :requires-grad NIL
   :backward <Node: PROCEEDNODE-T (A[~] -> A[~])>}
@@ -75,9 +75,9 @@ In addition, reading the value of a `:reduction` keyword (one of `:mean` `:sum` 
 ```lisp
 (proceed (L1Norm (randn `(10 10)) (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (1 1) -> :view (<(BROADCAST 1)> <(BROADCAST 1)>) -> :visible-shape (1 1) :named ChainTMP13824 
+{CPUTENSOR[float] :shape (1 1) -> :view (<(BROADCAST 1)> <(BROADCAST 1)>) -> :visible-shape (1 1) :named ChainTMP2170 
   :vec-state [computed]
-  ((1.148601))
+  ((1.1390866))
   :facet :input
   :requires-grad NIL
   :backward <Node: PROCEEDNODE-T (A[~] -> A[~])>}
@@ -102,9 +102,9 @@ In addition, reading the value of a `:reduction` keyword (one of `:mean` `:sum` 
 ```lisp
 (proceed (MSE (randn `(10 10)) (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (1 1) -> :view (<(BROADCAST 1)> <(BROADCAST 1)>) -> :visible-shape (1 1) :named ChainTMP14222 
+{CPUTENSOR[float] :shape (1 1) -> :view (<(BROADCAST 1)> <(BROADCAST 1)>) -> :visible-shape (1 1) :named ChainTMP2584 
   :vec-state [computed]
-  ((2.182282))
+  ((1.4544442))
   :facet :input
   :requires-grad NIL
   :backward <Node: PROCEEDNODE-T (A[~] -> A[~])>}
@@ -196,7 +196,7 @@ y = xA^\intercal + b
 ```lisp
 (LinearLayer 10 5)
 
-<Composite: LINEARLAYER{W14226}(
+<Composite: LINEARLAYER{W2588}(
     <Input : ((~ BATCH-SIZE 10)) -> Output: ((~ BATCH-SIZE 5))>
 
     WEIGHTS -> (5 10)

--- a/docs/cl-waffe2-docs/docs/nodes.md
+++ b/docs/cl-waffe2-docs/docs/nodes.md
@@ -896,6 +896,42 @@ input-form = (variable-place save-for-backward-name)
 
 Reading the save-for-backward of currently working node, the macro binds each `variable-place` the stored tensor.
 
+## [generic] on-finalizing-compiling
+
+```lisp
+(on-finalizing-compiling current-node variable next-variable)
+```
+
+The generic function `on-finalizing-compiling` is invoked after the body of `define-impl` is expanded when performing `compile-chain-forward`.
+
+Return S expression to be embodied in the compiled code if needed, especially, devices which support jit-compiling will need this, because you can get information before and after the node.
+
+### Inputs
+
+```lisp
+     [TopLevel]
+         |
+     [CosNode1]
+         |
+     [SinNode1]   <- If invoked at this point...
+         |
+   [MoveTensorNode2]
+         |
+     [SinNode3]
+         |
+   [MoveTensorNode4]
+         |
+        ...
+```
+
+`current-node (i.e.: SinNode1)` used to dispatch methods.
+
+`variable (i.e.: corresponding variable of SinNode1)` returns the corresponding var of current node.
+
+`next-variables (i.e.: corresponding variable of MoveTensorNode2)` returns corresponding variable of next node.
+
+See also: `the implementation of JITLispTensor`.
+
 ## [class] Composite
 
 [class] Composite

--- a/docs/cl-waffe2-docs/docs/overview.md
+++ b/docs/cl-waffe2-docs/docs/overview.md
@@ -48,7 +48,7 @@ As of this writing (2023/07/05), we provide two standard implementation of `:cl-
 
 ```
 :cl-waffe2/backends.lisp
-:cl-waffe2/backends.cpu    
+:cl-waffe2/backends.cpu
 ```
 
 If only time and money would permit, I'm willing to implement CUDA/Metal Backends.
@@ -57,8 +57,7 @@ If only time and money would permit, I'm willing to implement CUDA/Metal Backend
 
 On the other hand :cl-waffe2/backends.cpu is accelerated by OpenBLAS (maybe MKL is ok) and other foreign backends, this is SBCL-Dependant and sometimes could be unsafe, but provides `full speed`.
 
-
-TODO:
+(P.S: `:cl-waffe2/backends.jit.lisp` is now partially available (not tested all), it is still unstable but demonstrates how to extend the JIT compiler on other backends in cl-waffe2.)
 
 ```
 :cl-waffe2/backends.fastmath (NOT IMPLEMENTED YET!)

--- a/docs/cl-waffe2-docs/docs/utils.md
+++ b/docs/cl-waffe2-docs/docs/utils.md
@@ -15,7 +15,7 @@ The generic function `convert-tensor-facet` pays an important role when converti
 
 This method is intended to be extended by users.
 
-For example: `AbstractTensor` -> `simple-array`, can be used as:
+For example, converting `AbstractTensor` -> `simple-array`:
 
 ```lisp
 (convert-tensor-facet (randn `(3 3)) 'simple-array)

--- a/examples/mlp_sin_wave.lisp
+++ b/examples/mlp_sin_wave.lisp
@@ -26,6 +26,7 @@
 (deftrainer (MLPTrainer (self in-features hidden-dim &key (lr 1e-1))
 	     :model (Simple-MLP in-features hidden-dim)
 	     :optimizer (SGD :lr lr)
+	     :compile-mode :fastest
 	     :build ((self)
 		     (MSE
 		      (make-input `(batch-size 1) :TrainY)
@@ -37,9 +38,11 @@
 	     :minimize! ((self)
 			 (zero-grads! (model self))
 			 (let ((loss (forward (model self))))
-			   (format t "Training Loss: ~a~%" (tensor-vec loss)))
+			   ;;(format t "Training Loss: ~a~%" (tensor-vec loss))
+			   )
 			 (backward  (model self))
-			 (optimize! (model self)))
+			 (optimize! (model self))
+			 )
 	     :predict ((self x)
 		       (call (model self) x))))
 			 
@@ -55,9 +58,10 @@
 		(iter-num 1))
   (let* ((X (proceed (!sin (ax+b `(,batch-size 100) 0.01 0.1))))
  	 (Y (proceed (!cos (ax+b `(,batch-size 1)   0.01 0.1))))
-	 (trainer (MLPTrainer 100 10 :lr 1e-1)))
+	 (trainer (MLPTrainer 100 10 :lr 1e-3)))
 
-    (loop for nth-epoch fixnum upfrom 0 below iter-num
-	  do (set-inputs trainer X Y)
-	     (minimize! trainer))))
+    (time
+     (loop for nth-epoch fixnum upfrom 0 below iter-num
+	   do (set-inputs trainer X Y)
+	      (minimize! trainer)))))
 

--- a/source/backends/JITLispTensor/compiler.lisp
+++ b/source/backends/JITLispTensor/compiler.lisp
@@ -1,7 +1,137 @@
 
 (in-package :cl-waffe2/backends.jit.lisp)
 
-(defparameter *operands* `(+ - * / move))
+(defvar *compiled-tensors* nil "Tensor1 Tensor2...")
+(defvar *compiled-tensors-aref* nil "(aref Tesnor1 i) (aref Tensor2 i) ...")
 
 ;; (defmethod (eql ...) or pattern match)
+
+(defun ->op-type (obj)
+  (typecase obj
+    (opAST :opAST)
+    (JITLispTensor :tensor)
+    (null :null)
+    (T (error "Detected unknown type of variable: ~a" obj))))
+
+(deftype ast-variable-types () `(and keyword (member :opAST :tensor :null)))
+    
+(defstruct (opAST
+	    (:constructor make-opAST (operation &rest args)))
+  "opAST is a data structure which is:
+[car args]
+      |
+    an list of AST_Variable"
+  (car  operation :type JITLispTensor)
+  (args args :type list))
+
+(defstruct (AST-Variable
+	    (:constructor make-ast-variable
+		(content &aux (type (->op-type content)))))
+  (type type :type ast-variable-types)
+  (content content :type (or null opAST JITLispTensor)))
+
+(defun add-variable (tensor)
+  ;; TODO: Ignore MoveTensorNode
+  (unless (find tensor *compiled-tensors*)
+    (push tensor *compiled-tensors*)))
+
+(defun confirm-compiling-area (toplevel)
+  "Tracing the previous variables, returns AST of compiling region."
+
+  (declare (type JITLispTensor toplevel))
+
+  (let* ((variables (tensor-variables toplevel)))
+    (apply #'make-opAST toplevel
+	   (loop for called-var in variables
+		 do (add-variable called-var)
+		 if (apply-compile-p toplevel called-var)
+		   collect (make-ast-variable
+			    (confirm-compiling-area called-var))
+		 else
+		   collect (make-ast-variable called-var)))))
+
+(defun invoke-compiler! (current-node variable next-var)
+  (declare (type LispJIT-Blueprint current-node)
+	   (type JITLispTensor variable)
+	   (type (or null JITLispTensor) next-var))
+  (declare (ignore current-node next-var))
+
+  (let* ((*compiled-tensors* `(,variable))
+	 (compiling-area (confirm-compiling-area variable)))
+    ;;
+    ;; (let ((vec1 (tensor-vec a))
+    ;;       (vec2 (tensor-vec b))
+    ;;              ...
+    ;;
+    ;;   (loop-with-view ...
+    ;;       (setf (aref vec1 index) (sin (aref ...)))))
+    ;;
+
+    (with-allocating-vectors *compiled-tensors*
+      (with-expand-call-with-view *compiled-tensors* index
+	(trace-and-compile! compiling-area)))))
+
+
+(defun tensor-vec-id (tensor)
+  (declare (type AbstractTensor tensor))
+  (symb (tensor-id tensor) '-vec))
+
+(defun with-allocating-vectors (tensors body)
+  `(let (,@(loop for tensor in tensors
+		 collect `(,(tensor-vec-id tensor) (tensor-vec ,tensor))))
+     (declare ,@(loop for tensor in tensors
+		      collect `(type (simple-array ,(dtype->lisp-type (dtype tensor)) (*)) ,(tensor-vec-id tensor)))
+	      (ignorable ,@(map 'list #'tensor-vec-id tensors)))
+     ,body))
+
+(defmacro with-expand-call-with-view (tensors index-char &body body)
+  (let ((views-area (gensym)))
+    `(call-with-view
+      #'(lambda (&rest ,views-area)
+	  (let ((*compiled-tensors-aref* (view->accessors ,views-area ',index-char)))
+	    `(loop for ,',index-char fixnum upfrom 0 below ,(size-of (car ,views-area) 0)
+		   do ,,@body)))
+      ,tensors
+      :at-least-dim 1)))
+
+(defun view->accessors (views index-symbol)
+  "View -> '(aref tensor i)"
+  (let ((result (make-hash-table)))
+    (loop for view   in views
+	  for tensor in *compiled-tensors* 
+	  do (let* ((key (tensor-id tensor))
+		    (reader `(aref ,(tensor-vec-id tensor) ,index-symbol)))
+	       (setf (gethash key result) reader)))
+    result))
+
+(defun expand-aref (tensor)
+  (declare (type AbstractTensor tensor))
+  (gethash (tensor-id tensor) *compiled-tensors-aref*))
+
+(defun expand-aref-read (tensor)
+  (declare (type AbstractTensor tensor))
+  `(aref ,(gethash (tensor-id tensor) *compiled-tensors-aref*) index))
+
+(defgeneric implement-op (opcode opAST &rest arguments))
+
+;; Fix: symbols to use
+
+(defun trace-and-compile! (compile-toplevel)
+  (declare (type opAST compile-toplevel))
+
+  ;; If the end of node?
+
+  (when (null (tensor-backward (opAST-car compile-toplevel)))
+    (return-from trace-and-compile!
+       (expand-aref (opAST-car compile-toplevel))))
+ 
+  (let ((code (blueprint-opecode (tensor-backward (opAST-car compile-toplevel)))))
+    (apply #'implement-op code compile-toplevel
+	   (loop for var in (opAST-args compile-toplevel)
+		 if (eql (ast-variable-type var) :null)
+		   collect nil
+		 if (eql (ast-variable-type var) :opAST)
+		   collect (trace-and-compile! (ast-variable-content var))
+		 if (eql (ast-variable-type var) :tensor)
+		   collect (expand-aref-read (ast-variable-content var))))))
 

--- a/source/backends/JITLispTensor/compiler.lisp
+++ b/source/backends/JITLispTensor/compiler.lisp
@@ -8,6 +8,9 @@
 
 ;; TODO: Eliminate unused MoveTensorNode and allocation with it.
 ;; AVX2 Isn't wokirng? Supper slow -> No, compute-stepby is included to complied code.
+;; Except the usage of no-grad
+;; setf使わない代わりに高速に動作とか？
+;; setfのアクセスをキャッシュするとかしないと速くならない
 
 (defun ->op-type (obj)
   (typecase obj

--- a/source/backends/JITLispTensor/compiler.lisp
+++ b/source/backends/JITLispTensor/compiler.lisp
@@ -3,8 +3,9 @@
 
 (defvar *compiled-tensors* nil "Tensor1 Tensor2...")
 (defvar *compiled-tensors-aref* nil "(aref Tesnor1 i) (aref Tensor2 i) ...")
-
+(defvar *subscript-char* nil)
 ;; (defmethod (eql ...) or pattern match)
+;; TODO: Ignore unused MoveTensorNode and allocation with it.
 
 (defun ->op-type (obj)
   (typecase obj
@@ -45,10 +46,10 @@
 	   (loop for called-var in variables
 		 do (add-variable called-var)
 		 if (apply-compile-p toplevel called-var)
-		   collect (make-ast-variable
-			    (confirm-compiling-area called-var))
+		   collect (make-ast-variable called-var)
 		 else
-		   collect (make-ast-variable called-var)))))
+		   collect (make-ast-variable
+			    (confirm-compiling-area called-var))))))
 
 (defun invoke-compiler! (current-node variable next-var)
   (declare (type LispJIT-Blueprint current-node)
@@ -57,7 +58,10 @@
   (declare (ignore current-node next-var))
 
   (let* ((*compiled-tensors* `(,variable))
+	 (*subscript-char* (gensym "Index"))
 	 (compiling-area (confirm-compiling-area variable)))
+
+    ;; The form below is expanded into:
     ;;
     ;; (let ((vec1 (tensor-vec a))
     ;;       (vec2 (tensor-vec b))
@@ -68,7 +72,7 @@
     ;;
 
     (with-allocating-vectors *compiled-tensors*
-      (with-expand-call-with-view *compiled-tensors* index
+      (with-expand-call-with-view *compiled-tensors* *subscript-char*
 	(trace-and-compile! compiling-area)))))
 
 
@@ -88,8 +92,8 @@
   (let ((views-area (gensym)))
     `(call-with-view
       #'(lambda (&rest ,views-area)
-	  (let ((*compiled-tensors-aref* (view->accessors ,views-area ',index-char)))
-	    `(loop for ,',index-char fixnum upfrom 0 below ,(size-of (car ,views-area) 0)
+	  (let ((*compiled-tensors-aref* (view->accessors ,views-area ,index-char)))
+	    `(loop for ,,index-char fixnum upfrom 0 below ,(size-of (car ,views-area) 0)
 		   do ,,@body)))
       ,tensors
       :at-least-dim 1)))
@@ -108,30 +112,30 @@
   (declare (type AbstractTensor tensor))
   (gethash (tensor-id tensor) *compiled-tensors-aref*))
 
-(defun expand-aref-read (tensor)
-  (declare (type AbstractTensor tensor))
-  `(aref ,(gethash (tensor-id tensor) *compiled-tensors-aref*) index))
-
 (defgeneric implement-op (opcode opAST &rest arguments))
 
-;; Fix: symbols to use
-
 (defun trace-and-compile! (compile-toplevel)
+  (declare (type opAST compile-toplevel))
+  (let ((called-top-var (opAST-car compile-toplevel)))
+    `(setf ,(expand-aref called-top-var) ,(explore-and-compile! compile-toplevel))))
+
+(defun explore-and-compile! (compile-toplevel)
   (declare (type opAST compile-toplevel))
 
   ;; If the end of node?
 
   (when (null (tensor-backward (opAST-car compile-toplevel)))
-    (return-from trace-and-compile!
+    (return-from explore-and-compile!
        (expand-aref (opAST-car compile-toplevel))))
  
   (let ((code (blueprint-opecode (tensor-backward (opAST-car compile-toplevel)))))
     (apply #'implement-op code compile-toplevel
 	   (loop for var in (opAST-args compile-toplevel)
+		 do (print var)
 		 if (eql (ast-variable-type var) :null)
 		   collect nil
 		 if (eql (ast-variable-type var) :opAST)
-		   collect (trace-and-compile! (ast-variable-content var))
+		   collect (explore-and-compile! (ast-variable-content var))
 		 if (eql (ast-variable-type var) :tensor)
-		   collect (expand-aref-read (ast-variable-content var))))))
+		   collect (expand-aref (ast-variable-content var))))))
 

--- a/source/backends/JITLispTensor/compiler.lisp
+++ b/source/backends/JITLispTensor/compiler.lisp
@@ -1,0 +1,7 @@
+
+(in-package :cl-waffe2/backends.jit.lisp)
+
+(defparameter *operands* `(+ - * / move))
+
+;; (defmethod (eql ...) or pattern match)
+

--- a/source/backends/JITLispTensor/compiler.lisp
+++ b/source/backends/JITLispTensor/compiler.lisp
@@ -68,14 +68,14 @@
     `(call-with-view
       #'(lambda (&rest ,views-area)
 	  (let ((*compiled-tensors-aref* (view->accessors ,views-area ,index-char)))
-	    `(loop for ,,index-char fixnum upfrom 0 below ,(size-of (car ,views-area) 0)
-		   do (let (,@(loop for view in ,views-area
+	    `(let (,@(loop for view in ,views-area
 				    for tensor in ,tensors
 				    collect `(,(tensor-stride-id tensor) (the fixnum ,(stride-of view 0))))
 			    ,@(loop for view in ,views-area
 				    for tensor in ,tensors
 				    collect `(,(tensor-offset-id tensor) (the fixnum ,(offset-of view 0)))))
-			,,@body))))
+	       (loop for ,,index-char fixnum upfrom 0 below ,(size-of (car ,views-area) 0)
+		   do ,,@body))))
       ,tensors
       :at-least-dim 1)))
 
@@ -161,7 +161,7 @@
   (declare (type opAST compile-toplevel))
   (let* ((*tensors-use* nil)
 	 (tree (explore-and-compile! compile-toplevel)))
-    `(setf ,(expand-aref (opAST-car compile-toplevel)) ,tree)))
+    (print `(setf ,(expand-aref (opAST-car compile-toplevel)) ,tree))))
 
 (defun explore-and-compile! (compile-toplevel)
   (declare (type opAST compile-toplevel))

--- a/source/backends/JITLispTensor/compiler.lisp
+++ b/source/backends/JITLispTensor/compiler.lisp
@@ -121,8 +121,8 @@
 				 `(,variable)
 				 nil))
 	 (*compiled-tensors-aref* (make-hash-table))
-	 (*subscript-char* (gensym "Index"))
-	 (compiling-area (confirm-compiling-area variable)))
+	 (*subscript-char*        (gensym "Index"))
+	 (compiling-area          (confirm-compiling-area variable)))
 
     ;; The form below is expanded into:
     ;;
@@ -204,7 +204,8 @@
 			       collect (tensor-aref-id (ast-variable-content var))
 
 			     if (eql (ast-variable-type var) :scalar)
-			       collect `(the ,(dtype->lisp-type (dtype (ast-variable-content var))) ,(tensor-vec (ast-variable-content var)))))))
+			       ;; Cache: accessing to scalar
+			       collect `(the ,(dtype->lisp-type (dtype (ast-variable-content var))) (tensor-vec ,(tensor-id (ast-variable-content var))))))))
       (typecase iseq
 	(list iseq)
 	(iseq (iseq-code iseq))))))

--- a/source/backends/JITLispTensor/delayed-node-impls.lisp
+++ b/source/backends/JITLispTensor/delayed-node-impls.lisp
@@ -8,23 +8,57 @@
 
 ;; Arithmetic operation family is originally declared as:
 ;; X <- op(X, Y)
-(macrolet ((define-arith-impl (name lisp-op save-for-backward)
+(macrolet ((define-arith-impl (name lisp-op)
 	     `(define-impl (,name
 			    :device JITLispTensor
 			    :extends (LispJIT-Blueprint))
-			   :save-for-backward ',save-for-backward
 			   :forward ((self x y)
 				     (declare (ignore y))
-				     (setf (blueprint-op-func self) ',lisp-op)
+				     (setf (blueprint-operand self) ',lisp-op)
 				     `(progn ,x)))))
-  (define-arith-impl AddNode + nil)
-  (define-arith-impl SubNode - nil)
-  (define-arith-impl MulNode * (t t))
-  (define-arith-impl DivNode / (t t)))
+  (define-arith-impl AddNode +)
+  (define-arith-impl SubNode -)
+  (define-arith-impl MulNode *)
+  (define-arith-impl DivNode /))
 
+
+;; MoveTensor is declared as:
+;; Move(A, B) -> A
 ;; A[~] B[~] -> A[~]
 (define-impl (MoveTensorNode :device JITLispTensor :extends (LispJIT-Blueprint))
 	     :forward ((self out target)
 		       (declare (ignore target))
-		       (setf (blueprint-op-func self) 'move)
+		       (progn
+			 (setf (blueprint-operand self) 'move)
+			 nil)
+		       
 		       `(progn ,out)))
+
+(define-impl (InverseTensorNode :device JITLispTensor :extends (LispJIT-Blueprint))
+	     :forward ((self x)
+		       (setf (blueprint-operand self) 'inverse)
+		       `(progn ,x)))
+
+
+;;
+;; Scalar-Mat Operation family are originally declared as:
+;; (A[~] Scalar[scal] -> A[~] where scal = 1)
+;;
+(macrolet ((define-scalar-mat-impl (name lisp-op)
+	     `(define-impl (,name
+			    :device JITLispTensor
+			    :extends (LispJIT-Blueprint))
+			   :forward ((self A scalar)
+				     (declare (ignore scalar))
+				     (setf (blueprint-operand self) ',lisp-op)
+				     `(progn ,A)))))
+  
+  (define-scalar-mat-impl ScalarAdd scalar-add)
+  (define-scalar-mat-impl ScalarSub scalar-sub)
+  (define-scalar-mat-impl ScalarMul scalar-mul)
+  (define-scalar-mat-impl ScalarDiv scalar-div))
+
+
+;; Todo: Element-wise kernels...
+
+

--- a/source/backends/JITLispTensor/delayed-node-impls.lisp
+++ b/source/backends/JITLispTensor/delayed-node-impls.lisp
@@ -9,18 +9,21 @@
 ;; Arithmetic operation family is originally declared as:
 ;; X <- op(X, Y)
 (macrolet ((define-arith-impl (name lisp-op)
-	     `(define-impl (,name
-			    :device JITLispTensor
-			    :extends (LispJIT-Blueprint))
-			   :forward ((self x y)
-				     (declare (ignore y))
-				     (setf (blueprint-operand self) ',lisp-op)
-				     `(progn ,x)))))
+	     `(progn
+		(define-impl (,name
+			      :device JITLispTensor
+			      :extends (LispJIT-Blueprint))
+			     :forward ((self x y)
+				       (declare (ignore y))
+				       (setf (blueprint-opecode self) ',lisp-op)
+				       `(progn ,x)))
+
+		(defmethod implement-op ((opcode (eql ',lisp-op)) opAST &rest args)
+		  `(,',lisp-op ,(car args) ,(second args))))))
   (define-arith-impl AddNode +)
   (define-arith-impl SubNode -)
   (define-arith-impl MulNode *)
   (define-arith-impl DivNode /))
-
 
 ;; MoveTensor is declared as:
 ;; Move(A, B) -> A
@@ -29,17 +32,22 @@
 	     :forward ((self out target)
 		       (declare (ignore target))
 		       (progn
-			 (setf (blueprint-operand self) 'move)
+			 (setf (blueprint-opecode self) 'move)
 			 nil)
 		       
 		       `(progn ,out)))
 
+(defmethod implement-op ((opcode (eql 'move)) opAST &rest args)
+  ;; A <- B
+  `(setf ,(car args) ,(second args)))
+
 (define-impl (InverseTensorNode :device JITLispTensor :extends (LispJIT-Blueprint))
 	     :forward ((self x)
-		       (setf (blueprint-operand self) 'inverse)
+		       (setf (blueprint-opecode self) 'inverse)
 		       `(progn ,x)))
 
-
+(defmethod implement-op ((op (eql 'inverse)) opAST &rest args)
+  `(/ 1 ,(car args)))
 ;;
 ;; Scalar-Mat Operation family are originally declared as:
 ;; (A[~] Scalar[scal] -> A[~] where scal = 1)
@@ -50,7 +58,7 @@
 			    :extends (LispJIT-Blueprint))
 			   :forward ((self A scalar)
 				     (declare (ignore scalar))
-				     (setf (blueprint-operand self) ',lisp-op)
+				     (setf (blueprint-opecode self) ',lisp-op)
 				     `(progn ,A)))))
   
   (define-scalar-mat-impl ScalarAdd scalar-add)

--- a/source/backends/JITLispTensor/delayed-node-impls.lisp
+++ b/source/backends/JITLispTensor/delayed-node-impls.lisp
@@ -47,20 +47,8 @@
 			 nil)
 		       `(progn ,out)))
 
-(define-impl (MoveScalarTensorNode :device JITLispTensor :reject-p #'only-when-no-grad :extends (LispJIT-Blueprint))
-	     :forward ((self out target)
-		       (progn
-			 (setf (blueprint-use-var self) `(,target))
-			 (setf (blueprint-opecode self) 'move-scal)
-			 nil)
-		       `(progn ,out)))
-
 (defmethod implement-op ((opcode (eql 'move)) opAST &rest args)
   ;; A <- B
-  (make-iseq (second args)
-	     (car args)))
-
-(defmethod implement-op ((opcode (eql 'move-scal)) opAST &rest args)
   (make-iseq (second args)
 	     (car args)))
 

--- a/source/backends/JITLispTensor/delayed-node-impls.lisp
+++ b/source/backends/JITLispTensor/delayed-node-impls.lisp
@@ -5,9 +5,10 @@
 ;; delayed-node-impls.lisp provides define-impl forms of principle operations of JITLispTensor.
 ;;
 
-(defun only-when-no-grad (&rest inputs)
-  (declare (ignore inputs))
-  (not *no-grad*))
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (defun only-when-no-grad (&rest inputs)
+    (declare (ignore inputs))
+    (not *no-grad*)))
 
 
 ;; Arithmetic operation family is originally declared as:

--- a/source/backends/JITLispTensor/delayed-node-impls.lisp
+++ b/source/backends/JITLispTensor/delayed-node-impls.lisp
@@ -50,7 +50,8 @@
 		       `(progn ,x)))
 
 (defmethod implement-op ((op (eql 'inverse)) opAST &rest args)
-  `(/ 1 ,(car args)))
+  `(setf ,(car args) (/ 1 ,(car args))))
+
 ;;
 ;; Scalar-Mat Operation family are originally declared as:
 ;; (A[~] Scalar[scal] -> A[~] where scal = 1)
@@ -70,6 +71,10 @@
   (define-scalar-mat-impl ScalarDiv scalar-div))
 
 
-;; Todo: Element-wise kernels...
+;; Todo: Element-wise kernels... (OK)
+;; Todo: Scalar And Scalar Kernel ... !sub uses
+;; Todo: Eliminate move
+;; Todo: Mathematical APIs
+;; Todo: TEst
 
 

--- a/source/backends/JITLispTensor/delayed-node-impls.lisp
+++ b/source/backends/JITLispTensor/delayed-node-impls.lisp
@@ -19,11 +19,12 @@
 				       `(progn ,x)))
 
 		(defmethod implement-op ((opcode (eql ',lisp-op)) opAST &rest args)
-		  `(,',lisp-op ,(car args) ,(second args))))))
+		  `(setf ,(car args) (,',lisp-op ,(car args) ,(second args)))))))
   (define-arith-impl AddNode +)
   (define-arith-impl SubNode -)
   (define-arith-impl MulNode *)
   (define-arith-impl DivNode /))
+
 
 ;; MoveTensor is declared as:
 ;; Move(A, B) -> A
@@ -38,7 +39,10 @@
 
 (defmethod implement-op ((opcode (eql 'move)) opAST &rest args)
   ;; A <- B
-  `(setf ,(car args) ,(second args)))
+  (let ((node (tensor-backward (opAST-car opAST))))
+    (if (movetensor-ignore-me node)
+	(second args)
+	`(setf ,(car args) ,(second args)))))
 
 (define-impl (InverseTensorNode :device JITLispTensor :extends (LispJIT-Blueprint))
 	     :forward ((self x)

--- a/source/backends/JITLispTensor/delayed-node-impls.lisp
+++ b/source/backends/JITLispTensor/delayed-node-impls.lisp
@@ -1,0 +1,30 @@
+
+(in-package :cl-waffe2/backends.jit.lisp)
+
+;;
+;; delayed-node-impls.lisp provides define-impl forms of principle operations of JITLispTensor.
+;;
+
+
+;; Arithmetic operation family is originally declared as:
+;; X <- op(X, Y)
+(macrolet ((define-arith-impl (name lisp-op save-for-backward)
+	     `(define-impl (,name
+			    :device JITLispTensor
+			    :extends (LispJIT-Blueprint))
+			   :save-for-backward ',save-for-backward
+			   :forward ((self x y)
+				     (declare (ignore y))
+				     (setf (blueprint-op-func self) ',lisp-op)
+				     `(progn ,x)))))
+  (define-arith-impl AddNode + nil)
+  (define-arith-impl SubNode - nil)
+  (define-arith-impl MulNode * (t t))
+  (define-arith-impl DivNode / (t t)))
+
+;; A[~] B[~] -> A[~]
+(define-impl (MoveTensorNode :device JITLispTensor :extends (LispJIT-Blueprint))
+	     :forward ((self out target)
+		       (declare (ignore target))
+		       (setf (blueprint-op-func self) 'move)
+		       `(progn ,out)))

--- a/source/backends/JITLispTensor/delayed-node-impls.lisp
+++ b/source/backends/JITLispTensor/delayed-node-impls.lisp
@@ -34,7 +34,6 @@
 		       (progn
 			 (setf (blueprint-opecode self) 'move)
 			 nil)
-		       
 		       `(progn ,out)))
 
 (defmethod implement-op ((opcode (eql 'move)) opAST &rest args)

--- a/source/backends/JITLispTensor/jit.lisp
+++ b/source/backends/JITLispTensor/jit.lisp
@@ -90,8 +90,6 @@ AbstractNodes which extends this class, is recognised as `LispJITAble` Node by L
 	;;(format t "[INFO] Compiling nodes from ~a...~%" current-node)
 	;; Pass these informations to invoke-compiler! function
 	;; Later, compiled lisp code will be returned.
-	(print (invoke-compiler! current-node variable next-variable))
-
-	)
+	(invoke-compiler! current-node variable next-variable))
       nil))
 

--- a/source/backends/JITLispTensor/jit.lisp
+++ b/source/backends/JITLispTensor/jit.lisp
@@ -62,7 +62,9 @@ AbstractNodes which extends this class, is recognised as `LispJITAble` Node by L
 (defun tensor-lisp-jit-p (tensor)
   "Returns T if the backward of tensor is a subtype of JITLispTensor"
   (let ((backward (tensor-backward tensor)))
-    (subtypep (class-of backward) 'LispJIT-Blueprint)))
+    (or
+     (subtypep (class-of backward) 'LispJIT-Blueprint)
+     (subtypep (class-of backward) 'ScalarTensor))))
 
 (defun apply-compile-p (variable next-variable)
   "Following the defition of 3., return t if there's a need to run compiling."

--- a/source/backends/JITLispTensor/jit.lisp
+++ b/source/backends/JITLispTensor/jit.lisp
@@ -1,0 +1,37 @@
+
+(in-package :cl-waffe2/backends.jit.lisp)
+
+;; = [An blueprint of user-defined JIT Compiler in cl-waffe2] ===================
+;;
+;; 1. Goal
+;;
+;; Ex> (!sin (!sin (!sin x))) generates:
+;;
+;; (loop-with-view ...
+;;          (setf (aref out ...) (sin (sin (sin i))))
+;;
+;; Without JIT:
+;;
+;; (setq out1 (loop-with-view (setf (aref out ...) (sin x))))
+;; (setq out1 (loop-with-view (setf (aref out ...) (sin x))))
+;; (setq out1 (loop-with-view (setf (aref out ...) (sin x)))) ...
+;;
+
+(defclass LispJIT-Blueprint ()
+  ((op-func :initform nil :type symbol :accessor blueprint-op-func))
+  (:documentation "
+## [class] LispJIT-Blueprint
+
+AbstractNodes which extends this class, is recognised as `LispJITAble` Node by Lisp-JIT-Compiler. This class possess information which is necessary for jit-compiling to cl code.
+"))
+
+;;(defmethod on-compiling-finalizing .. Trace and JIT and Return S exp.
+
+
+(defmethod on-finalizing-compiling ((current-node LispJIT-Blueprint)
+				    &rest variables)
+  ;; (if (finalize-p?
+  ;; ..
+  )
+
+

--- a/source/backends/JITLispTensor/jit.lisp
+++ b/source/backends/JITLispTensor/jit.lisp
@@ -52,7 +52,8 @@
 ;;
 
 (defclass LispJIT-Blueprint ()
-  ((opecode :initform nil :type symbol :accessor blueprint-opecode))
+  ((opecode :initform nil :type symbol :accessor blueprint-opecode)
+   (use-vars :initform nil :type list :accessor blueprint-use-var))
   (:documentation "
 ## [class] LispJIT-Blueprint
 
@@ -78,7 +79,10 @@ AbstractNodes which extends this class, is recognised as `LispJITAble` Node by L
    (funcall (compose #'not #'tensor-lisp-jit-p) next-variable)
 
    ;; The change of shapes is detected:
-   (not (cl-waffe2/vm.generic-tensor::shape-equal-list (shape variable) (shape next-variable)))))
+   (and (not (cl-waffe2/vm.generic-tensor::shape-equal-list (shape variable) (shape next-variable)))
+	;; A += 1.0 is legal though
+	(not (or (typep variable 'ScalarTensor)
+		 (typep variable 'ScalarTensor))))))
 
 (defparameter *compiling-ntime-count* 0)
 
@@ -92,6 +96,6 @@ AbstractNodes which extends this class, is recognised as `LispJITAble` Node by L
 	;;(format t "[INFO] Compiling nodes from ~a...~%" current-node)
 	;; Pass these informations to invoke-compiler! function
 	;; Later, compiled lisp code will be returned.
-	(invoke-compiler! current-node variable next-variable))
+	(print (invoke-compiler! current-node variable next-variable)))
       nil))
 

--- a/source/backends/JITLispTensor/jit.lisp
+++ b/source/backends/JITLispTensor/jit.lisp
@@ -85,7 +85,7 @@ AbstractNodes which extends this class, is recognised as `LispJITAble` Node by L
 	;;(format t "[INFO] Compiling nodes from ~a...~%" current-node)
 	;; Pass these informations to invoke-compiler! function
 	;; Later, compiled lisp code will be returned.
-	(invoke-compiler! current-node variable next-variable)
+	(print (invoke-compiler! current-node variable next-variable))
 
 	)
       nil))

--- a/source/backends/JITLispTensor/jit.lisp
+++ b/source/backends/JITLispTensor/jit.lisp
@@ -17,21 +17,62 @@
 ;; (setq out1 (loop-with-view (setf (aref out ...) (sin x)))) ...
 ;;
 
+;; 2. Implementation
+;;
+;; On the end of calling of compile-forward-chain, a generic-function `on-finalizing-compiling` is invoked which users can append lisp-code as needed.
+;; on-finalizing-compiling will give these informations:
+;;   
+;;     [TopLevel]
+;;         |
+;;     [SinNode1]   <- If invoked at this point...
+;;         |
+;;   [MoveTensorNode2]
+;;         |
+;;     [SinNode3]
+;;         |
+;;   [MoveTensorNode4]
+;;         |
+;;        ...
+;; Info:
+;;   - current-node SinNode1, to get corresponding LispJIT-Blueprint
+;;   - past-variables (list TopLevel)
+;;   - next-variables (list MoveTensorNode2), needed to judge whether accept node or not.
+;;
+
+(defparameter *operands* `(+ - * / move))
+
 (defclass LispJIT-Blueprint ()
-  ((op-func :initform nil :type symbol :accessor blueprint-op-func))
+  ((operand :initform nil :type symbol :accessor blueprint-operand))
   (:documentation "
 ## [class] LispJIT-Blueprint
 
 AbstractNodes which extends this class, is recognised as `LispJITAble` Node by Lisp-JIT-Compiler. This class possess information which is necessary for jit-compiling to cl code.
 "))
 
-;;(defmethod on-compiling-finalizing .. Trace and JIT and Return S exp.
-
+;; pattern match tukaou kana...
 
 (defmethod on-finalizing-compiling ((current-node LispJIT-Blueprint)
-				    &rest variables)
+				    variable
+				    next-variables)
+
+  (print current-node)
+  (print variable)
+  (print next-variables)
+  ;;(defmethod on-compiling-finalizing .. Trace and JIT and Return S exp.
   ;; (if (finalize-p?
-  ;; ..
+  ;; .. oyogaseteoku
+  ;; do-compile
+  nil
   )
+
+
+(defun test-case-tmp ()
+  (with-devices (JITLispTensor cl-waffe2/backends.lisp:LispTensor)
+    (let ((out (!sin (!add (randn `(10 10)) (randn `(10 10))))))
+      (let ((res (build out)))
+	res))))
+
+
+;; defgeneric jitlisp-trace (operand (eq ...)) ...)
 
 

--- a/source/backends/JITLispTensor/jit.lisp
+++ b/source/backends/JITLispTensor/jit.lisp
@@ -85,13 +85,12 @@ AbstractNodes which extends this class, is recognised as `LispJITAble` Node by L
 				    variable
 				    next-variable)
   "If the node is needed to be compiled, compile."
-  (print current-node)
   (if (apply-compile-p variable next-variable)
       (progn
 	(incf *compiling-ntime-count* 1)
 	;;(format t "[INFO] Compiling nodes from ~a...~%" current-node)
 	;; Pass these informations to invoke-compiler! function
 	;; Later, compiled lisp code will be returned.
-	(print (invoke-compiler! current-node variable next-variable)))
+        (invoke-compiler! current-node variable next-variable))
       nil))
 

--- a/source/backends/JITLispTensor/jit.lisp
+++ b/source/backends/JITLispTensor/jit.lisp
@@ -63,9 +63,7 @@ AbstractNodes which extends this class, is recognised as `LispJITAble` Node by L
 (defun tensor-lisp-jit-p (tensor)
   "Returns T if the backward of tensor is a subtype of JITLispTensor"
   (let ((backward (tensor-backward tensor)))
-    (or
-     (subtypep (class-of backward) 'LispJIT-Blueprint)
-     (subtypep (class-of backward) 'ScalarTensor))))
+    (subtypep (class-of backward) 'LispJIT-Blueprint)))
 
 (defun apply-compile-p (variable next-variable)
   "Following the defition of 3., return t if there's a need to run compiling."
@@ -79,10 +77,7 @@ AbstractNodes which extends this class, is recognised as `LispJITAble` Node by L
    (funcall (compose #'not #'tensor-lisp-jit-p) next-variable)
 
    ;; The change of shapes is detected:
-   (and (not (cl-waffe2/vm.generic-tensor::shape-equal-list (shape variable) (shape next-variable)))
-	;; A += 1.0 is legal though
-	(not (or (typep variable 'ScalarTensor)
-		 (typep variable 'ScalarTensor))))))
+   (and (not (cl-waffe2/vm.generic-tensor::shape-equal-list (shape variable) (shape next-variable))))))
 
 (defparameter *compiling-ntime-count* 0)
 
@@ -90,6 +85,7 @@ AbstractNodes which extends this class, is recognised as `LispJITAble` Node by L
 				    variable
 				    next-variable)
   "If the node is needed to be compiled, compile."
+  (print current-node)
   (if (apply-compile-p variable next-variable)
       (progn
 	(incf *compiling-ntime-count* 1)

--- a/source/backends/JITLispTensor/jit.lisp
+++ b/source/backends/JITLispTensor/jit.lisp
@@ -1,6 +1,13 @@
 
 (in-package :cl-waffe2/backends.jit.lisp)
 
+;;
+;; :cl-waffe2/backends.jit.lisp provides an example of implementing user-defined JIT Compiler
+;; in cl-waffe2. This program could be applied into CUDA/Metal/C++ compiler in the future...
+;;
+;; For simplicity, this package compiles from cl-waffe2 into Common Lisp program.
+;;
+
 ;; = [An blueprint of user-defined JIT Compiler in cl-waffe2] ===================
 ;;
 ;; 1. Goal
@@ -17,7 +24,7 @@
 ;; (setq out1 (loop-with-view (setf (aref out ...) (sin x)))) ...
 ;;
 
-;; 2. Implementation
+;; 2. Implementation: Embedding an additional program into compiled lisp code.
 ;;
 ;; On the end of calling of compile-forward-chain, a generic-function `on-finalizing-compiling` is invoked which users can append lisp-code as needed.
 ;; on-finalizing-compiling will give these informations:
@@ -41,8 +48,6 @@
 ;; 3. Constraints
 ;; Detecting the changes of devices in the nodes(e.g.: [SinNode-JITLispTensor] -> [CosNode-LispTensor]), compiler will stop tracing and compiles a kernel.
 ;; Detecting the changes of shapes in the nodes, compiler will stop tracing and compiles a kernel. (because complicated iteration can't be compiled in one go)
-;;
-;;
 ;;
 ;;
 
@@ -89,24 +94,4 @@ AbstractNodes which extends this class, is recognised as `LispJITAble` Node by L
 
 	)
       nil))
-
-
-;; Later: Delete Test Codes:
-(defun test-case-tmp ()
-  (with-no-grad
-    (with-devices (JITLispTensor cl-waffe2/backends.lisp:LispTensor)
-      (let ((a (!cos (!sin (forward (AddNode :float)
-				    (randn `(10 10))
-				    (randn `(10 10)))
-			   :-> (!copy (randn `(10 10))))
-		     :-> (randn `(10 10)))))
-	(build a)))))
-
-(defun test-case-tmp1 ()
-  (with-no-grad
-    (with-devices (JITLispTensor cl-waffe2/backends.lisp:LispTensor)
-      (let ((a (forward (AddNode :float)
-			(randn `(10 10))
-			(randn `(10 10)))))
-	(build a)))))
 

--- a/source/backends/JITLispTensor/package.lisp
+++ b/source/backends/JITLispTensor/package.lisp
@@ -30,3 +30,7 @@
   (intern (with-output-to-string (out) (dolist (sym inputs) (princ sym out)))))
 
 
+(defmacro with-ez-to-view (&body body)
+  `(let ((*with-printing-tensor-omitted* t))
+     ,@body))
+

--- a/source/backends/JITLispTensor/package.lisp
+++ b/source/backends/JITLispTensor/package.lisp
@@ -15,3 +15,14 @@
 (in-package :cl-waffe2/backends.jit.lisp)
 
 
+(defun compose (&rest fns)
+  "fn_1(fn_2(fn_n...))"
+  (if fns
+      (let ((fn1 (car (last fns)))
+            (fns (butlast fns)))
+        #'(lambda (&rest args)
+                   (reduce #'funcall fns
+                           :from-end t
+                           :initial-value (apply fn1 args))))
+      #'identity))
+

--- a/source/backends/JITLispTensor/package.lisp
+++ b/source/backends/JITLispTensor/package.lisp
@@ -4,6 +4,7 @@
 (defpackage :cl-waffe2/backends.jit.lisp
   (:documentation "cl-waffe2/backends.jit.lisp demonstrates an example case of implementing jit with cl-waffe2.")
   (:use :cl
+	:cl-waffe2/distributions
         :cl-waffe2/vm.generic-tensor
 	:cl-waffe2/vm.nodes
         :cl-waffe2/base-impl)

--- a/source/backends/JITLispTensor/package.lisp
+++ b/source/backends/JITLispTensor/package.lisp
@@ -1,0 +1,16 @@
+
+(in-package :cl-user)
+
+(defpackage :cl-waffe2/backends.jit.lisp
+  (:documentation "cl-waffe2/backends.jit.lisp demonstrates an example case of implementing jit with cl-waffe2.")
+  (:use :cl
+        :cl-waffe2/vm.generic-tensor
+	:cl-waffe2/vm.nodes
+        :cl-waffe2/base-impl)
+  (:export
+   #:JITLispTensor))
+
+
+(in-package :cl-waffe2/backends.jit.lisp)
+
+

--- a/source/backends/JITLispTensor/package.lisp
+++ b/source/backends/JITLispTensor/package.lisp
@@ -26,3 +26,7 @@
                            :initial-value (apply fn1 args))))
       #'identity))
 
+(defun symb (&rest inputs)
+  (intern (with-output-to-string (out) (dolist (sym inputs) (princ sym out)))))
+
+

--- a/source/backends/JITLispTensor/t/compiler.lisp
+++ b/source/backends/JITLispTensor/t/compiler.lisp
@@ -37,3 +37,11 @@
 ;; !add
 ;; (!copy (!sin (!copy A))) Sandwitch by Non-JITCompilable-Nodes
 
+
+;;(with-devices (JITLispTensor cl-waffe2/backends.lisp:LispTensor)
+;;	  (with-no-grad (proceed-time (!add (!view (ax+b `(1 3) 0 1) `(:broadcast 3))
+;;					    (ax+b `(3 3) 0 2)))))
+
+;;(with-devices (JITLispTensor cl-waffe2/backends.lisp:LispTensor)
+;;	  (with-no-grad (proceed-time (!copy (lazy-print (randn `(3 3)))))))
+;;

--- a/source/backends/JITLispTensor/t/compiler.lisp
+++ b/source/backends/JITLispTensor/t/compiler.lisp
@@ -31,3 +31,9 @@
 	(= cl-waffe2/backends.jit.lisp::*compiling-ntime-count* 1))))
 
 
+
+;; Test Case
+;; A+=B
+;; !add
+;; (!copy (!sin (!copy A))) Sandwitch by Non-JITCompilable-Nodes
+

--- a/source/backends/JITLispTensor/t/compiler.lisp
+++ b/source/backends/JITLispTensor/t/compiler.lisp
@@ -1,0 +1,34 @@
+
+(in-package :cl-waffe2/backends.jit.lisp.test)
+
+(in-suite :jit-lisp-test)
+
+
+(defun test-case-tmp ()
+  (with-no-grad
+    (with-devices (JITLispTensor cl-waffe2/backends.lisp:LispTensor)
+      (let ((a (!cos (!sin (forward (AddNode :float)
+				    (randn `(10 10))
+				    (randn `(10 10)))
+			   :-> (!copy (randn `(10 10))))
+		     :-> (randn `(10 10)))))
+	(build a)))))
+
+(defun test-case-tmp1 ()
+  (with-no-grad
+    (with-devices (JITLispTensor cl-waffe2/backends.lisp:LispTensor)
+      (let ((a (forward (AddNode :float)
+			(randn `(10 10))
+			(randn `(10 10)))))
+	(build a)))))
+
+;; Check compiler can detect the change of shape, devices.
+(test delimiting-compilable-nodes
+  (is (let ((cl-waffe2/backends.jit.lisp::*compiling-ntime-count* 0))
+	(test-case-tmp)
+	(= cl-waffe2/backends.jit.lisp::*compiling-ntime-count* 2)))
+  (is (let ((cl-waffe2/backends.jit.lisp::*compiling-ntime-count* 0))
+	(test-case-tmp1)
+	(= cl-waffe2/backends.jit.lisp::*compiling-ntime-count* 1))))
+
+

--- a/source/backends/JITLispTensor/t/compiler.lisp
+++ b/source/backends/JITLispTensor/t/compiler.lisp
@@ -1,9 +1,6 @@
 
 (in-package :cl-waffe2/backends.jit.lisp.test)
 
-(in-suite :jit-lisp-test)
-
-
 (defun test-case-tmp ()
   (with-no-grad
     (with-devices (JITLispTensor cl-waffe2/backends.lisp:LispTensor)
@@ -21,6 +18,8 @@
 			(randn `(10 10))
 			(randn `(10 10)))))
 	(build a)))))
+
+(in-suite :jit-lisp-test)
 
 ;; Check compiler can detect the change of shape, devices.
 (test delimiting-compilable-nodes

--- a/source/backends/JITLispTensor/t/package.lisp
+++ b/source/backends/JITLispTensor/t/package.lisp
@@ -7,3 +7,4 @@
 (in-package :cl-waffe2/backends.jit.lisp.test)
 
 (def-suite :jit-lisp-test)
+

--- a/source/backends/JITLispTensor/t/package.lisp
+++ b/source/backends/JITLispTensor/t/package.lisp
@@ -1,0 +1,9 @@
+
+(in-package :cl-user)
+
+(defpackage :cl-waffe2/backends.jit.lisp.test
+  (:use :cl :cl-waffe2 :cl-waffe2/distributions :cl-waffe2/base-impl :cl-waffe2/vm.generic-tensor :cl-waffe2/vm.nodes :cl-waffe2/backends.lisp :cl-waffe2/backends.jit.lisp :fiveam))
+
+(in-package :cl-waffe2/backends.jit.lisp.test)
+
+(def-suite :jit-lisp-test)

--- a/source/backends/JITLispTensor/tensor.lisp
+++ b/source/backends/JITLispTensor/tensor.lisp
@@ -1,7 +1,5 @@
 
-
 (in-package :cl-waffe2/backends.jit.lisp)
 
 (defclass JITLispTensor (cl-waffe2/backends.lisp:LispTensor) nil)
-
 

--- a/source/backends/JITLispTensor/tensor.lisp
+++ b/source/backends/JITLispTensor/tensor.lisp
@@ -1,5 +1,23 @@
 
 (in-package :cl-waffe2/backends.jit.lisp)
 
-(defclass JITLispTensor (cl-waffe2/backends.lisp:LispTensor) nil)
+(defclass JITLispTensor (AbstractTensor) nil)
+
+(defmethod initialize-instance :before ((tensor JITLispTensor)
+					&rest initargs
+					&key &allow-other-keys)
+  ;; if projected-p -> alloc new vec
+  (let* ((shape (getf initargs :shape))
+	(dtype (dtype->lisp-type (getf initargs :dtype)))
+	(vec   (getf initargs :vec))
+	(facet (getf initargs :facet))
+	(initial-element (coerce (or (getf initargs :initial-element) 0) dtype)))
+    (when (eql facet :exist)
+      (if vec
+	  (setf (tensor-vec tensor) vec)
+	  (setf (tensor-vec tensor)
+		(make-array
+		 (apply #'* shape)
+		 :element-type dtype
+		 :initial-element initial-element))))))
 

--- a/source/backends/JITLispTensor/tensor.lisp
+++ b/source/backends/JITLispTensor/tensor.lisp
@@ -1,0 +1,7 @@
+
+
+(in-package :cl-waffe2/backends.jit.lisp)
+
+(defclass JITLispTensor (cl-waffe2/backends.lisp:LispTensor) nil)
+
+

--- a/source/backends/JITLispTensor/tensor.lisp
+++ b/source/backends/JITLispTensor/tensor.lisp
@@ -1,6 +1,6 @@
 
 (in-package :cl-waffe2/backends.jit.lisp)
-
+#|
 (defclass JITLispTensor (AbstractTensor) nil)
 
 (defmethod initialize-instance :before ((tensor JITLispTensor)
@@ -21,3 +21,6 @@
 		 :element-type dtype
 		 :initial-element initial-element))))))
 
+|#
+
+(defclass JITLispTensor (cl-waffe2/backends.lisp:LispTensor) nil)

--- a/source/backends/JITLispTensor/tensor.lisp
+++ b/source/backends/JITLispTensor/tensor.lisp
@@ -2,3 +2,4 @@
 (in-package :cl-waffe2/backends.jit.lisp)
 
 (defclass JITLispTensor (cl-waffe2/backends.lisp:LispTensor) nil)
+

--- a/source/backends/JITLispTensor/tensor.lisp
+++ b/source/backends/JITLispTensor/tensor.lisp
@@ -2,4 +2,3 @@
 (in-package :cl-waffe2/backends.jit.lisp)
 
 (defclass JITLispTensor (cl-waffe2/backends.lisp:LispTensor) nil)
-

--- a/source/base-impl/mathematics.lisp
+++ b/source/base-impl/mathematics.lisp
@@ -20,6 +20,7 @@
 		(export ',defun-name)
 		(defnode (,node-name (myself)
 			  :where (X[~] OUT[~] -> OUT[~])
+			  :save-for-backward ,save-for-backward
 			  :backward ,backward
 			  :documentation
 			  ,(format nil "The node `~a` takes X as an argument, applying a ~(~a~) function into each element and writes the result into out.
@@ -39,6 +40,7 @@ See also: `~a` `~(~a~)`"
 				   defun-name)))
 		(defnode (,scal-node-name (myself)
 			  :where (X[~] OUT[~] -> OUT[~])
+			  :save-for-backward ,save-for-backward
 			  :backward ,backward
 			  :out-scalar-p t
 			  :documentation

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -327,7 +327,7 @@ Tracing until one of variables reached a toplevel tensor (detach-p is t or no ba
     (when (compiled-kernel-cache-p fw-compiled)
       (push fw-compiled *kernel-storeroom*))
     
-    (let ((next-states (map 'list #'(lambda (x) (compile-forward-chain x :stop-me stop-me :called-with-vars (tensor-variables toplevel))) vars))
+    (let ((next-states (map 'list #'(lambda (x) (compile-forward-chain x :stop-me stop-me :called-with-vars toplevel)) vars))
 	  (out-places  (map 'list #'tensor-id vars)))
       
       ;;

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -370,10 +370,11 @@ Tracing until one of variables reached a toplevel tensor (detach-p is t or no ba
 	 ;; Calls an event: on-finalizing-compiling
 	 ;; If JIT is implemented by user, expand user defined forms
 	 
-	 ,(cl-waffe2/vm.nodes:on-finalizing-compiling
-	   (tensor-backward toplevel)
-	   toplevel
-	   called-with-vars)
+	 ,(when (tensor-backward toplevel)
+	    (cl-waffe2/vm.nodes:on-finalizing-compiling
+	     (tensor-backward toplevel)
+	     toplevel
+	     called-with-vars))
 	   
 
 	 ;; TODO UPDATE
@@ -394,7 +395,7 @@ The definition/implementation of nodes could be invaild."
 		,node
 		(nth ,(tensor-out-n toplevel) ',(cl-waffe2/vm.nodes:node-output-shape node))
 		(shape (nth ,(tensor-out-n toplevel) (statecontainer-forward-result (tensor-state ,(tensor-id toplevel)))))))) ;; Output shape compiled
-
+	 
 	 
 	 (nth ,(tensor-out-n toplevel) (statecontainer-forward-result (tensor-state ,(tensor-id toplevel))))))))
 

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -301,7 +301,10 @@ permute-order : ~a
   (shape-equal-list declared-shape (shape tensor)))
 
 ;; Set *runtime-shape-inspection* = t to detect run-time shape-error
-(defun compile-forward-chain (toplevel &key (stop-me nil))
+(defun compile-forward-chain (toplevel
+			      &key
+				(stop-me nil)
+				(called-with-vars nil))
   "
 ## [function] compile-forward-chain
 
@@ -324,7 +327,7 @@ Tracing until one of variables reached a toplevel tensor (detach-p is t or no ba
     (when (compiled-kernel-cache-p fw-compiled)
       (push fw-compiled *kernel-storeroom*))
     
-    (let ((next-states (map 'list #'(lambda (x) (compile-forward-chain x :stop-me stop-me)) vars))
+    (let ((next-states (map 'list #'(lambda (x) (compile-forward-chain x :stop-me stop-me :called-with-vars (tensor-variables toplevel))) vars))
 	  (out-places  (map 'list #'tensor-id vars)))
       
       ;;
@@ -353,6 +356,7 @@ Tracing until one of variables reached a toplevel tensor (detach-p is t or no ba
 		     (let ((out (statecontainer-backward-result (tensor-state ,(tensor-id toplevel)))))
 		       (car out))))
 
+	   ;; Seems ugly:
 	   ;; Judge the tensor is created when forward time or backward time
 	   (when (and *calling-backward-mode*
 		      (not (car (statecontainer-backward-result (tensor-state ,(tensor-id toplevel))))))
@@ -366,7 +370,10 @@ Tracing until one of variables reached a toplevel tensor (detach-p is t or no ba
 	 ;; Calls an event: on-finalizing-compiling
 	 ;; If JIT is implemented by user, expand user defined forms
 	 
-	 ;;,(cl-waffe2/vm.nodes:on-finalizing-compiling current-node vars)
+	 ,(cl-waffe2/vm.nodes:on-finalizing-compiling
+	   (tensor-backward toplevel)
+	   toplevel
+	   called-with-vars)
 	   
 
 	 ;; TODO UPDATE

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -346,6 +346,7 @@ Tracing until one of variables reached a toplevel tensor (detach-p is t or no ba
 			(,(tensor-id toplevel) (progn ,toplevel)))
 
 	 ;; The Operation hasn't done yet...
+	 ;; The code below seems ugly...
 	 
 	 (when (or (null (statecontainer-forward-result (tensor-state ,(tensor-id toplevel))))
 		   (when *calling-backward-mode*
@@ -361,6 +362,12 @@ Tracing until one of variables reached a toplevel tensor (detach-p is t or no ba
 	   
 	   (setf (statecontainer-forward-result (tensor-state ,(tensor-id toplevel)))
 		 (multiple-value-list (call-kernel ,fw-compiled ,@(map 'list #'tensor-id vars)))))
+
+	 ;; Calls an event: on-finalizing-compiling
+	 ;; If JIT is implemented by user, expand user defined forms
+	 
+	 ;;,(cl-waffe2/vm.nodes:on-finalizing-compiling current-node vars)
+	   
 
 	 ;; TODO UPDATE
 	 ,(when (and node

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -366,7 +366,7 @@ Tracing until one of variables reached a toplevel tensor (detach-p is t or no ba
 	   
 	   (setf (statecontainer-forward-result (tensor-state ,(tensor-id toplevel)))
 		 (multiple-value-list (call-kernel ,fw-compiled ,@(map 'list #'tensor-id vars)))))
-
+	 
 	 ;; Calls an event: on-finalizing-compiling
 	 ;; If JIT is implemented by user, expand user defined forms
 	 

--- a/source/vm/nodes/defnode.lisp
+++ b/source/vm/nodes/defnode.lisp
@@ -46,6 +46,11 @@ Return S expression to be embodied in the compiled code if needed, especially, d
 See also: `the implementation of JITLispTensor`.
 "))
 
+(defmethod on-finalizing-compiling ((current-node AbstractNode) variable next-variables)
+  (declare (ignore variable next-variables))
+  (when (next-method-p)
+    (call-next-method)))
+
 
 (defun node-compatible-p (node-name inputs)
   (declare (type list inputs))
@@ -164,6 +169,7 @@ The order of priority would be `(,@backend-priority ScalarTensor t). (t is a spe
   ;; ScalarTensor is forced to use.
   (loop for device in `(,@devices ScalarTensor t)
 	do (let ((node-name (subnode-name abstract-name device)))
+	     ;; JITLispTensor << LispTensor?
 	     (when (and
 		    (node-compatible-p node-name inputs)
 		    (subtypep node-name abstract-name))

--- a/source/vm/nodes/defnode.lisp
+++ b/source/vm/nodes/defnode.lisp
@@ -6,11 +6,44 @@
 (defparameter *node-reject-case-table* (make-hash-table))
 
 (defgeneric on-finalizing-compiling
-    (current-node &rest variables)
+    (current-node variable next-variables)
   (:documentation
    "
 ## [generic] on-finalizing-compiling
 
+```lisp
+(on-finalizing-compiling current-node variable next-variables)
+```
+
+The generic function `on-finalizing-compiling` is invoked after the body of `define-impl` is expanded when performing `compile-chain-forward`.
+
+Return S expression to be embodied in the compiled code if needed, especially, devices which support jit-compiling will need this, because you can get information before and after the node.
+
+### Inputs
+
+```lisp
+     [TopLevel]
+         |
+     [CosNode1]
+         |
+     [SinNode1]   <- If invoked at this point...
+         |
+   [MoveTensorNode2]
+         |
+     [SinNode3]
+         |
+   [MoveTensorNode4]
+         |
+        ...
+```
+
+`current-node (i.e.: SinNode1)` used to dispatch methods.
+
+`variable (i.e.: corresponding variable of SinNode1)` returns the corresponding var of SinNode1.
+
+`next-variables (i.e.: variables of MoveTensorNode2`)` returns the next node's variables.
+
+See also: `the implementation of JITLispTensor`.
 "))
 
 

--- a/source/vm/nodes/defnode.lisp
+++ b/source/vm/nodes/defnode.lisp
@@ -6,13 +6,13 @@
 (defparameter *node-reject-case-table* (make-hash-table))
 
 (defgeneric on-finalizing-compiling
-    (current-node variable next-variables)
+    (current-node variable next-variable)
   (:documentation
    "
 ## [generic] on-finalizing-compiling
 
 ```lisp
-(on-finalizing-compiling current-node variable next-variables)
+(on-finalizing-compiling current-node variable next-variable)
 ```
 
 The generic function `on-finalizing-compiling` is invoked after the body of `define-impl` is expanded when performing `compile-chain-forward`.
@@ -39,9 +39,9 @@ Return S expression to be embodied in the compiled code if needed, especially, d
 
 `current-node (i.e.: SinNode1)` used to dispatch methods.
 
-`variable (i.e.: corresponding variable of SinNode1)` returns the corresponding var of SinNode1.
+`variable (i.e.: corresponding variable of SinNode1)` returns the corresponding var of current node.
 
-`next-variables (i.e.: variables of MoveTensorNode2`)` returns the next node's variables.
+`next-variables (i.e.: corresponding variable of MoveTensorNode2)` returns corresponding variable of next node.
 
 See also: `the implementation of JITLispTensor`.
 "))

--- a/source/vm/nodes/package.lisp
+++ b/source/vm/nodes/package.lisp
@@ -40,6 +40,7 @@
 		#:system-lazy-read-save-for-backward
 		#:scalar-p)
   (:export
+   #:on-finalizing-compiling
    #:node-output-shape
    #:create-subscript-p
    #:composite-where


### PR DESCRIPTION
Added a new backend `:cl-waffe2/backends.jit.lisp` which arithmetic/mathematical functions are compiled to Common Lisp code. This is still unstable, but indicates I can do the same things in `C++/CUDA` :).

![image](https://github.com/hikettei/cl-waffe2/assets/88639579/66cc3ca3-fa83-4d60-9a77-18af816e74bf)
