### PR TITLE
[Enhancement] Added a simple JIT Compiler from Lisp to vectorized C.

### DIFF
--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -108,6 +108,7 @@
 	       (:file "backends/JITCPUTensor/on-finalizing")
 	       (:file "backends/JITCPUTensor/dtype")
 	       (:file "backends/JITCPUTensor/compiler")
+	       (:file "backends/JITCPUTensor/foreign-function")
 	       
 
 	       (:file "backends/JITCPUTensor/impls/arithmetic")

--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -195,12 +195,12 @@
 	       )
   :perform (test-op (o s)
 		    (symbol-call :fiveam :run! :jit-lisp-test)
-		    (symbol-call :fiveam :run! :jit-cpu-test)
 		    
 		    (symbol-call :fiveam :run! :test-nodes)
 		    (symbol-call :fiveam :run! :test-tensor)
 		    (symbol-call :fiveam :run! :base-impl-test)
 
+		    (symbol-call :fiveam :run! :jit-cpu-test)
 		    (symbol-call :fiveam :run! :lisp-backend-test)
 		    (symbol-call :fiveam :run! :test-backends-cpu)
 		    (symbol-call :fiveam :run! :nn-test)))

--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -100,6 +100,18 @@
 	       (:file "backends/JITLispTensor/tensor")
 	       (:file "backends/JITLispTensor/jit")
 	       (:file "backends/JITLispTensor/delayed-node-impls")
+
+	       (:file "backends/JITCPUTensor/package")
+	       (:file "backends/JITCPUTensor/tensor")
+	       (:file "backends/JITCPUTensor/blueprint")
+	       (:file "backends/JITCPUTensor/ir")
+	       (:file "backends/JITCPUTensor/on-finalizing")
+	       (:file "backends/JITCPUTensor/dtype")
+	       (:file "backends/JITCPUTensor/compiler")
+	       
+
+	       (:file "backends/JITCPUTensor/impls/arithmetic")
+	       (:file "backends/JITCPUTensor/impls/math")
 	       
 	       (:file "optimizers/defoptimizer")
 
@@ -184,8 +196,7 @@
 		    (symbol-call :fiveam :run! :base-impl-test)
 		    (symbol-call :fiveam :run! :lisp-backend-test)
 		    (symbol-call :fiveam :run! :test-backends-cpu)
-		    (symbol-call :fiveam :run! :nn-test)		    
-		    ))
+		    (symbol-call :fiveam :run! :nn-test)))
 
 
 (defpackage :cl-waffe2-docs-asdf

--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -69,6 +69,7 @@
 	       (:file "base-impl/mathematics")
 	       (:file "base-impl/logical")
 	       (:file "base-impl/transform")
+	       (:file "base-impl/ir")
 	       
 
 	       (:file "backends/lisp/package")
@@ -181,6 +182,8 @@
 
 	       (:file "backends/lisp/t/package")
 
+	       (:file "backends/JITCPUTensor/t/package")
+	       
 	       (:file "backends/JITLispTensor/t/package")
 	       (:file "backends/JITLispTensor/t/compiler")
 
@@ -192,9 +195,12 @@
 	       )
   :perform (test-op (o s)
 		    (symbol-call :fiveam :run! :jit-lisp-test)
+		    (symbol-call :fiveam :run! :jit-cpu-test)
+		    
 		    (symbol-call :fiveam :run! :test-nodes)
 		    (symbol-call :fiveam :run! :test-tensor)
 		    (symbol-call :fiveam :run! :base-impl-test)
+
 		    (symbol-call :fiveam :run! :lisp-backend-test)
 		    (symbol-call :fiveam :run! :test-backends-cpu)
 		    (symbol-call :fiveam :run! :nn-test)))

--- a/source/backends/JITCPUTensor/blueprint.lisp
+++ b/source/backends/JITCPUTensor/blueprint.lisp
@@ -1,32 +1,35 @@
 
 (in-package :cl-waffe2/backends.jit.cpu)
 
-;; CPUJITTensor and ScalarTensor are subject to jit-compiled.
+;; In this device, JITCPUTensor and JITCPUScalarTensor are subject to jit-compiled.
+;; Blueprint ... stores corresponding C ir node.
 
 (defclass CPUJIT-Blueprint ()
   ((opecode :initform nil :type symbol :accessor blueprint-opecode)
    (use-vars :initform nil :type list :accessor  blueprint-use-var))
   (:documentation "
 ## [class] CPUJIT-Blueprint
-
-AbstractNodes which extends this class, is recognised as `CPI-JITAble` Node by CPU-JIT-Compiler. This class possess information which is necessary for jit-compiling to cl code.
+Nodes to be involved in JIT, should extend this class.
 "))
 
 (defclass CPUJIT-Scalar-Blueprint (CPUJIT-Blueprint)
   ((opecode :initform nil :type symbol :accessor blueprint-opecode)
    (use-vars :initform nil :type list :accessor  blueprint-use-var))
   (:documentation "
-## [class] CPUJIT-Blueprint
-
-AbstractNodes which extends this class, is recognised as `CPI-JITAble` Node by CPU-JIT-Compiler. This class possess information which is necessary for jit-compiling to cl code.
+## [class] CPUJIT-Scalar-Blueprint
+Nodes to be involved in JIT, should extend this class.
 "))
 
 (defgeneric translate-op (opcode opast &rest args) (:documentation "
 ## [generic] translate-op
 
-Return: OpInstruction
+Return -> Instruction
 "))
 
+;; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+;; [TODO]
+;; The generated C codes is merely a copy of the computation node, not optimized.
+;; For efficiency, we have to fuse operations and prune unused nodes.
 ;;
 ;; Instructions that the method translate-op can return are following:
 ;;
@@ -50,4 +53,6 @@ Return: OpInstruction
   (fname function-name :type string)
   (displace-to displace-to :type AbstractTensor)
   (args function-arguments :type list))
+
+;; TODO: Compose :apply instructions and optimize generated c codes.
 

--- a/source/backends/JITCPUTensor/blueprint.lisp
+++ b/source/backends/JITCPUTensor/blueprint.lisp
@@ -21,3 +21,33 @@ AbstractNodes which extends this class, is recognised as `CPI-JITAble` Node by C
 AbstractNodes which extends this class, is recognised as `CPI-JITAble` Node by CPU-JIT-Compiler. This class possess information which is necessary for jit-compiling to cl code.
 "))
 
+(defgeneric translate-op (opcode opast &rest args) (:documentation "
+## [generic] translate-op
+
+Return: OpInstruction
+"))
+
+;;
+;; Instructions that the method translate-op can return are following:
+;;
+
+;; 1. modify: A[...] += B[...]
+;; 2. apply : A[...] = f(A[...])
+;; 3. set   : A[...] = B[...]
+;; 4. ignore: A[...]
+;;
+;; (2.) is composable:
+;;   apply . apply = apply(apply(x))
+;;
+
+(defstruct (Instruction
+	    (:constructor make-inst (inst-type function-name displace-to function-arguments)))
+  "
+ displace-to
+   A[...]     = function-name(function-arguments)
+ "
+  (type inst-type :type (and keyword (member :modify :apply :set :ignore)))
+  (fname function-name :type string)
+  (displace-to displace-to :type AbstractTensor)
+  (args function-arguments :type list))
+

--- a/source/backends/JITCPUTensor/blueprint.lisp
+++ b/source/backends/JITCPUTensor/blueprint.lisp
@@ -1,5 +1,5 @@
 
-(in-package :cl-waffe2/backends.jit.lisp)
+(in-package :cl-waffe2/backends.jit.cpu)
 
 ;; CPUJITTensor and ScalarTensor are subject to jit-compiled.
 
@@ -12,7 +12,7 @@
 AbstractNodes which extends this class, is recognised as `CPI-JITAble` Node by CPU-JIT-Compiler. This class possess information which is necessary for jit-compiling to cl code.
 "))
 
-(defclass CPUJIT-Scalar-Blueprint ()
+(defclass CPUJIT-Scalar-Blueprint (CPUJIT-Blueprint)
   ((opecode :initform nil :type symbol :accessor blueprint-opecode)
    (use-vars :initform nil :type list :accessor  blueprint-use-var))
   (:documentation "
@@ -20,7 +20,4 @@ AbstractNodes which extends this class, is recognised as `CPI-JITAble` Node by C
 
 AbstractNodes which extends this class, is recognised as `CPI-JITAble` Node by CPU-JIT-Compiler. This class possess information which is necessary for jit-compiling to cl code.
 "))
-
-
-
 

--- a/source/backends/JITCPUTensor/blueprint.lisp
+++ b/source/backends/JITCPUTensor/blueprint.lisp
@@ -1,0 +1,26 @@
+
+(in-package :cl-waffe2/backends.jit.lisp)
+
+;; CPUJITTensor and ScalarTensor are subject to jit-compiled.
+
+(defclass CPUJIT-Blueprint ()
+  ((opecode :initform nil :type symbol :accessor blueprint-opecode)
+   (use-vars :initform nil :type list :accessor  blueprint-use-var))
+  (:documentation "
+## [class] CPUJIT-Blueprint
+
+AbstractNodes which extends this class, is recognised as `CPI-JITAble` Node by CPU-JIT-Compiler. This class possess information which is necessary for jit-compiling to cl code.
+"))
+
+(defclass CPUJIT-Scalar-Blueprint ()
+  ((opecode :initform nil :type symbol :accessor blueprint-opecode)
+   (use-vars :initform nil :type list :accessor  blueprint-use-var))
+  (:documentation "
+## [class] CPUJIT-Blueprint
+
+AbstractNodes which extends this class, is recognised as `CPI-JITAble` Node by CPU-JIT-Compiler. This class possess information which is necessary for jit-compiling to cl code.
+"))
+
+
+
+

--- a/source/backends/JITCPUTensor/compiler.lisp
+++ b/source/backends/JITCPUTensor/compiler.lisp
@@ -28,8 +28,10 @@
 
 (defun place-toplevel-form (cffi-call-name tensors)
   "Places headers, function definition and macros."
-  (write-buff "~%~%#pragma simd~%")
-  ;; #pragma GCC optimize ("O3")
+  
+  (write-buff "~%~%#pragma SIMD~%")
+  (write-buff "#pragma GCC optimize (\"O3\")~%")
+  ;;(write-buff "#pragma GCC target \"avx2\"")
   ;; #pragma GCC target "avx2" avx512 ...
   ;; ^ (TODO) Identify CPU by cpu_has_avx512 ...
   

--- a/source/backends/JITCPUTensor/compiler.lisp
+++ b/source/backends/JITCPUTensor/compiler.lisp
@@ -77,7 +77,7 @@ void function-name (int size, float * restrict x1, int stride, int offset, float
   "
 Recursively exploring the computation node staring from toplevel, the function invoke-compiler! appends C codes depending on translate-op method to the current buffer.
 
-Return: (values envolved-tensors(but ScalarTensor) toplevel)
+Return: (values arguments envolved-tensors(but ScalarTensor) toplevel)
 "
   (declare (type JITAbleTensors toplevel))
 
@@ -85,6 +85,7 @@ Return: (values envolved-tensors(but ScalarTensor) toplevel)
 	 (envolved-nodes (confirm-compiling-area toplevel))
 	 (function-form  (apply #'cFunction function-name *compiled-tensors*)))
     (values
+     *compiled-tensors*
      ;; Used for expanding call-with-view
      (loop for tensor in *compiled-tensors*
 	   if (typep tensor 'JITCPUTensor)

--- a/source/backends/JITCPUTensor/compiler.lisp
+++ b/source/backends/JITCPUTensor/compiler.lisp
@@ -1,0 +1,13 @@
+
+(in-package :cl-waffe2/backends.jit.cpu)
+
+(defvar *compiled-code-buffer* nil "The variable collects generated C codes.")
+
+(defmacro with-compiling-mode (&body body)
+  "Initializes *compiled-code-buffer*"
+  `(with-output-to-string (*compiled-code-buffer*)
+     ,@body))
+
+(defun write-buff (control-string &rest args)
+  "Appends the given characters to *compiled-code-buffer*."
+  (apply #'format *compiled-code-buffer* control-string args))

--- a/source/backends/JITCPUTensor/compiler.lisp
+++ b/source/backends/JITCPUTensor/compiler.lisp
@@ -36,6 +36,12 @@
 
   (write-buff "~%~a;~%~%" (apply #'cFunction cffi-call-name tensors)))
 
+(defun cAref (tensor)
+  (declare (type AbstractTensor tensor))
+  (format nil "~a[i * ~a_STRIDE]"
+	  (tensor-id tensor)
+	  (tensor-id tensor)))
+
 ;; Tensor -> (Tensor-vec stride offset)
 (defun cFunction (function-name &rest arguments)
   "Header:
@@ -48,29 +54,41 @@ void function-name (int size, float * restrict x1, int stride, int offset, float
 		  for n upfrom 0
 		  do (cVar arg
 			   :restrict (= 1 (count (tensor-id arg) arguments :key #'tensor-id))
-			   :comma (not (= n (1- (length arguments)))))
+			   :comma (or
+				   (typep arg 'JITCPUTensor)
+				   (not (= n (1- (length arguments))))))
 		  if (typep arg 'JITCPUTensor)
 		    do (cStride arg :comma (not (= n (1- (length arguments))))))
 	    (write-buff ")"))))
     (format nil "void ~a~a;~%" function-name arguments-form)))
 
 (defun invoke-compiler! (function-name toplevel)
-  ""
+  "
+Return: (values envolved-tensors(but ScalarTensor) toplevel)
+"
   (declare (type JITAbleTensors toplevel))
 
-  (let* ((*compiled-tensors*)
+  (let* ((*compiled-tensors* `(,toplevel))
 	 (envolved-nodes (confirm-compiling-area toplevel))
 	 (function-form  (apply #'cFunction function-name *compiled-tensors*)))
-    (with-compiling-mode
-      (place-toplevel-form function-name *compiled-tensors*)
+    (values
+     *compiled-tensors*
+     (with-compiling-mode
+       (place-toplevel-form function-name *compiled-tensors*)
 
-      ;; void function-name (...) { ...
-      (write-buff "~a { ~%" function-form)
-      (with-indent 4
-	(write-c-line "for(int i=0;i<size;i++) {~%")
-	(with-indent 8
-	  (ir->C envolved-nodes))
-	(write-c-line "}~%"))
-      (write-c-line "}~%"))))
+       ;; void function-name (...) { ...
+       (write-buff "~a { ~%" function-form)
+       (with-indent 4
+	 (write-c-line "for(int i=0;i<size;i++) {~%")
+	 (with-indent 8
+	   (ir->C envolved-nodes))
+	 (write-c-line "}~%"))
+       (write-c-line "}~%")))))
 
+
+;; Workload:
+;; 1. CPUのAVX拡張命令を特定
+;; 2. コンパイルの設定
+;; 3. gccの設定
+;; 4. 動的にCFFIから読み込む
 

--- a/source/backends/JITCPUTensor/compiler.lisp
+++ b/source/backends/JITCPUTensor/compiler.lisp
@@ -22,7 +22,7 @@
   (apply #'format *compiled-code-buffer* control-string args))
 
 (defparameter *includes*
-  `("immintrin.h" "stdbool.h" "math.h" "stdio.h" "stdint.h"))
+  `("immintrin.h" "stdbool.h" "stdlib.h" "math.h" "stdio.h" "stdint.h"))
 
 (defun place-toplevel-form (cffi-call-name tensors)
   (write-buff "~%~%#pragma simd~%")
@@ -38,6 +38,7 @@
   ;; Utils
 
   (write-buff "#define INV_SCALAR(scal) 1 / scal;~%~%")
+  (write-buff "#define SQUARE_SCALAR(scal) scal * scal;~%~%")
   )
 
 (defun cAref (tensor)

--- a/source/backends/JITCPUTensor/compiler.lisp
+++ b/source/backends/JITCPUTensor/compiler.lisp
@@ -2,6 +2,10 @@
 (in-package :cl-waffe2/backends.jit.cpu)
 
 (defvar *compiled-code-buffer* nil "The variable collects generated C codes.")
+(defparameter *indent-width* 0)
+
+(defmacro with-indent (indent &body body)
+  `(let ((*indent-width* ,indent)) ,@body))
 
 (defmacro with-compiling-mode (&body body)
   "Initializes *compiled-code-buffer*"
@@ -11,3 +15,62 @@
 (defun write-buff (control-string &rest args)
   "Appends the given characters to *compiled-code-buffer*."
   (apply #'format *compiled-code-buffer* control-string args))
+
+(defun write-c-line (control-string &rest args)
+  "Appends the given characters to *compiled-code-buffer*."
+  (dotimes (i *indent-width*) (princ " " *compiled-code-buffer*))
+  (apply #'format *compiled-code-buffer* control-string args))
+
+
+(defparameter *includes*
+  `("immintrin.h" "stdbool.h" "math.h" "stdio.h" "stdint.h"))
+
+(defun place-toplevel-form (cffi-call-name tensors)
+  (write-buff "~%~%#pragma simd~%")
+  ;; #pragma GCC optimize ("O3")
+  ;; #pragma GCC target "avx2" avx512 ...
+  ;; ^ (TODO) Identify CPU by cpu_has_avx512 ...
+  
+  (loop for include in *includes*
+	do (write-buff "#include <~a>~%" include))
+
+  (write-buff "~%~a;~%~%" (apply #'cFunction cffi-call-name tensors)))
+
+;; Tensor -> (Tensor-vec stride offset)
+(defun cFunction (function-name &rest arguments)
+  "Header:
+void function-name (int size, float * restrict x1, int stride, int offset, float* x2 ...)"
+
+  (let ((arguments-form
+	  (with-compiling-mode
+	    (write-buff "(uint32_t restrict * size, ")
+	    (loop for arg in arguments
+		  for n upfrom 0
+		  do (cVar arg
+			   :restrict (= 1 (count (tensor-id arg) arguments :key #'tensor-id))
+			   :comma (not (= n (1- (length arguments)))))
+		  if (typep arg 'JITCPUTensor)
+		    do (cStride arg :comma (not (= n (1- (length arguments))))))
+	    (write-buff ")"))))
+    (format nil "void ~a~a;~%" function-name arguments-form)))
+
+(defun invoke-compiler! (function-name toplevel)
+  ""
+  (declare (type JITAbleTensors toplevel))
+
+  (let* ((*compiled-tensors*)
+	 (envolved-nodes (confirm-compiling-area toplevel))
+	 (function-form  (apply #'cFunction function-name *compiled-tensors*)))
+    (with-compiling-mode
+      (place-toplevel-form function-name *compiled-tensors*)
+
+      ;; void function-name (...) { ...
+      (write-buff "~a { ~%" function-form)
+      (with-indent 4
+	(write-c-line "for(int i=0;i<size;i++) {~%")
+	(with-indent 8
+	  (ir->C envolved-nodes))
+	(write-c-line "}~%"))
+      (write-c-line "}~%"))))
+
+

--- a/source/backends/JITCPUTensor/compiler.lisp
+++ b/source/backends/JITCPUTensor/compiler.lisp
@@ -21,7 +21,6 @@
   (dotimes (i *indent-width*) (princ " " *compiled-code-buffer*))
   (apply #'format *compiled-code-buffer* control-string args))
 
-
 (defparameter *includes*
   `("immintrin.h" "stdbool.h" "math.h" "stdio.h" "stdint.h"))
 
@@ -34,7 +33,12 @@
   (loop for include in *includes*
 	do (write-buff "#include <~a>~%" include))
 
-  (write-buff "~%~a;~%~%" (apply #'cFunction cffi-call-name tensors)))
+  (write-buff "~%~a;~%~%" (apply #'cFunction cffi-call-name tensors))
+
+  ;; Utils
+
+  (write-buff "#define INV_SCALAR(scal) 1 / scal;~%~%")
+  )
 
 (defun cAref (tensor)
   (declare (type AbstractTensor tensor))

--- a/source/backends/JITCPUTensor/compiler.lisp
+++ b/source/backends/JITCPUTensor/compiler.lisp
@@ -60,7 +60,7 @@ void function-name (int size, float * restrict x1, int stride, int offset, float
 
   (let ((arguments-form
 	  (with-compiling-mode
-	    (write-buff "(uint32_t restrict * size, ")
+	    (write-buff "(uint32_t size, ")
 	    (loop for arg in arguments
 		  for n upfrom 0
 		  do (cVar arg

--- a/source/backends/JITCPUTensor/compiler.lisp
+++ b/source/backends/JITCPUTensor/compiler.lisp
@@ -29,11 +29,10 @@
 (defun place-toplevel-form (cffi-call-name tensors)
   "Places headers, function definition and macros."
   
-  (write-buff "~%~%#pragma SIMD~%")
-  (write-buff "#pragma GCC optimize (\"O3\")~%")
+  (write-buff "~%#pragma SIMD~%")
+  ;;(write-buff "#pragma GCC optimize (\"O3\")~%")
   ;;(write-buff "#pragma GCC target \"avx2\"")
   ;; #pragma GCC target "avx2" avx512 ...
-  ;; ^ (TODO) Identify CPU by cpu_has_avx512 ...
   
   (loop for include in *includes*
 	do (write-buff "#include <~a>~%" include))
@@ -45,14 +44,16 @@
   (write-buff "#define SQUARE_SCALAR(scal) scal * scal;~%~%")
   )
 
-(defun cAref (tensor)
+(defun cAref (tensor &key (pointer nil))
   "Reading the given tensor's id, the function returns a string which corresponds to aref in C"
   (declare (type AbstractTensor tensor))
   (if (typep tensor 'JITCPUTensor)
       (format nil "~a[i * ~a_STRIDE]"
 	      (tensor-id tensor)
 	      (tensor-id tensor))
-      (format nil "~a" (tensor-id tensor))))
+      (if pointer
+	  (format nil "*~a" (tensor-id tensor))
+	  (format nil "~a"    (tensor-id tensor)))))
 
 (defun cFunction (function-name &rest arguments)
   "Header:
@@ -69,7 +70,8 @@ void function-name (int size, float * restrict x1, int stride, int offset, float
 			   :restrict (= 1 (count (tensor-id arg) arguments :key #'tensor-id))
 			   :comma (or
 				   (typep arg 'JITCPUTensor)
-				   (not (= n (1- (length arguments))))))
+				   (not (= n (1- (length arguments)))))
+			   :pointer t)
 		  if (typep arg 'JITCPUTensor)
 		    do (cStride arg :comma (not (= n (1- (length arguments))))))
 	    (write-buff ")"))))
@@ -79,28 +81,36 @@ void function-name (int size, float * restrict x1, int stride, int offset, float
   "
 Recursively exploring the computation node staring from toplevel, the function invoke-compiler! appends C codes depending on translate-op method to the current buffer.
 
-Return: (values arguments envolved-tensors(but ScalarTensor) toplevel)
+Return: (values arguments envolved-tensors(but ScalarTensor) scalars toplevel)
 "
   (declare (type JITAbleTensors toplevel))
 
   (let* ((*compiled-tensors* `(,toplevel))
 	 (envolved-nodes (confirm-compiling-area toplevel))
-	 (function-form  (apply #'cFunction function-name *compiled-tensors*)))
+	 (function-form  (apply #'cFunction function-name *compiled-tensors*))
+	 (tensors (loop for tensor in *compiled-tensors*
+			if (typep tensor 'JITCPUTensor)
+			  collect tensor)))
     (values
      *compiled-tensors*
      ;; Used for expanding call-with-view
+     tensors
      (loop for tensor in *compiled-tensors*
-	   if (typep tensor 'JITCPUTensor)
+	   if (typep tensor 'JITCPUScalarTensor)
 	     collect tensor)
      (with-compiling-mode
        (place-toplevel-form function-name *compiled-tensors*)
 
        ;; void function-name (...) { ...
        (write-buff "~a { ~%" function-form)
-       (with-indent 4
-	 (write-c-line "for(int i=0; i<size; i++) {~%")
-	 (with-indent 8
-	   (ir->C envolved-nodes))
-	 (write-c-line "}~%"))
+       (if (null tensors)
+	   (with-indent 4
+	     (ir->C envolved-nodes))
+	   (with-indent 4
+	     (write-c-line "for(int i=0; i<size; i++) {~%")
+	     (with-indent 8
+	       (ir->C envolved-nodes))
+	     (write-c-line "}~%")))
+       
        (write-c-line "}~%")))))
 

--- a/source/backends/JITCPUTensor/dtype.lisp
+++ b/source/backends/JITCPUTensor/dtype.lisp
@@ -1,18 +1,7 @@
 
 (in-package :cl-waffe2/backends.jit.cpu)
 
-;; cl-waffe2 dtype -> C Dtype
-
-;; single-flaot -> float
-;; double-float -> double
-;;        ...
-
-
-;;
-;; (c++defun aaa ((c++type (dtype tensor)) ... ...)
-;;    (inst-set ())
-;;    (inst-load ()))
-;;
+;; LUT: cl-waffe2 dtype -> C type
 
 ;; Memo: https://zenn.dev/mod_poppo/articles/vectorization-and-restrict
 (defun dtype->ctype (dtype)

--- a/source/backends/JITCPUTensor/dtype.lisp
+++ b/source/backends/JITCPUTensor/dtype.lisp
@@ -53,8 +53,12 @@ but failed because cl-waffe2 encountered an unsupported dtype: ~a" dtype))))
   (write-buff "~a~a" (tensor-id tensor)
 	      (if comma ", " "")))
 
-(defun cStride (tensor &key (comma nil))
+(defun cStride (tensor &key (comma nil) (typedef t))
   (declare (type JITCPUTensor))
-  (write-buff "int32_t restrict * ~a_STRIDE~a" (tensor-id tensor)
+  (write-buff "~a~a_STRIDE~a"
+	      (if typedef
+		  "int32_t restrict * "
+		  "")
+	      (tensor-id tensor)
 	      (if comma ", " "")))
 

--- a/source/backends/JITCPUTensor/dtype.lisp
+++ b/source/backends/JITCPUTensor/dtype.lisp
@@ -40,7 +40,7 @@ but failed because cl-waffe2 encountered an unsupported dtype: ~a" dtype))))
 		 (if restrict
 		     " restrict * "
 		     "* ")))
-    (JITScalarTensor
+    (JITCPUScalarTensor
      (write-buff "~a "		
 		 (dtype->ctype (dtype tensor))))
     (T

--- a/source/backends/JITCPUTensor/dtype.lisp
+++ b/source/backends/JITCPUTensor/dtype.lisp
@@ -19,7 +19,7 @@
     (T (error "dtype->ctype: Attempted to generate C codes
 but failed because cl-waffe2 encountered an unsupported dtype: ~a" dtype))))
 
-(defun cType (tensor &key (restrict nil))
+(defun cType (tensor &key (restrict nil) (pointer nil))
   (declare (type AbstractTensor tensor)
 	   (type boolean restrict))
   (typecase tensor
@@ -30,15 +30,18 @@ but failed because cl-waffe2 encountered an unsupported dtype: ~a" dtype))))
 		     (progn nil "* ");;" restrict * "
 		     "* ")))
     (JITCPUScalarTensor
-     (write-buff "~a "		
-		 (dtype->ctype (dtype tensor))))
+     (write-buff "~a~a"
+		 (dtype->ctype (dtype tensor))
+		 (if pointer
+		     " *"
+		     "")))
     (T
      (error "cType: the given tensor isn't JITAble.
 ~a" tensor))))
 
-(defun cVar (tensor &key (restrict nil) (comma nil))
+(defun cVar (tensor &key (restrict nil) (comma nil) (pointer nil))
   (declare (type AbstractTensor tensor))
-  (cType tensor :restrict restrict)
+  (cType tensor :restrict restrict :pointer pointer)
   (write-buff "~a~a" (tensor-id tensor)
 	      (if comma ", " "")))
 

--- a/source/backends/JITCPUTensor/dtype.lisp
+++ b/source/backends/JITCPUTensor/dtype.lisp
@@ -1,0 +1,60 @@
+
+(in-package :cl-waffe2/backends.jit.cpu)
+
+;; cl-waffe2 dtype -> C Dtype
+
+;; single-flaot -> float
+;; double-float -> double
+;;        ...
+
+
+;;
+;; (c++defun aaa ((c++type (dtype tensor)) ... ...)
+;;    (inst-set ())
+;;    (inst-load ()))
+;;
+
+;; Memo: https://zenn.dev/mod_poppo/articles/vectorization-and-restrict
+(defun dtype->ctype (dtype)
+  (declare (type keyword dtype))
+  (case dtype
+    (:double "double")
+    (:float "float")
+    (:int32 "int32_t")
+    (:int16 "int16_t")
+    (:int8 "int8_t")
+    (:uint32 "uint32_t")
+    (:uint16 "uint16_t")
+    (:uint8 "uint8_t")
+    (:bit "bool")
+    (T (error "dtype->ctype: Attempted to generate C codes
+but failed because cl-waffe2 encountered an unsupported dtype: ~a" dtype))))
+
+(defun cType (tensor &key (restrict nil))
+  (declare (type AbstractTensor tensor)
+	   (type boolean restrict))
+  (typecase tensor
+    (JITCPUTensor
+     (write-buff "~a~a"
+		 (dtype->ctype (dtype tensor))
+		 (if restrict
+		     " restrict * "
+		     "* ")))
+    (ScalarTensor
+     (write-buff "~a "		
+		 (dtype->ctype (dtype tensor))))
+    (T
+     (error "cType: the given tensor isn't JITAble.
+~a" tensor))))
+
+(defun cVar (tensor &key (restrict nil) (comma nil))
+  (declare (type AbstractTensor tensor))
+  (cType tensor :restrict restrict)
+  (write-buff "~a~a" (tensor-id tensor)
+	      (if comma ", " "")))
+
+(defun cStride (tensor &key (comma nil))
+  (declare (type JITCPUTensor))
+  (write-buff "int32_t restrict * ~a_STRIDE~a" (tensor-id tensor)
+	      (if comma ", " "")))
+

--- a/source/backends/JITCPUTensor/dtype.lisp
+++ b/source/backends/JITCPUTensor/dtype.lisp
@@ -40,7 +40,7 @@ but failed because cl-waffe2 encountered an unsupported dtype: ~a" dtype))))
 		 (if restrict
 		     " restrict * "
 		     "* ")))
-    (ScalarTensor
+    (JITScalarTensor
      (write-buff "~a "		
 		 (dtype->ctype (dtype tensor))))
     (T

--- a/source/backends/JITCPUTensor/dtype.lisp
+++ b/source/backends/JITCPUTensor/dtype.lisp
@@ -27,7 +27,7 @@ but failed because cl-waffe2 encountered an unsupported dtype: ~a" dtype))))
      (write-buff "~a~a"
 		 (dtype->ctype (dtype tensor))
 		 (if restrict
-		     " restrict * "
+		     (progn nil "* ");;" restrict * "
 		     "* ")))
     (JITCPUScalarTensor
      (write-buff "~a "		
@@ -46,7 +46,7 @@ but failed because cl-waffe2 encountered an unsupported dtype: ~a" dtype))))
   (declare (type JITCPUTensor))
   (write-buff "~a~a_STRIDE~a"
 	      (if typedef
-		  "int32_t restrict * "
+		  "int32_t "
 		  "")
 	      (tensor-id tensor)
 	      (if comma ", " "")))

--- a/source/backends/JITCPUTensor/foreign-function.lisp
+++ b/source/backends/JITCPUTensor/foreign-function.lisp
@@ -67,7 +67,7 @@ Tips: Modify cl-waffe2/backends.jit.cpu:*default-c-compiler* to switch compilers
 		       ;; tensor_ptr tensor_stride ...
 		       ;; (dtype val)
 		       `(:pointer
-			 (tensor-ptr ,arg :offset ,(offset-of (read-view view-count) 0))
+			 (tensor-ptr (read-result ,arg) :offset ,(offset-of (read-view view-count) 0))
 			 :int32;;(:pointer :int32)
 			 ,(stride-of (read-view view-count) 0))
 		     (incf view-count)))

--- a/source/backends/JITCPUTensor/foreign-function.lisp
+++ b/source/backends/JITCPUTensor/foreign-function.lisp
@@ -1,0 +1,35 @@
+
+(in-package :cl-waffe2/backends.jit.cpu)
+
+;; Ref: https://stackoverflow.com/questions/6612169/compile-a-stream-of-data-in-c
+(defun load-foreign-function (source
+			      &key
+				;; (disassemble t)
+				(compiler "gcc-13")
+				(lang "c"))
+  (declare (type string source compiler))
+
+  (uiop:with-temporary-file (:pathname sharedlib :type "so" :keep t)
+    :close-stream
+    (let* ((cmd
+	     ;; gcc -shared -o sharedlib
+	     (list
+	      compiler "-shared"
+	      "-x" lang
+	      "-o" (uiop:native-namestring sharedlib) "-"))
+	   (process-info (uiop:launch-program
+			  cmd
+			  :input :stream
+			  :error-output :stream))
+	   (input (uiop:process-info-input process-info))
+	   (error-output (uiop:process-info-error-output process-info)))
+      (unwind-protect (princ source input)
+	(close input))
+      (unless (zerop (uiop:wait-process process-info))
+	(error "cl-waffe2/backends.jit.cpu: Failed to compile a shared library:~%~a~%"
+	       (alexandria:read-stream-content-into-string error-output))))
+    (print sharedlib)
+    ;;(cffi:load-foreign-library "")
+    ))
+
+;; (defmacro call-jit-function

--- a/source/backends/JITCPUTensor/foreign-function.lisp
+++ b/source/backends/JITCPUTensor/foreign-function.lisp
@@ -1,11 +1,17 @@
 
 (in-package :cl-waffe2/backends.jit.cpu)
 
+(defparameter *default-c-compiler* "gcc" "
+## [parameter] *default-c-compiler*
+
+Specify the command to compile the generated c codes. In default, \"gcc\"
+")
+
 ;; Ref: https://stackoverflow.com/questions/6612169/compile-a-stream-of-data-in-c
 (defun load-foreign-function (source
 			      &key
 				;; (disassemble t)
-				(compiler "gcc")
+				(compiler *default-c-compiler*)
 				(lang "c"))
   (declare (type string source compiler))
 
@@ -16,6 +22,7 @@
 	     (list
 	      compiler "-shared"
 	      "-x" lang
+	      "-fPIC" "-O3" "-march=native"
 	      "-o" (uiop:native-namestring sharedlib) "-"))
 	   (process-info (uiop:launch-program
 			  cmd

--- a/source/backends/JITCPUTensor/foreign-function.lisp
+++ b/source/backends/JITCPUTensor/foreign-function.lisp
@@ -5,7 +5,7 @@
 (defun load-foreign-function (source
 			      &key
 				;; (disassemble t)
-				(compiler "gcc-13")
+				(compiler "gcc")
 				(lang "c"))
   (declare (type string source compiler))
 
@@ -28,8 +28,6 @@
       (unless (zerop (uiop:wait-process process-info))
 	(error "cl-waffe2/backends.jit.cpu: Failed to compile a shared library:~%~a~%"
 	       (alexandria:read-stream-content-into-string error-output))))
-    (print sharedlib)
-    ;;(cffi:load-foreign-library "")
-    ))
+    (cffi:load-foreign-library sharedlib)))
 
 ;; (defmacro call-jit-function

--- a/source/backends/JITCPUTensor/foreign-function.lisp
+++ b/source/backends/JITCPUTensor/foreign-function.lisp
@@ -30,4 +30,35 @@
 	       (alexandria:read-stream-content-into-string error-output))))
     (cffi:load-foreign-library sharedlib)))
 
-;; (defmacro call-jit-function
+(defun expand-funcall-form (function-name args views)
+  (declare (type string function-name)
+	   (type list args views))
+
+  (let ((view-count 0))
+    (flet ((read-view (nth)
+	     (let ((out (nth nth views)))
+	       out)))
+      `(cffi:foreign-funcall
+	,function-name
+	,@(if (null views)
+	      `(:uint32 0)
+	      `(:uint32 ,(size-of (car views) 0)))
+	,@(loop for arg in args
+		append
+		(typecase arg
+		  (JITCPUScalarTensor
+		   ;; pass the pointer directly
+		   ;; sb-ext:int-sap
+		   `(,(dtype arg) (tensor-vec ,arg)))
+		  (JITCPUTensor
+		   (prog1
+		       ;; tensor_ptr tensor_stride ...
+		       ;; (dtype val)
+		       `(:pointer
+			 (tensor-ptr ,arg :offset ,(offset-of (read-view view-count) 0))
+			 :int32;;(:pointer :int32)
+			 ,(stride-of (read-view view-count) 0))
+		     (incf view-count)))
+		  (T (error "unknown type of arguments: ~a" arg))))
+	:void))))
+

--- a/source/backends/JITCPUTensor/foreign-function.lisp
+++ b/source/backends/JITCPUTensor/foreign-function.lisp
@@ -33,8 +33,13 @@ Specify the command to compile the generated c codes. In default, \"gcc\"
       (unwind-protect (princ source input)
 	(close input))
       (unless (zerop (uiop:wait-process process-info))
-	(error "cl-waffe2/backends.jit.cpu: Failed to compile a shared library:~%~a~%"
-	       (alexandria:read-stream-content-into-string error-output))))
+	(error "cl-waffe2/backends.jit.cpu: Failed to compile a shared library:~%~a~%
+
+Compiled with: ~a
+Tips: Modify cl-waffe2/backends.jit.cpu:*default-c-compiler* to switch compilers for cl-waffe2 to use. (If the error is related to gcc.)"
+	       (alexandria:read-stream-content-into-string error-output)
+	       (with-output-to-string (out)
+		 (dolist (c cmd) (princ c out) (princ " " out))))))
     (cffi:load-foreign-library sharedlib)))
 
 (defun expand-funcall-form (function-name args views)
@@ -56,7 +61,7 @@ Specify the command to compile the generated c codes. In default, \"gcc\"
 		  (JITCPUScalarTensor
 		   ;; pass the pointer directly
 		   ;; sb-ext:int-sap
-		   `(,(dtype arg) (tensor-vec ,arg)))
+		   `(:pointer ,(int-sap-id arg)))
 		  (JITCPUTensor
 		   (prog1
 		       ;; tensor_ptr tensor_stride ...

--- a/source/backends/JITCPUTensor/impls/arithmetic.lisp
+++ b/source/backends/JITCPUTensor/impls/arithmetic.lisp
@@ -44,7 +44,7 @@
 			 nil)
 		       `(progn ,out)))
 
-(define-impl (cl-waffe2/base-impl::MoveScalarTensorNode :device JITScalarTensor :extends (CPUJIT-Scalar-Blueprint))
+(define-impl (cl-waffe2/base-impl::MoveScalarTensorNode :device JITCPUScalarTensor :extends (CPUJIT-Scalar-Blueprint))
 	     :forward ((self out target)
 		       (progn
 			 (setf (blueprint-use-var self) `(,out ,target))
@@ -102,7 +102,7 @@
 
 (macrolet ((define-sas-op (name lisp-op)
 	     `(define-impl (,name
-			    :device JITScalarTensor
+			    :device JITCPUScalarTensor
 			    :extends (CPUJIT-Scalar-Blueprint))
 			   :forward ((self A scalar)
 				     (progn

--- a/source/backends/JITCPUTensor/impls/arithmetic.lisp
+++ b/source/backends/JITCPUTensor/impls/arithmetic.lisp
@@ -1,0 +1,45 @@
+
+(in-package :cl-waffe2/backends.jit.cpu)
+
+
+;; Arithmetic operation family is originally declared as:
+;; X <- op(X, Y)
+(macrolet ((define-arith-impl (name lisp-op op-name)
+	     `(progn
+		(define-impl (,name
+			      :device JITCPUTensor
+			      :extends (CPUJIT-Blueprint))
+			     :forward ((self x y)
+				       ;; Called at a Toplevel
+				       (progn
+					 (setf (blueprint-use-var self) `(,x ,y))
+					 (setf (blueprint-opecode self) ',lisp-op)
+					 nil)
+
+				       ;; Embedding into JIT
+				       `(progn ,x)))
+
+		(defmethod translate-op ((opcode (eql ',lisp-op)) opAST &rest args)
+		  (make-inst :modify
+			     ,op-name
+			     (car args)
+			     (cdr args))))))
+  (define-arith-impl AddNode + "+=")
+  (define-arith-impl SubNode - "-=")
+  (define-arith-impl MulNode * "*=")
+  (define-arith-impl DivNode / "/="))
+
+(define-impl (MoveTensorNode :device JITCPUTensor :extends (CPUJIT-Blueprint))
+	     :forward ((self out target)
+		       (progn
+			 (setf (blueprint-use-var self) `(,out ,target))
+			 (setf (blueprint-opecode self) 'move)
+			 nil)
+		       `(progn ,out)))
+
+(defmethod translate-op ((opcode (eql 'move)) opAST &rest args)
+  ;; A <- B
+  (let ((self (tensor-backward (opAST-car opAST))))
+    (if (movetensor-ignore-me self)
+	(make-inst :ignore "" (second args) (second args))
+	(make-inst :modify "=" (car args) (cdr args)))))

--- a/source/backends/JITCPUTensor/impls/math.lisp
+++ b/source/backends/JITCPUTensor/impls/math.lisp
@@ -1,0 +1,3 @@
+
+(in-package :cl-waffe2/backends.jit.cpu)
+

--- a/source/backends/JITCPUTensor/impls/math.lisp
+++ b/source/backends/JITCPUTensor/impls/math.lisp
@@ -19,7 +19,7 @@
 			     (list (car inputs))))
 
 		(define-impl (,(symb 'scalar- node)
-			      :device JITScalarTensor
+			      :device JITCPUScalarTensor
 			      :extends (CPUJIT-Scalar-Blueprint))
 			     :forward ((self X out)
 				       (declare (ignore out))

--- a/source/backends/JITCPUTensor/impls/math.lisp
+++ b/source/backends/JITCPUTensor/impls/math.lisp
@@ -1,3 +1,68 @@
 
 (in-package :cl-waffe2/backends.jit.cpu)
 
+
+;; Mathmatical (one-arg) functions are defined as:
+;; X[~] OUT[~] -> OUT[~]
+;;
+
+(macrolet ((define-math-impl (node name c-func-name &key (cast nil))
+	     `(progn
+		(defmethod translate-op ((op (eql ',name)) opAST &rest inputs)
+		  (make-inst :apply
+			     (if ,cast
+				 (format nil "(~a)~a"
+					 (dtype->ctype (dtype (car inputs)))
+					 ,c-func-name)
+				 ,c-func-name)
+			     (second inputs)
+			     (list (car inputs))))
+
+		(define-impl (,(symb 'scalar- node)
+			      :device JITScalarTensor
+			      :extends (CPUJIT-Scalar-Blueprint))
+			     :forward ((self X out)
+				       (declare (ignore out))
+				       (progn
+					 (setf (blueprint-use-var self) `(,X))
+					 (setf (blueprint-opecode self) ',name)
+					 nil)
+				       `(progn ,X)))		
+
+		(define-impl (,node
+			      :device JITCPUTensor
+			      :extends (CPUJIT-Blueprint))
+			     :forward ((self X out)
+				       (declare (ignore out))
+				       (progn
+					 (setf (blueprint-use-var self) `(,X))
+					 (setf (blueprint-opecode self) ',name)
+					 nil)
+				       `(progn ,X))))))
+  (define-math-impl AbsNode abs       "abs")
+  (define-math-impl SignNode signum   "sign" :cast t)
+
+  (define-math-impl SqrtNode sqrt     "sqrt")
+  (define-math-impl SquareNode square "SQUARE_SCALAR")
+
+  (define-math-impl SinNode sin       "sin")
+  (define-math-impl ASinNode asin     "asin")
+  (define-math-impl SinhNode sinh     "sinh")
+  (define-math-impl ASinHNode asinh   "asinh")
+
+  (define-math-impl CosNode cos       "cos")
+  (define-math-impl AcosNode acos     "acos")
+  (define-math-impl CoshNode cosh     "cosh")
+  (define-math-impl AcosHNode acosh   "acosh")
+
+  (define-math-impl TanNode tan       "tan")
+  (define-math-impl ATanNode atan     "atan")
+  (define-math-impl TanhNode tanh     "tanh")
+  (define-math-impl ATanHNode atanh   "atanh")
+
+  (define-math-impl ExpNode exp       "exp")
+  (define-math-impl LogeNode log      "log")
+
+  (define-math-impl Log2Node log2     "log2")
+  (define-math-impl Log10Node log10   "log10"))
+

--- a/source/backends/JITCPUTensor/ir.lisp
+++ b/source/backends/JITCPUTensor/ir.lisp
@@ -1,0 +1,63 @@
+
+(in-package :cl-waffe2/backends.jit.cpu)
+
+
+(defvar *compiled-tensors* nil "An list of variables used in the computation node.")
+
+(defun add-variable (tensor)
+  ;; If the backward is MoveTensorNode
+  ;; ignore this function on some conditions
+  (unless (find tensor *compiled-tensors*)
+    (push tensor *compiled-tensors*)))
+
+(deftype ast-variable-types () `(and keyword (member :opAST :scalar :tensor :null)))
+
+(defstruct (iSeq
+	    (:constructor make-iseq (code displace-out-to)))
+  (code code :type (or symbol list))
+  (displace-out-to displace-out-to :type (or symbol list)))
+
+(defstruct (opAST
+	    (:constructor make-opAST (operation &rest args)))
+  "opAST is a data structure which is:
+[car args]
+      |
+    an list of AST_Variable"
+  (car  operation :type (or JITScalarTensor JITCPUTensor))
+  (args args :type list))
+
+(defstruct (AST-Variable
+	    (:constructor make-ast-variable
+		(content &aux (type (->op-type content)))))
+  (type type :type ast-variable-types)
+  (content content :type (or null opAST JITScalarTensor JITCPUTensor)))
+
+(defun ->op-type (obj)
+  (typecase obj
+    (opAST :opAST)
+    (JITCPUTensor :tensor)
+    (JITScalarTensor  :scalar)
+    (null :null)
+    (T (error "Detected unknown type of variable: ~a" obj))))
+
+(defun confirm-compiling-area (toplevel)
+  "Tracing the previous variables, returns AST of compiling region."
+  (declare (type (or JITScalarTensor JITCPUTensor) toplevel))
+
+  (add-variable toplevel)
+  (let* ((variables (tensor-variables toplevel)))
+    (apply #'make-opAST toplevel
+	   (loop for called-var in variables
+		 if (apply-compile-p toplevel called-var)
+		   collect (progn
+			     (add-variable called-var)
+			     (make-ast-variable called-var))
+		 else
+		   collect (make-ast-variable
+			    (confirm-compiling-area called-var))))))
+
+(defun ir->c (opAST)
+  (declare (type opAST opAST))
+
+  ""
+  )

--- a/source/backends/JITCPUTensor/ir.lisp
+++ b/source/backends/JITCPUTensor/ir.lisp
@@ -25,7 +25,7 @@
         |
 an list of AST_Variable
 "
-  (car  operation :type (or JITScalarTensor JITCPUTensor))
+  (car  operation :type (or JITCPUScalarTensor JITCPUTensor))
   (args args :type list))
 
 (defstruct (AST-Variable
@@ -33,19 +33,19 @@ an list of AST_Variable
 		(content &aux (type (->op-type content)))))
   "The end of opAST node."
   (type type :type ast-variable-types)
-  (content content :type (or null opAST JITScalarTensor JITCPUTensor)))
+  (content content :type (or null opAST JITCPUScalarTensor JITCPUTensor)))
 
 (defun ->op-type (obj)
   (typecase obj
     (opAST :opAST)
     (JITCPUTensor :tensor)
-    (JITScalarTensor  :scalar)
+    (JITCPUScalarTensor  :scalar)
     (null :null)
     (T (error "Detected unknown type of variable: ~a" obj))))
 
 (defun confirm-compiling-area (toplevel)
   "Tracing the previous variables, returns AST of compiling region."
-  (declare (type (or JITScalarTensor JITCPUTensor) toplevel))
+  (declare (type (or JITCPUScalarTensor JITCPUTensor) toplevel))
 
   (if (and (movetensor-p (tensor-backward toplevel))
 	   (movetensor-ignore-me (tensor-backward toplevel)))

--- a/source/backends/JITCPUTensor/ir.lisp
+++ b/source/backends/JITCPUTensor/ir.lisp
@@ -79,7 +79,6 @@ an list of AST_Variable
   (declare (type opAST opAST))
 
   (let ((code (blueprint-opecode (tensor-backward (opAST-car opAST)))))
-
     (loop for var in (opAST-args opAST)
 	  if (eql (ast-variable-type var) :opAST)
 	    do (ir->C (ast-variable-content var)))

--- a/source/backends/JITCPUTensor/ir.lisp
+++ b/source/backends/JITCPUTensor/ir.lisp
@@ -67,6 +67,12 @@ an list of AST_Variable
 		 collect (make-ast-variable
 			  (confirm-compiling-area called-var)))))
 
+;; FuseOPs ... opASTの合成演算を考える (e.g.: apply(apply(x)))
+;; コンパイルされたコードの最適化は後で考えよう
+;; ノードの中間地点: A=Bを削除したい
+;; しかし、副作用を期待している部分があるので安易に削除できないから
+;; チョットコマル
+
 (defun ir->c (opAST)
   "Recursively this function explores opAST, generating and writing C code to buffer."
   (declare (type opAST opAST))
@@ -93,14 +99,28 @@ an list of AST_Variable
 	 (write-c-line "~a ~a ~a;~%"
 		       (cAref (instruction-displace-to form))
 		       (instruction-fname form)
-		       (cAref (car (instruction-args form)))))
+		       (cAref (car (instruction-args form))))
+	 (write-c-line "~a ~a ~a;~%"
+		       (cAref (opAST-car opAST))
+		       "="
+		       (cAref (instruction-displace-to form)))
+	 )
 	(:apply
-	 
 
+	 
+	 (write-c-line "~a ~a ~a;~%"
+		       (cAref (opAST-car opAST))
+		       "="
+		       (cAref (instruction-displace-to form)))
 	 )
 	
 	(:set
 
+	 
+	 (write-c-line "~a ~a ~a;~%"
+		       (cAref (opAST-car opAST))
+		       "="
+		       (cAref (instruction-displace-to form)))
 	 )
 
 	(:ignore

--- a/source/backends/JITCPUTensor/ir.lisp
+++ b/source/backends/JITCPUTensor/ir.lisp
@@ -6,8 +6,7 @@
 (defvar *compiled-tensors* nil "An list of variables used in the computation node.")
 
 (defun add-variable (tensor)
-  ;; If the backward is MoveTensorNode
-  ;; ignore this function on some conditions
+  "Adds the given tensor to *compiled-tensors* if there's no duplicate"
   (unless (find tensor *compiled-tensors*)
     (push tensor *compiled-tensors*)))
 
@@ -16,7 +15,8 @@
 ;; opAST  = {Variable, Leaves}
 ;;
 
-(deftype ast-variable-types () `(and keyword (member :opAST :scalar :tensor :null)))
+(deftype ast-variable-types ()
+  `(and keyword (member :opAST :scalar :tensor :null)))
 
 (defstruct (opAST
 	    (:constructor make-opAST (operation &rest args)))
@@ -67,11 +67,12 @@ an list of AST_Variable
 		 collect (make-ast-variable
 			  (confirm-compiling-area called-var)))))
 
-;; FuseOPs ... opASTの合成演算を考える (e.g.: apply(apply(x)))
-;; コンパイルされたコードの最適化は後で考えよう
-;; ノードの中間地点: A=Bを削除したい
-;; しかし、副作用を期待している部分があるので安易に削除できないから
-;; チョットコマル
+;; ~~ TODO ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+;; Fuse operations ... would be realised by composing ops  (e.g.: apply(apply(x)))
+;; Delete: A ton of intermidate node, that is,: A=B
+;; However, some A=B nodes are needed and shouldn't be pruned, it interrupts optimizing generating codes...
+;; Anyway, confirm the very least work and then think about it.
+;; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 (defun ir->c (opAST)
   "Recursively this function explores opAST, generating and writing C code to buffer."
@@ -126,11 +127,12 @@ an list of AST_Variable
 	
 	(:set
 
+	 (error ":set isn't available currently")
 	 
-	 (write-c-line "~a ~a ~a;~%"
-		       (cAref (opAST-car opAST))
-		       "="
-		       (cAref (instruction-displace-to form)))
+	 ;; (write-c-line "~a ~a ~a;~%"
+	 ;;	       (cAref (opAST-car opAST))
+	 ;;	       "="
+	 ;;	       (cAref (instruction-displace-to form)))
 	 )
 
 	(:ignore

--- a/source/backends/JITCPUTensor/ir.lisp
+++ b/source/backends/JITCPUTensor/ir.lisp
@@ -7,7 +7,7 @@
 
 (defun add-variable (tensor)
   "Adds the given tensor to *compiled-tensors* if there's no duplicate"
-  (unless (find tensor *compiled-tensors*)
+  (unless (find (tensor-id tensor) *compiled-tensors* :key #'tensor-id)
     (push tensor *compiled-tensors*)))
 
 ;;
@@ -55,8 +55,8 @@ an list of AST_Variable
       
       ;; Otherwise, we can collect envolved tensors normally:
       (loop for var in (tensor-variables toplevel)
-	    if (apply-compile-p toplevel var)
-	      do (add-variable var)))
+	    ;; if (apply-compile-p toplevel var)
+	    do (add-variable var)))
 
   ;; Explore JITAble Nodes deeper:
   (apply #'make-opAST toplevel

--- a/source/backends/JITCPUTensor/ir.lisp
+++ b/source/backends/JITCPUTensor/ir.lisp
@@ -106,6 +106,16 @@ an list of AST_Variable
 		       (cAref (instruction-displace-to form)))
 	 )
 	(:apply
+	 ;; A[...] = f(A[...], B[...]);
+	 (write-c-line "~a = ~a(~a);~%"
+		       (cAref (instruction-displace-to form))
+		       (instruction-fname form)
+		       (with-output-to-string (out)
+			 (loop for arg in (instruction-args form)
+			       for i upfrom 0
+			       do (princ (cAref arg) out)
+			       unless (= i (1- (length (instruction-args form))))
+				 do (princ  ", " out))))
 
 	 
 	 (write-c-line "~a ~a ~a;~%"

--- a/source/backends/JITCPUTensor/ir.lisp
+++ b/source/backends/JITCPUTensor/ir.lisp
@@ -97,31 +97,31 @@ an list of AST_Variable
 	(:modify
 	 ;; A[...] += A[...];
 	 (write-c-line "~a ~a ~a;~%"
-		       (cAref (instruction-displace-to form))
+		       (cAref (instruction-displace-to form) :pointer t)
 		       (instruction-fname form)
-		       (cAref (car (instruction-args form))))
+		       (cAref (car (instruction-args form)) :pointer t))
 	 (write-c-line "~a ~a ~a;~%"
-		       (cAref (opAST-car opAST))
+		       (cAref (opAST-car opAST) :pointer t)
 		       "="
-		       (cAref (instruction-displace-to form)))
+		       (cAref (instruction-displace-to form) :pointer t))
 	 )
 	(:apply
 	 ;; A[...] = f(A[...], B[...]);
 	 (write-c-line "~a = ~a(~a);~%"
-		       (cAref (instruction-displace-to form))
+		       (cAref (instruction-displace-to form) :pointer t)
 		       (instruction-fname form)
 		       (with-output-to-string (out)
 			 (loop for arg in (instruction-args form)
 			       for i upfrom 0
-			       do (princ (cAref arg) out)
+			       do (princ (cAref arg :pointer t) out)
 			       unless (= i (1- (length (instruction-args form))))
 				 do (princ  ", " out))))
 
 	 
 	 (write-c-line "~a ~a ~a;~%"
-		       (cAref (opAST-car opAST))
+		       (cAref (opAST-car opAST) :pointer t)
 		       "="
-		       (cAref (instruction-displace-to form)))
+		       (cAref (instruction-displace-to form) :pointer t))
 	 )
 	
 	(:set

--- a/source/backends/JITCPUTensor/ir.lisp
+++ b/source/backends/JITCPUTensor/ir.lisp
@@ -2,6 +2,7 @@
 (in-package :cl-waffe2/backends.jit.cpu)
 
 
+;; On compiling, we gather tensors which envolved in compiling to *compiled-tensor*.
 (defvar *compiled-tensors* nil "An list of variables used in the computation node.")
 
 (defun add-variable (tensor)
@@ -10,25 +11,27 @@
   (unless (find tensor *compiled-tensors*)
     (push tensor *compiled-tensors*)))
 
-(deftype ast-variable-types () `(and keyword (member :opAST :scalar :tensor :null)))
+;;
+;; Trans: opAST -> <opAST>, Scalar, Tensor, nil
+;; opAST  = {Variable, Leaves}
+;;
 
-(defstruct (iSeq
-	    (:constructor make-iseq (code displace-out-to)))
-  (code code :type (or symbol list))
-  (displace-out-to displace-out-to :type (or symbol list)))
+(deftype ast-variable-types () `(and keyword (member :opAST :scalar :tensor :null)))
 
 (defstruct (opAST
 	    (:constructor make-opAST (operation &rest args)))
-  "opAST is a data structure which is:
-[car args]
-      |
-    an list of AST_Variable"
+  "
+    [car args]
+        |
+an list of AST_Variable
+"
   (car  operation :type (or JITScalarTensor JITCPUTensor))
   (args args :type list))
 
 (defstruct (AST-Variable
 	    (:constructor make-ast-variable
 		(content &aux (type (->op-type content)))))
+  "The end of opAST node."
   (type type :type ast-variable-types)
   (content content :type (or null opAST JITScalarTensor JITCPUTensor)))
 
@@ -44,20 +47,63 @@
   "Tracing the previous variables, returns AST of compiling region."
   (declare (type (or JITScalarTensor JITCPUTensor) toplevel))
 
-  (add-variable toplevel)
-  (let* ((variables (tensor-variables toplevel)))
-    (apply #'make-opAST toplevel
-	   (loop for called-var in variables
-		 if (apply-compile-p toplevel called-var)
-		   collect (progn
-			     (add-variable called-var)
-			     (make-ast-variable called-var))
-		 else
-		   collect (make-ast-variable
-			    (confirm-compiling-area called-var))))))
+  (if (and (movetensor-p (tensor-backward toplevel))
+	   (movetensor-ignore-me (tensor-backward toplevel)))
+      ;; MoveTensorNode: X[~] OUT[~] -> X[~]
+      ;; If pruned, X is never allocated/used.
+      (add-variable (second (tensor-variables toplevel)))
+      
+      ;; Otherwise, we can collect envolved tensors normally:
+      (loop for var in (tensor-variables toplevel)
+	    if (apply-compile-p toplevel var)
+	      do (add-variable var)))
+
+  ;; Explore JITAble Nodes deeper:
+  (apply #'make-opAST toplevel
+	 (loop for called-var in (tensor-variables toplevel)
+	       if (apply-compile-p toplevel called-var)
+		 collect (make-ast-variable called-var)
+	       else
+		 collect (make-ast-variable
+			  (confirm-compiling-area called-var)))))
 
 (defun ir->c (opAST)
+  "Recursively this function explores opAST, generating and writing C code to buffer."
   (declare (type opAST opAST))
 
-  ""
-  )
+  (let ((code (blueprint-opecode (tensor-backward (opAST-car opAST)))))
+
+    (loop for var in (opAST-args opAST)
+	  if (eql (ast-variable-type var) :opAST)
+	    do (ir->C (ast-variable-content var)))
+
+    
+    (let ((form
+	    (apply #'translate-op code opAST
+		   (loop for var in (opAST-args opAST)
+			 if (eql (ast-variable-type var) :opAST)
+			   collect (opAST-car (ast-variable-content var))
+			 if (or (eql (ast-variable-type var) :tensor)
+				(eql (ast-variable-type var) :scalar))
+			   collect (ast-variable-content var)))))
+
+      (case (Instruction-type form)
+	(:modify
+	 ;; A[...] += A[...];
+	 (write-c-line "~a ~a ~a;~%"
+		       (cAref (instruction-displace-to form))
+		       (instruction-fname form)
+		       (cAref (car (instruction-args form)))))
+	(:apply
+	 
+
+	 )
+	
+	(:set
+
+	 )
+
+	(:ignore
+	 
+	 )))))
+

--- a/source/backends/JITCPUTensor/on-finalizing.lisp
+++ b/source/backends/JITCPUTensor/on-finalizing.lisp
@@ -42,6 +42,7 @@
 	;;(format t "[INFO] Compiling nodes from ~a...~%" current-node)
 	;; Pass these informations to invoke-compiler! function
         (multiple-value-bind (variables source) (invoke-compiler! jit-function-name variable)
+	  (print source)
 	  (load-foreign-function source)
 	  (print source)
 	  (print (tensor-id variable)))

--- a/source/backends/JITCPUTensor/on-finalizing.lisp
+++ b/source/backends/JITCPUTensor/on-finalizing.lisp
@@ -41,8 +41,9 @@
 	(incf *compiling-ntime-count* 1)
 	;;(format t "[INFO] Compiling nodes from ~a...~%" current-node)
 	;; Pass these informations to invoke-compiler! function
-        (multiple-value-bind (variables kernel-code) (invoke-compiler! jit-function-name variable)
-	  (print kernel-code)
+        (multiple-value-bind (variables source) (invoke-compiler! jit-function-name variable)
+	  (load-foreign-function source)
+	  (print source)
 	  (print (tensor-id variable)))
 	
 	;; flowchart:

--- a/source/backends/JITCPUTensor/on-finalizing.lisp
+++ b/source/backends/JITCPUTensor/on-finalizing.lisp
@@ -1,0 +1,54 @@
+
+(in-package :cl-waffe2/backends.jit.cpu)
+
+;; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+;; Generating a C Code from cl-waffe2.
+;; The scope of JIT: Whether the generated code can be expressed with only one `for`.
+;; 
+;; 
+
+
+
+;; Memo: OffsetはLisp側で加算することにする
+;; Pragma SIMDで自動ベクトル化
+;; gemmはOpenBLASのAPIを呼び出す
+;; void NAME ...
+
+;; 
+
+(defparameter *includes*
+  `("immintrin.h" "stdbool.h" "math.h" "stdio.h" "stdint.h"))
+
+(defun place-toplevel-form (cffi-call-name tensors)
+  (write-buff "~%~%#pragma simd~%")
+  ;; #pragma GCC optimize ("O3")
+  ;; #pragma GCC target "avx2" avx512 ...
+  ;; ^ (TODO) cpu_has_avx512 ...
+  
+  (loop for include in *includes*
+	do (write-buff "#include <~a>~%" include))
+
+  (write-buff "~%~a;~%~%" (apply #'cFunction cffi-call-name tensors)))
+
+;; Tensor -> (Tensor-vec stride offset)
+(defun cFunction (function-name &rest arguments)
+  "Header:
+void function-name (int size, float * restrict x1, int stride, int offset, float* x2 ...)"
+
+  (let ((arguments-form
+	  (with-compiling-mode
+	    (write-buff "(uint32_t size, ")
+	    (loop for arg in arguments
+		  for n upfrom 0
+		  do (cVar arg
+			   :restrict (= 1 (count (tensor-id arg) arguments :key #'tensor-id))
+			   :comma (not (= n (1- (length arguments)))))
+		  if (typep arg 'JITCPUTensor)
+		    do (cStride arg :comma (not (= n (1- (length arguments))))))
+	    (write-buff ")"))))
+    (format nil "void ~a~a" function-name arguments-form)))
+
+;; Dynamically calls compiled c shared lib <-> Lisp Programs via CFFI.
+
+;; (defun call-c-form (tensors))
+

--- a/source/backends/JITCPUTensor/on-finalizing.lisp
+++ b/source/backends/JITCPUTensor/on-finalizing.lisp
@@ -43,7 +43,9 @@
 	;;(format t "[INFO] Compiling nodes from ~a...~%" current-node)
 	;; Pass these informations to invoke-compiler! function
         (multiple-value-bind (vars kernel-code) (invoke-compiler! jit-function-name variable)
-	  (print kernel-code))
+	  (print kernel-code)
+	  (print "RESULT")
+	  (print (tensor-id variable)))
 	
 	;; flowchart:
 	;;

--- a/source/backends/JITCPUTensor/on-finalizing.lisp
+++ b/source/backends/JITCPUTensor/on-finalizing.lisp
@@ -1,6 +1,14 @@
 
 (in-package :cl-waffe2/backends.jit.cpu)
 
+;;TODO:
+;;
+;; コンパイルオプションの設定
+;; 使うコンパイラを設定で宣言
+;; バグ修正 scalar mat?  これメインで動かすのでテストをちゃんと書く
+;; 演算の合成と計算ノードの最適化
+;; restrict option disassemble it.
+
 ;; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ;; Generating a C Code from cl-waffe2.
 ;; The scope of JIT: Whether the generated code can be expressed with only one `for`.
@@ -37,7 +45,7 @@
 				    next-variable)
   "If the node is needed to be compiled, compile."
   (if (apply-compile-p variable next-variable)
-      (let ((jit-function-name (symbol-name (gensym "JIT_FUNCTION"))))
+      (let ((jit-function-name (symbol-name (gensym "CL_WAFFE2_C_KERNEL"))))
 	(incf *compiling-ntime-count* 1)
 	;;(format t "[INFO] Compiling nodes from ~a...~%" current-node)
 	;; Pass these informations to invoke-compiler! function
@@ -61,6 +69,7 @@
 		       :at-least-dim 1))))
 	    `(progn
 	       ,call-form
+	       ;;(print ,variable)
 	       ;; Overwrite the results
 	       (setf (cl-waffe2/vm.generic-tensor::statecontainer-forward-result (tensor-state ,variable))
 		     (list ,variable))))))

--- a/source/backends/JITCPUTensor/on-finalizing.lisp
+++ b/source/backends/JITCPUTensor/on-finalizing.lisp
@@ -31,8 +31,7 @@
 
 (defparameter *compiling-ntime-count* 0)
 
-
-;; MEMO: proceedモードで動作するときはevalする？
+;; Note: eval it when called with vm-build?
 (defmethod on-finalizing-compiling ((current-node CPUJIT-Blueprint)
 				    variable
 				    next-variable)
@@ -42,9 +41,8 @@
 	(incf *compiling-ntime-count* 1)
 	;;(format t "[INFO] Compiling nodes from ~a...~%" current-node)
 	;; Pass these informations to invoke-compiler! function
-        (multiple-value-bind (vars kernel-code) (invoke-compiler! jit-function-name variable)
+        (multiple-value-bind (variables kernel-code) (invoke-compiler! jit-function-name variable)
 	  (print kernel-code)
-	  (print "RESULT")
 	  (print (tensor-id variable)))
 	
 	;; flowchart:

--- a/source/backends/JITCPUTensor/package.lisp
+++ b/source/backends/JITCPUTensor/package.lisp
@@ -1,0 +1,35 @@
+
+(in-package :cl-user)
+
+;; TODO: Delete JITLispTensor
+
+(defpackage :cl-waffe2/backends.jit.cpu
+  (:documentation "from cl-waffe2 to C Compiler and oneDNN Support?")
+  (:use :cl
+   :cl-waffe2/distributions
+        :cl-waffe2/vm.generic-tensor
+   :cl-waffe2/vm.nodes
+        :cl-waffe2/base-impl)
+  (:export
+   #:JITCPUTensor))
+
+(in-package :cl-waffe2/backends.jit.cpu)
+
+(defun compose (&rest fns)
+  "fn_1(fn_2(fn_n...))"
+  (if fns
+      (let ((fn1 (car (last fns)))
+            (fns (butlast fns)))
+        #'(lambda (&rest args)
+            (reduce #'funcall fns
+                    :from-end t
+                    :initial-value (apply fn1 args))))
+      #'identity))
+
+(defun symb (&rest inputs)
+  (intern (with-output-to-string (out) (dolist (sym inputs) (princ sym out)))))
+
+(defmacro with-ez-to-view (&body body)
+  `(let ((*with-printing-tensor-omitted* t))
+     ,@body))
+

--- a/source/backends/JITCPUTensor/package.lisp
+++ b/source/backends/JITCPUTensor/package.lisp
@@ -11,7 +11,8 @@
    :cl-waffe2/vm.nodes
         :cl-waffe2/base-impl)
   (:export
-   #:JITCPUTensor))
+   #:JITCPUTensor
+   #:JITCPUScalarTensor))
 
 (in-package :cl-waffe2/backends.jit.cpu)
 

--- a/source/backends/JITCPUTensor/package.lisp
+++ b/source/backends/JITCPUTensor/package.lisp
@@ -13,7 +13,8 @@
   (:export
    #:*default-c-compiler*
    #:JITCPUTensor
-   #:JITCPUScalarTensor))
+   #:JITCPUScalarTensor
+   #:with-cpu-jit))
 
 (in-package :cl-waffe2/backends.jit.cpu)
 

--- a/source/backends/JITCPUTensor/package.lisp
+++ b/source/backends/JITCPUTensor/package.lisp
@@ -6,11 +6,12 @@
 (defpackage :cl-waffe2/backends.jit.cpu
   (:documentation "from cl-waffe2 to C Compiler and oneDNN Support?")
   (:use :cl
-   :cl-waffe2/distributions
+        :cl-waffe2/distributions
         :cl-waffe2/vm.generic-tensor
-   :cl-waffe2/vm.nodes
+        :cl-waffe2/vm.nodes
         :cl-waffe2/base-impl)
   (:export
+   #:*default-c-compiler*
    #:JITCPUTensor
    #:JITCPUScalarTensor))
 

--- a/source/backends/JITCPUTensor/t/package.lisp
+++ b/source/backends/JITCPUTensor/t/package.lisp
@@ -1,0 +1,30 @@
+
+(in-package :cl-user)
+
+(defpackage :cl-waffe2/backends.jit.cpu.test
+  (:use :cl :cl-waffe2 :cl-waffe2/distributions :cl-waffe2/base-impl :cl-waffe2/vm.generic-tensor :cl-waffe2/vm.nodes :cl-waffe2/backends.cpu :cl-waffe2/backends.jit.cpu :fiveam :cl-waffe2/base-impl.test))
+
+(in-package :cl-waffe2/backends.jit.cpu.test)
+
+(def-suite :jit-cpu-test)
+
+(in-suite :jit-cpu-test)
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  
+(add-tester JITCPUTensor)
+(sub-tester JITCPUTensor)
+(mul-tester JITCPUTensor)
+(div-tester JITCPUTensor)
+(move-tester JITCPUTensor)
+
+(scalar-add-tester JITCPUTensor JITCPUScalarTensor)
+(scalar-sub-tester JITCPUTensor JITCPUScalarTensor)
+(scalar-mul-tester JITCPUTensor JITCPUScalarTensor)
+(scalar-div-tester JITCPUTensor JITCPUScalarTensor)
+
+(sum-tester LispTensor JITCPUScalarTensor)
+
+(mathematical-test-set JITCPUTensor JITCPUScalarTensor)
+)
+

--- a/source/backends/JITCPUTensor/tensor.lisp
+++ b/source/backends/JITCPUTensor/tensor.lisp
@@ -2,6 +2,8 @@
 (in-package :cl-waffe2/backends.jit.cpu)
 
 (defclass JITCPUTensor (cl-waffe2/backends.cpu:CPUTensor) nil)
+
+;; TODO: Rename -> JITCPUScalarTensor
 (defclass JITScalarTensor (cl-waffe2/vm.generic-tensor:ScalarTensor) nil)
 
 (deftype JITAbleTensors ()

--- a/source/backends/JITCPUTensor/tensor.lisp
+++ b/source/backends/JITCPUTensor/tensor.lisp
@@ -15,7 +15,7 @@
 
 ;; Memo: https://groups.google.com/g/comp.lang.lisp/c/4aDbcVUBraQ
 ;; Pinning Arrays?
-
+;; TODO: Do it outside call-with-view
 (declaim (inline tensor-ptr))
 (defun tensor-ptr (tensor &key (offset 0))
   (declare (type JITCPUTensor tensor)

--- a/source/backends/JITCPUTensor/tensor.lisp
+++ b/source/backends/JITCPUTensor/tensor.lisp
@@ -2,8 +2,14 @@
 (in-package :cl-waffe2/backends.jit.cpu)
 
 (defclass JITCPUTensor (cl-waffe2/backends.cpu:CPUTensor) nil)
+(defclass JITScalarTensor (cl-waffe2/vm.generic-tensor:ScalarTensor) nil)
 
 (deftype JITAbleTensors ()
   "JITAbleTensor is tensors which are subject to be compiled: JITCPUTensor and ScalarTensor."
   `(or JITCPUTensor cl-waffe2/vm.generic-tensor:ScalarTensor))
+
+(defmacro with-cpu-jit ((&rest more-devices) &body body)
+  `(with-devices (JITCPUTensor JITScalarTensor ,@more-devices)
+     ,@body))
+
 

--- a/source/backends/JITCPUTensor/tensor.lisp
+++ b/source/backends/JITCPUTensor/tensor.lisp
@@ -1,0 +1,9 @@
+
+(in-package :cl-waffe2/backends.jit.cpu)
+
+(defclass JITCPUTensor (cl-waffe2/backends.cpu:CPUTensor) nil)
+
+(deftype JITAbleTensors ()
+  "JITAbleTensor is tensors which are subject to be compiled: JITCPUTensor and ScalarTensor."
+  `(or JITCPUTensor cl-waffe2/vm.generic-tensor:ScalarTensor))
+

--- a/source/backends/JITCPUTensor/tensor.lisp
+++ b/source/backends/JITCPUTensor/tensor.lisp
@@ -3,15 +3,14 @@
 
 (defclass JITCPUTensor (cl-waffe2/backends.cpu:CPUTensor) nil)
 
-;; TODO: Rename -> JITCPUScalarTensor
-(defclass JITScalarTensor (cl-waffe2/vm.generic-tensor:ScalarTensor) nil)
+(defclass JITCPUScalarTensor (cl-waffe2/vm.generic-tensor:ScalarTensor) nil)
 
 (deftype JITAbleTensors ()
   "JITAbleTensor is tensors which are subject to be compiled: JITCPUTensor and ScalarTensor."
-  `(or JITCPUTensor cl-waffe2/vm.generic-tensor:ScalarTensor))
+  `(or JITCPUTensor JITCPUScalarTensor))
 
 (defmacro with-cpu-jit ((&rest more-devices) &body body)
-  `(with-devices (JITCPUTensor JITScalarTensor ,@more-devices)
+  `(with-devices (JITCPUTensor JITCPUScalarTensor ,@more-devices)
      ,@body))
 
 

--- a/source/backends/JITCPUTensor/tensor.lisp
+++ b/source/backends/JITCPUTensor/tensor.lisp
@@ -13,6 +13,8 @@
   `(with-devices (JITCPUTensor JITCPUScalarTensor ,@more-devices)
      ,@body))
 
+;; Memo: https://groups.google.com/g/comp.lang.lisp/c/4aDbcVUBraQ
+;; Pinning Arrays?
 
 (declaim (inline tensor-ptr))
 (defun tensor-ptr (tensor &key (offset 0))

--- a/source/backends/JITCPUTensor/tensor.lisp
+++ b/source/backends/JITCPUTensor/tensor.lisp
@@ -14,3 +14,13 @@
      ,@body))
 
 
+(declaim (inline tensor-ptr))
+(defun tensor-ptr (tensor &key (offset 0))
+  (declare (type JITCPUTensor tensor)
+	   (type fixnum offset))
+  #+sbcl
+  (let ((ptr (sb-sys:vector-sap (sb-ext:array-storage-vector (the (simple-array * (*)) (tensor-vec tensor))))))
+    (locally (declare (optimize (speed 1) (safety 1)))
+      (cffi:incf-pointer ptr (the fixnum (* (the fixnum (cffi:foreign-type-size (dtype tensor))) offset)))))
+  #-(or sbcl)
+  (error "JITCPUTensor requires SBCL to access the storage vector!"))

--- a/source/backends/JITLispTensor/t/compiler.lisp
+++ b/source/backends/JITLispTensor/t/compiler.lisp
@@ -22,6 +22,10 @@
 (in-suite :jit-lisp-test)
 
 ;; Check compiler can detect the change of shape, devices.
+
+;; This test is no longer working...
+
+#|
 (test delimiting-compilable-nodes
   (is (let ((cl-waffe2/backends.jit.lisp::*compiling-ntime-count* 0))
 	(test-case-tmp)
@@ -30,7 +34,7 @@
 	(test-case-tmp1)
 	(= cl-waffe2/backends.jit.lisp::*compiling-ntime-count* 1))))
 
-
+|#
 
 ;; Test Case
 ;; A+=B

--- a/source/base-impl/ir.lisp
+++ b/source/base-impl/ir.lisp
@@ -1,0 +1,83 @@
+
+(in-package :cl-waffe2/base-impl)
+
+;; ir.lisp provides AbstractNodes and its implementation of controling flows of nodes
+
+;; Principle Nodes:
+;;   IfNode
+;;   LoopNode
+
+
+;; Unsafe of number of arguments
+;; There should be something better way to deal with flexible arguments.
+
+;; IfNode ... then/elseの帰り値が複数だったら？？？
+
+#|
+(defnode (IfNode (self condition then else)
+	  :documentation "
+```lisp
+             out
+              |
+   [IfNode cond = `(> a 1)]
+ then  |              | else
+    [Node1]         [Node2]
+       |              |
+       ----------------
+              |
+           result
+```
+
+(call (IfNode `(> n 1) (SinNode) (CosNode))
+      (randn `(3 3))
+      (randn `(3 3)))
+"
+	  :where (Out[~] -> Result[~]) ;; Multiple arguments?
+	  :slots ((condition :initarg :condition :reader cond-of :type list)
+		  (then :initarg :then :reader then-of :type AbstractTensor)
+		  (else :initarg :else :reader else-of :type AbstractTensor)
+		  (built-then :accessor then-model :type Compiled-Composite)
+		  (built-else :accessor else-model :type Compiled-Composite))
+	  :backward ((self dout out)
+		     (declare (ignore dout out))
+		     (let ((then (then-model self))
+			   (else (else-model self)))
+		       (values
+			(!mul 0 (lazy-if (cond-of self)
+					 then
+					 else)))))))
+
+
+(define-impl (IfNode :device t
+		     :cache-when-compiled nil)
+	     :forward ((self out)
+		       (declare (ignore out))
+		       (let ((then (build (then-of self)))
+			     (else (build (else-of self))))
+			 (setf (then-model self) then
+			       (else-model self) else)
+			 `(progn
+			    (cl-waffe2/vm.generic-tensor::declare-compiled-composite ,then)
+			    (cl-waffe2/vm.generic-tensor::declare-compiled-composite ,else)
+			    (if ,(cond-of self)
+				(forward ,then)
+				(forward ,else))))))
+
+(defmacro lazy-if (condition then else)
+  `(call (IfNode ,condition ,then ,else) (make-clone ,then)))
+
+
+(defun ?all (tensor)
+  (print tensor)
+  nil)
+
+(defun test-case ()
+  (let ((a (!sin (ax+b `(3 3) 1 0)))
+	(b (!sin (ax+b `(3 3) 1 0))))
+    (lazy-if (?all (A>B a b))
+	     (lazy-print (!sum (!sub a b)))
+	     (lazy-print (!sum (!add a b))))))
+
+|#
+
+

--- a/source/base-impl/ir.lisp
+++ b/source/base-impl/ir.lisp
@@ -1,83 +1,12 @@
 
 (in-package :cl-waffe2/base-impl)
 
-;; ir.lisp provides AbstractNodes and its implementation of controling flows of nodes
-
-;; Principle Nodes:
+;; [TODO] :
+;;  ir.lisp provides nodes which controls the flow of nodes:
+;;
 ;;   IfNode
-;;   LoopNode
-
-
-;; Unsafe of number of arguments
-;; There should be something better way to deal with flexible arguments.
-
-;; IfNode ... then/elseの帰り値が複数だったら？？？
-
-#|
-(defnode (IfNode (self condition then else)
-	  :documentation "
-```lisp
-             out
-              |
-   [IfNode cond = `(> a 1)]
- then  |              | else
-    [Node1]         [Node2]
-       |              |
-       ----------------
-              |
-           result
-```
-
-(call (IfNode `(> n 1) (SinNode) (CosNode))
-      (randn `(3 3))
-      (randn `(3 3)))
-"
-	  :where (Out[~] -> Result[~]) ;; Multiple arguments?
-	  :slots ((condition :initarg :condition :reader cond-of :type list)
-		  (then :initarg :then :reader then-of :type AbstractTensor)
-		  (else :initarg :else :reader else-of :type AbstractTensor)
-		  (built-then :accessor then-model :type Compiled-Composite)
-		  (built-else :accessor else-model :type Compiled-Composite))
-	  :backward ((self dout out)
-		     (declare (ignore dout out))
-		     (let ((then (then-model self))
-			   (else (else-model self)))
-		       (values
-			(!mul 0 (lazy-if (cond-of self)
-					 then
-					 else)))))))
-
-
-(define-impl (IfNode :device t
-		     :cache-when-compiled nil)
-	     :forward ((self out)
-		       (declare (ignore out))
-		       (let ((then (build (then-of self)))
-			     (else (build (else-of self))))
-			 (setf (then-model self) then
-			       (else-model self) else)
-			 `(progn
-			    (cl-waffe2/vm.generic-tensor::declare-compiled-composite ,then)
-			    (cl-waffe2/vm.generic-tensor::declare-compiled-composite ,else)
-			    (if ,(cond-of self)
-				(forward ,then)
-				(forward ,else))))))
-
-(defmacro lazy-if (condition then else)
-  `(call (IfNode ,condition ,then ,else) (make-clone ,then)))
-
-
-(defun ?all (tensor)
-  (print tensor)
-  nil)
-
-(defun test-case ()
-  (let ((a (!sin (ax+b `(3 3) 1 0)))
-	(b (!sin (ax+b `(3 3) 1 0))))
-    (lazy-if (?all (A>B a b))
-	     (lazy-print (!sum (!sub a b)))
-	     (lazy-print (!sum (!add a b))))))
-
-|#
+;;   MapNode
+;;   RecurrentNode
+;;
 
 

--- a/source/base-impl/t/mathematical.lisp
+++ b/source/base-impl/t/mathematical.lisp
@@ -143,22 +143,22 @@
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (export 'mathematical-test-set)
-  (defmacro mathematical-test-set (backend)
+  (defmacro mathematical-test-set (&rest backend)
     `(eval-when (:compile-toplevel :load-toplevel :execute)
-       (abs-tester ,backend)
-       (sign-tester ,backend)
-       (sqrt-tester ,backend)
-       (square-tester ,backend)
+       (abs-tester ,@backend)
+       (sign-tester ,@backend)
+       (sqrt-tester ,@backend)
+       (square-tester ,@backend)
        
-       (sin-tester ,backend)
-       (cos-tester ,backend)
+       (sin-tester ,@backend)
+       (cos-tester ,@backend)
        ;;(tan-tester ,backend)
        ;; To Add: trig func fam
 
-       (exp-tester ,backend)
-       (log2-tester ,backend)
-       (log10-tester ,backend)
-       (logE-tester ,backend)
+       (exp-tester ,@backend)
+       (log2-tester ,@backend)
+       (log10-tester ,@backend)
+       (logE-tester ,@backend)
        ;; add: expt
        )))
 			

--- a/source/base-impl/t/package.lisp
+++ b/source/base-impl/t/package.lisp
@@ -35,11 +35,11 @@
      (export ',name)
      ;; You can use this macro for testing other backends, other dtypes.
      
-     (defmacro ,name (backend)
+     (defmacro ,name (&rest backend)
        #+sbcl(declare (sb-ext:muffle-conditions cl:style-warning))
-       `(let ((*using-backend* '`(,,backend)))
+       `(let ((*using-backend* '`(,,@backend)))
 	  ,@(map 'list #'(lambda (dtype)
-			   `(test ,(symb ', name '- dtype '- backend)
+			   `(test ,(symb ', name '- dtype '- (car backend))
 			      (is (with-dtype ,dtype
 				    (with-memory-pool
 				      (let ((result (progn ,,@body)))

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -27,6 +27,8 @@
    #:with-column-major
    #:with-row-major
    #:with-cpu
+
+   #:set-devices-toplevel
    ;;#:with-cuda
    )
 

--- a/source/utils.lisp
+++ b/source/utils.lisp
@@ -28,7 +28,6 @@
      ,@body))
 
 ;; Broadcast_Auto shouldn't be modular, all the nodes defined in cl-waffe2, should work under all combines of config.
-
 (defmacro with-config ((&key
 			  ;; TO ADD:
 			  ;; Global Dtype
@@ -75,4 +74,15 @@
 		      (find :initarg slots))
 		   slots))
        slots))
+
+
+(defun set-devices-toplevel (&rest devices)
+  "
+## [function] set-devices-toplevel
+"
+  (assert (every #'(lambda (x) (subtypep x 'AbstractTensor)) devices)
+	  nil
+	  "set-devices-toplevel: the given device isn't subtype of AbstractTensor: ~a" devices)
+  
+  (setf cl-waffe2/vm.generic-tensor:*using-backend* devices))
 

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -301,6 +301,8 @@ permute-order : ~a
   (shape-equal-list declared-shape (shape tensor)))
 
 ;; TODO: read-result should be inlined
+(declaim (inline read-result)
+	 (ftype (function (AbstractTensor) AbstractTensor) read-result))
 (defun read-result (tensor)
  "Returns the result of computing of tensor in the compiled code"
   (declare (type AbstractTensor tensor))

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -300,13 +300,14 @@ permute-order : ~a
 
   (shape-equal-list declared-shape (shape tensor)))
 
+;; TODO: read-result should be inlined
 (defun read-result (tensor)
  "Returns the result of computing of tensor in the compiled code"
   (declare (type AbstractTensor tensor))
 
   (let ((state (tensor-state tensor)))
     (if state
-	(nth (tensor-out-n tensor) (statecontainer-forward-result (tensor-state tensor)))
+        (nth (tensor-out-n tensor) (the list (statecontainer-forward-result (tensor-state tensor))))
 	tensor)))
 
 ;; Set *runtime-shape-inspection* = t to detect run-time shape-error
@@ -372,19 +373,19 @@ Tracing until one of variables reached a toplevel tensor (detach-p is t or no ba
 	     (setf (statecontainer-backward-result (tensor-state ,(tensor-id toplevel)))
 		   (list (null (statecontainer-forward-result (tensor-state ,(tensor-id toplevel)))))))
 
+
+	   ;; Calls an event: on-finalizing-compiling
+	   ;; If JIT is implemented by user, expand user defined forms
 	   
 	   (setf (statecontainer-forward-result (tensor-state ,(tensor-id toplevel)))
 		 (multiple-value-list (call-kernel ,fw-compiled ,@(map 'list #'tensor-id vars)))))
-	 
-	 ;; Calls an event: on-finalizing-compiling
-	 ;; If JIT is implemented by user, expand user defined forms
-	 
+
 	 ,(when (tensor-backward toplevel)
 	    (cl-waffe2/vm.nodes:on-finalizing-compiling
 	     (tensor-backward toplevel)
 	     toplevel
 	     called-with-vars))
-	   
+	 
 
 	 ;; TODO UPDATE
 	 ,(when (and node
@@ -404,7 +405,6 @@ The definition/implementation of nodes could be invaild."
 		,node
 		(nth ,(tensor-out-n toplevel) ',(cl-waffe2/vm.nodes:node-output-shape node))
 		(shape (nth ,(tensor-out-n toplevel) (statecontainer-forward-result (tensor-state ,(tensor-id toplevel)))))))) ;; Output shape compiled
-	 
 	 
 	 (nth ,(tensor-out-n toplevel) (statecontainer-forward-result (tensor-state ,(tensor-id toplevel))))))))
 

--- a/source/vm/generic-tensor/cache.lisp
+++ b/source/vm/generic-tensor/cache.lisp
@@ -68,6 +68,7 @@
 (defstruct Compiled-Kernel
   (name nil :type symbol)            ;; SinNode-CPUTENSOR
   (body nil :type list)              ;; (named-lambda ... () ...)
+  (cache-when-compiled nil :type boolean)
   (cache-p nil :type boolean)
   (args nil :type list)
   (view-route nil :type list)) ;; 2D 3D Flatten ...
@@ -218,11 +219,12 @@ Reading *kernel-storeroom*, the function expands the form below.
 		 args)))
     (if (null target)
 	(let ((compiled-function (make-funcallable-kernel kernel-function compile-option)))
-	  (lut-search-function
-	   *compiled-function-cache*
-	   (compiled-kernel-name kernel-function)
-	   args
-	   :setme compiled-function)
+	  (when (compiled-kernel-cache-when-compiled kernel-function)
+	    (lut-search-function
+	     *compiled-function-cache*
+	     (compiled-kernel-name kernel-function)
+	     args
+	     :setme compiled-function))
 	  (apply compiled-function args))
 	(apply target args))))
 

--- a/source/vm/generic-tensor/interpreter.lisp
+++ b/source/vm/generic-tensor/interpreter.lisp
@@ -48,7 +48,6 @@
   (declare (type AbstractTensor toplevel)
 	   (type boolean stop-me)
 	   (optimize (speed 3)))
-  (declare (ignore called-with-vars))
 
   (when (or stop-me
 	    (null (tensor-state toplevel)))
@@ -62,7 +61,6 @@
 	 (vars  (tensor-variables toplevel))
 	 (node  (tensor-backward toplevel))
 	 (compiled-fw (statecontainer-forward-out-form state)))
-    (declare (ignore node))
 
     (let ((next-states (map 'list #'(lambda (x) (run-node! x :stop-me stop-me :called-with-vars toplevel :compile-option compile-option)) vars)))
       (register-variables vars)
@@ -81,17 +79,18 @@
       ;; Calling User-defined JIT Compiler
 
       ;; = [FIXME] ======
-      ;; JITが今のところ動作しない
-      ;; 埋め込まれたコードにTensorIDが直接埋め込まれている。
-      ;; Cacheの検索をどうやってやるかが課題になる。
-
-      #|
+      ;; JIT isn't working on interpreter mode.
+      ;; eval?
+      
+      
       (when node
-	(cl-waffe2/vm.nodes:on-finalizing-compiling
-	 node
-	 toplevel
-         called-with-vars))
-      |#
+	(let ((result (cl-waffe2/vm.nodes:on-finalizing-compiling
+		       node
+		       toplevel
+		       called-with-vars)))
+	  (when result
+	    (eval result))))
+      
 
       ;; on-calling-finalizing...
       (nth (tensor-out-n toplevel) (statecontainer-forward-result state)))))

--- a/source/vm/generic-tensor/package.lisp
+++ b/source/vm/generic-tensor/package.lisp
@@ -94,7 +94,10 @@
   ;; APIs for StateContainer
   (:export
    #:statecontainer
+   #:statecontainer-forward-out-form
    #:make-statecontainer
+
+   #:compiled-kernel-body
    )
 
   (:export

--- a/source/vm/nodes/defnode.lisp
+++ b/source/vm/nodes/defnode.lisp
@@ -84,6 +84,7 @@ reject-when=nil, or (apply reject-when inputs)=t"
    :name name
    :body body
    :args args
+   :cache-when-compiled traceable?
    :cache-p (when (and traceable? *call-with-view-route*) t)
    :view-route (if (and traceable? *call-with-view-route*)
 		   *call-with-view-route*)))


### PR DESCRIPTION
I've added new backends: `JITCPUTensor` and `JITCPUScalarTensor` which works by dynamically compiling the cl-waffe2 program into a C program. and not they're available on `:cl-waffe2/backends.jit.cpu` package and enabled under the `(with-cpu-jit &body body)` macro.

Note that this feature is still in the experimental stage. In fact, the generated C code is still redundant and not optimised in any way. In addition, it has not yet been fully tested and is unstable.