### PR TITLE
[JIT] Complicated Views Supporting

### DIFF
--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -183,6 +183,7 @@
 	       (:file "backends/lisp/t/package")
 
 	       (:file "backends/JITCPUTensor/t/package")
+	       (:file "backends/JITCPUTensor/t/jit")
 	       
 	       (:file "backends/JITLispTensor/t/package")
 	       (:file "backends/JITLispTensor/t/compiler")

--- a/source/backends/JITCPUTensor/compiler.lisp
+++ b/source/backends/JITCPUTensor/compiler.lisp
@@ -86,7 +86,7 @@ Return: (values arguments envolved-tensors(but ScalarTensor) scalars toplevel)
 "
   (declare (type JITAbleTensors toplevel))
 
-  (let* ((*compiled-tensors* `(,toplevel))
+  (let* ((*compiled-tensors* `())
 	 (envolved-nodes (confirm-compiling-area toplevel))
 	 (function-form  (apply #'cFunction function-name *compiled-tensors*))
 	 (tensors (loop for tensor in *compiled-tensors*
@@ -102,6 +102,18 @@ Return: (values arguments envolved-tensors(but ScalarTensor) scalars toplevel)
      scalars
      (with-compiling-mode
        (place-toplevel-form function-name *compiled-tensors*)
+
+       
+       (write-buff "~%// [~a Tensors]~%" (length tensors))
+       (dolist (tensor tensors)
+	 (write-buff "// ~a: ~a ~a~%"
+		     (tensor-id tensor)
+		     (shape tensor)
+		     (tensor-attribute tensor)))
+       (write-buff "~%// [~a Scalars]~%" (length scalars))
+       (dolist (tensor scalars)
+	 (write-buff "// ~a: ~a ~a~%" (tensor-id tensor) (shape tensor) (tensor-attribute tensor)))
+       
        ;; void function-name (...) { ...
        (write-buff "~a { ~%" function-form)
        (if (null tensors)

--- a/source/backends/JITCPUTensor/compiler.lisp
+++ b/source/backends/JITCPUTensor/compiler.lisp
@@ -77,6 +77,12 @@ void function-name (int size, float * restrict x1, int stride, int offset, float
 	    (write-buff ")"))))
     (format nil "void ~a~a~%" function-name arguments-form)))
 
+(defun insert-loop-for ()
+  (let ((back-indent-size (max 0 (- *indent-width* 4))))
+    (with-indent back-indent-size
+      (write-c-line "}~%~%")
+      (write-c-line "for(int i=0; i<size; i++) {~%"))))
+
 ;; [TODO] Printing JIT Compiler Report
 (defun invoke-compiler! (function-name toplevel)
   "

--- a/source/backends/JITCPUTensor/compiler.lisp
+++ b/source/backends/JITCPUTensor/compiler.lisp
@@ -28,21 +28,22 @@
 
 (defun place-toplevel-form (cffi-call-name tensors)
   "Places headers, function definition and macros."
-  
-  (write-buff "~%#pragma SIMD~%")
-  ;;(write-buff "#pragma GCC optimize (\"O3\")~%")
-  ;;(write-buff "#pragma GCC target \"avx2\"")
-  ;; #pragma GCC target "avx2" avx512 ...
-  
-  (loop for include in *includes*
-	do (write-buff "#include <~a>~%" include))
 
-  (write-buff "~%~a;~%~%" (apply #'cFunction cffi-call-name tensors))
+  (when (null *caching-c-source*) 
+    (write-buff "~%#pragma SIMD~%")
+    ;;(write-buff "#pragma GCC optimize (\"O3\")~%")
+    ;;(write-buff "#pragma GCC target \"avx2\"")
+    ;; #pragma GCC target "avx2" avx512 ...
+    
+    (loop for include in *includes*
+	  do (write-buff "#include <~a>~%" include))
 
-  ;; Utils
-  (write-buff "#define INV_SCALAR(scal) 1 / scal;~%~%")
-  (write-buff "#define SQUARE_SCALAR(scal) scal * scal;~%~%")
-  )
+    (write-buff "~%~a;~%~%" (apply #'cFunction cffi-call-name tensors))
+
+    ;; Utils
+    (write-buff "#define INV_SCALAR(scal) 1 / scal;~%~%")
+    (write-buff "#define SQUARE_SCALAR(scal) scal * scal;~%~%")
+    ))
 
 (defun cAref (tensor &key (pointer nil))
   "Reading the given tensor's id, the function returns a string which corresponds to aref in C"

--- a/source/backends/JITCPUTensor/foreign-function.lisp
+++ b/source/backends/JITCPUTensor/foreign-function.lisp
@@ -77,10 +77,9 @@ Tips: Modify cl-waffe2/backends.jit.cpu:*default-c-compiler* to switch compilers
 		  (JITCPUTensor
 		   (prog1
 		       ;; tensor_ptr tensor_stride ...
-		       ;; (dtype val)
 		       `(:pointer
 			 (tensor-ptr (read-result ,arg) :offset ,(offset-of (read-view view-count) 0))
-			 :int32;;(:pointer :int32)
+			 :int32
 			 ,(stride-of (read-view view-count) 0))
 		     (incf view-count)))
 		  (T (error "unknown type of arguments: ~a" arg))))

--- a/source/backends/JITCPUTensor/foreign-function.lisp
+++ b/source/backends/JITCPUTensor/foreign-function.lisp
@@ -61,7 +61,9 @@ Tips: Modify cl-waffe2/backends.jit.cpu:*default-c-compiler* to switch compilers
   (let ((view-count 0))
     (flet ((read-view (nth)
 	     (let ((out (nth nth views)))
-	       out)))
+	       (if (null out)
+		   (error "cl-waffe2/backends.cpu.jit:expand-funcall-form view exhausted")
+		   out))))
       `(cffi:foreign-funcall
 	,function-name
 	,@(if (null views)

--- a/source/backends/JITCPUTensor/impls/arithmetic.lisp
+++ b/source/backends/JITCPUTensor/impls/arithmetic.lisp
@@ -56,8 +56,8 @@
   ;; A <- B
   (let ((self (tensor-backward (opAST-car opAST))))
     (if (movetensor-ignore-me self)
-	(make-inst :set     ""   (car args) (cdr args))
-	(make-inst :modify  "="  (car args) (cdr args)))))
+	(make-inst :set     "="   (car args) (cdr args))
+	(make-inst :modify  "="   (car args) (cdr args)))))
 
 (define-impl (InverseTensorNode :device JITCPUTensor :extends (CPUJIT-Blueprint))
 	     :forward ((self x)

--- a/source/backends/JITCPUTensor/impls/math.lisp
+++ b/source/backends/JITCPUTensor/impls/math.lisp
@@ -22,23 +22,21 @@
 			      :device JITCPUScalarTensor
 			      :extends (CPUJIT-Scalar-Blueprint))
 			     :forward ((self X out)
-				       (declare (ignore out))
 				       (progn
 					 (setf (blueprint-use-var self) `(,X))
 					 (setf (blueprint-opecode self) ',name)
 					 nil)
-				       `(progn ,X)))		
+				       `(progn ,out)))		
 
 		(define-impl (,node
 			      :device JITCPUTensor
 			      :extends (CPUJIT-Blueprint))
 			     :forward ((self X out)
-				       (declare (ignore out))
 				       (progn
 					 (setf (blueprint-use-var self) `(,X))
 					 (setf (blueprint-opecode self) ',name)
 					 nil)
-				       `(progn ,X))))))
+				       `(progn ,out))))))
   (define-math-impl AbsNode abs       "abs")
   (define-math-impl SignNode signum   "sign" :cast t)
 

--- a/source/backends/JITCPUTensor/ir.lisp
+++ b/source/backends/JITCPUTensor/ir.lisp
@@ -87,6 +87,8 @@ an list of AST_Variable
 ;; Anyway, confirm the very least work and then think about it.
 ;; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+;; [modify] -> [apply] could be reduced?
+
 (defun ir->c (opAST)
   "Recursively this function explores opAST, generating and writing C code to buffer."
   (declare (type opAST opAST))

--- a/source/backends/JITCPUTensor/on-finalizing.lisp
+++ b/source/backends/JITCPUTensor/on-finalizing.lisp
@@ -90,12 +90,6 @@
 	       ;; Synchronize ScalarTensors
 	       (setf ,@(loop for scal in scalars
 			     append `((tensor-vec (read-result ,scal)) (cffi:mem-ref ,(int-sap-id scal) ,(dtype scal)))))
-
-	       ;; (!sin x) isn't working while (!copy (!sin x)) is ok.
-	       ,@(loop for tens in tensors
-		       collect `(progn
-				  (print ',(tensor-id tens))
-				  (print ,tens)))
 	       
 	       ;; Synchronize In-place
 	       (let* (,@(loop for case in (reverse *in-place-routes*)
@@ -105,6 +99,16 @@
 			       append `((tensor-vec ,(tensor-id (car case)))
 					(tensor-vec (read-result ,(cdr case)))))))
 
+	       ;; (!sin x) isn't working while (!copy (!sin x)) is ok.
+	       ,@(loop for tens in tensors
+		       collect `(progn
+				  (print ',(tensor-id tens))
+				  (print (read-result ,tens))))
+
+	       (print "VAR")
+	       (print ',(tensor-id variable))
+	       (print (read-result ,variable))
+	       
 	       ;; [Bug] (proceed (!sin x)) isn't working while (proceed (!copy (!sin x))) is ok.
 	       ;; Synchronize output if the last node is in-place
 	       ,(let* ((all-tensors `(,@scalars ,@tensors))

--- a/source/backends/JITCPUTensor/on-finalizing.lisp
+++ b/source/backends/JITCPUTensor/on-finalizing.lisp
@@ -86,6 +86,9 @@
 	       (setf ,@(loop for scal in scalars
 			     append `((cffi:mem-ref ,(int-sap-id scal) ,(dtype scal)) (tensor-vec (read-result ,scal)))))
 	       ,call-form
+
+	       ,@(loop for tensor in tensors
+		       collect `(tensor-vec (read-result ,tensor)))
 	       
 	       ;; Synchronize ScalarTensors
 	       (setf ,@(loop for scal in scalars
@@ -99,16 +102,7 @@
 			       append `((tensor-vec ,(tensor-id (car case)))
 					(tensor-vec (read-result ,(cdr case)))))))
 
-	       ;; (!sin x) isn't working while (!copy (!sin x)) is ok.
-	       ,@(loop for tens in tensors
-		       collect `(progn
-				  (print ',(tensor-id tens))
-				  (print (read-result ,tens))))
-
-	       (print "VAR")
-	       (print ',(tensor-id variable))
-	       (print (read-result ,variable))
-	       
+	              
 	       ;; [Bug] (proceed (!sin x)) isn't working while (proceed (!copy (!sin x))) is ok.
 	       ;; Synchronize output if the last node is in-place
 	       ,(let* ((all-tensors `(,@scalars ,@tensors))

--- a/source/backends/JITCPUTensor/on-finalizing.lisp
+++ b/source/backends/JITCPUTensor/on-finalizing.lisp
@@ -21,24 +21,30 @@
 ;;  Event Handlers
 ;; ===============================================================================
 
+;; End <-> Top
+;;             / variable
+;; next-variable
+;;             \ variable
+
 (defun apply-compile-p (variable next-variable)
   "Following the defition of 3., return t if there's a need to run compiling."
 
   ;; ViewTensorNode, PermuteTensorNode -> Compile -> ...
   ;;       ^ :device=t
-  (declare (ignore variable))
   (or
    ;; If One of next variables are performed in different devices, or didn't exist in the first place (i.e.: is the end of nodes):
    (null next-variable)
-   (not (typep next-variable 'JITAbleTensors))
+   ;;(not (typep next-variable 'JITAbleTensors))
    (not (typep (tensor-backward next-variable) 'CPUJIT-Blueprint))
 
-   ;; JITCPUTensor do not provide nodes that change shapes of tensors
-   ;; The change of shapes is detected:
-   ;;(and
-   ;; (not
-   ;;  (cl-waffe2/vm.generic-tensor::shape-equal-list (print (shape variable)) (print (shape next-variable)))))
-
+   ;; Composing element-wise operations with the same iteration.
+   ;; Split iteraton:
+   
+   (null (tensor-variables next-variable))
+   ;; この条件つければ動くけど
+   ;; コンパイルされたコードが細切りになってしまう・・・
+   (some #'tensor-projected-p (tensor-variables next-variable))
+   
    ))
 
 (defparameter *compiling-ntime-count* 0)

--- a/source/backends/JITCPUTensor/package.lisp
+++ b/source/backends/JITCPUTensor/package.lisp
@@ -33,3 +33,6 @@
 (defun symb (&rest inputs)
   (intern (with-output-to-string (out) (dolist (sym inputs) (princ sym out)))))
 
+(defun delete-newlines (string)
+  (cl-ppcre:regex-replace-all #\newline string " "))
+

--- a/source/backends/JITCPUTensor/t/jit.lisp
+++ b/source/backends/JITCPUTensor/t/jit.lisp
@@ -3,13 +3,9 @@
 
 (in-suite :jit-cpu-test)
 
-;; TODO: Write tests
 
-;; A+=B (!copy (!view ...))
-;; CopyとView以外は動く -> それさえ動けばSoftmax ugoku
-;; with-no-grad
-
-;;(test arithmetic-[normal+normal])
+;; Testing call-with-view/In-place mutation are working well
+;; Also: do tests on with-no-grad mode.
 
 (defun M= (a b)
   (every #'= a b))
@@ -42,6 +38,8 @@
 	 (tensor-vec
 	  (ax+b `(3 3) 0 0))))))
 
+
+;; Broadcasting += Normal
 (test arithmetic-[broadcast]A+B
   (is (with-cpu-jit ()
 	(M=

--- a/source/backends/JITCPUTensor/t/jit.lisp
+++ b/source/backends/JITCPUTensor/t/jit.lisp
@@ -1,0 +1,62 @@
+
+(in-package :cl-waffe2/backends.jit.cpu.test)
+
+(in-suite :jit-cpu-test)
+
+;; TODO: Write tests
+
+;; A+=B (!copy (!view ...))
+;; CopyとView以外は動く -> それさえ動けばSoftmax ugoku
+;; with-no-grad
+
+;;(test arithmetic-[normal+normal])
+
+(defun M= (a b)
+  (every #'= a b))
+
+(defmacro with-test-form (&body body)
+  `(flet ((lisp-case ()
+	    (with-devices (cl-waffe2/backends.lisp:LispTensor)
+	      ,@body))
+	  (jit-case ()
+	    (with-cpu-jit ()
+	      ,@body)))
+     (M=
+      (tensor-vec (proceed (lisp-case)))
+      (tensor-vec (proceed (jit-case))))))
+
+
+(test arithmetic-A+B
+  (is (with-cpu-jit ()
+	(M=
+	 (tensor-vec
+	  (proceed
+	   (!add (ax+b `(3 3) 1 0) (ax+b `(3 3) 1 0))))
+	 (tensor-vec
+	  (ax+b `(3 3) 2 0)))))
+  (is (with-cpu-jit ()
+	(M=
+	 (tensor-vec
+	  (proceed
+	   (!sub (ax+b `(3 3) 1 0) (ax+b `(3 3) 1 0))))
+	 (tensor-vec
+	  (ax+b `(3 3) 0 0))))))
+
+(test arithmetic-[broadcast]A+B
+  (is (with-cpu-jit ()
+	(M=
+	 (tensor-vec
+	  (proceed
+	   (!add
+	    (!view (ax+b `(1 3) 0 0) `(:broadcast 3))
+	    (ax+b `(3 3) 0 1))))
+	 (tensor-vec
+	  (ax+b `(1 3) 0 3)))))
+  (is (with-test-form
+	(!sum (ax+b `(3 3) 1 0)))))
+
+
+(test softmax-complicated-views-test
+  (is (with-test-form (cl-waffe2/nn:!softmax (ax+b `(3 3) 0 1)))))
+
+

--- a/source/backends/JITCPUTensor/t/package.lisp
+++ b/source/backends/JITCPUTensor/t/package.lisp
@@ -11,20 +11,15 @@
 (in-suite :jit-cpu-test)
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  
-(add-tester JITCPUTensor)
-(sub-tester JITCPUTensor)
-(mul-tester JITCPUTensor)
-(div-tester JITCPUTensor)
-(move-tester JITCPUTensor)
-
-(scalar-add-tester JITCPUTensor JITCPUScalarTensor)
-(scalar-sub-tester JITCPUTensor JITCPUScalarTensor)
-(scalar-mul-tester JITCPUTensor JITCPUScalarTensor)
-(scalar-div-tester JITCPUTensor JITCPUScalarTensor)
-
-(sum-tester LispTensor JITCPUScalarTensor)
-
-(mathematical-test-set JITCPUTensor JITCPUScalarTensor)
-)
+  (add-tester JITCPUTensor)
+  (sub-tester JITCPUTensor)
+  (mul-tester JITCPUTensor)
+  (div-tester JITCPUTensor)
+  (move-tester JITCPUTensor)
+  (scalar-add-tester JITCPUTensor JITCPUScalarTensor)
+  (scalar-sub-tester JITCPUTensor JITCPUScalarTensor)
+  (scalar-mul-tester JITCPUTensor JITCPUScalarTensor)
+  (scalar-div-tester JITCPUTensor JITCPUScalarTensor)
+  (sum-tester LispTensor JITCPUScalarTensor)
+  (mathematical-test-set JITCPUTensor JITCPUScalarTensor))
 

--- a/source/backends/JITLispTensor/compiler.lisp
+++ b/source/backends/JITLispTensor/compiler.lisp
@@ -42,7 +42,7 @@
 	    (:constructor make-iseq (code displace-out-to)))
   (code code :type (or symbol list))
   (displace-out-to displace-out-to :type (or symbol list)))
-    
+
 (defstruct (opAST
 	    (:constructor make-opAST (operation &rest args)))
   "opAST is a data structure which is:

--- a/source/backends/JITLispTensor/jit.lisp
+++ b/source/backends/JITLispTensor/jit.lisp
@@ -1,6 +1,7 @@
 
 (in-package :cl-waffe2/backends.jit.lisp)
 
+
 ;;
 ;; Goals:
 ;;   1. Use as a model case when extending to other backends.
@@ -91,7 +92,8 @@ AbstractNodes which extends this class, is recognised as `LispJITAble` Node by L
 
 (defmethod on-finalizing-compiling ((current-node LispJIT-Blueprint)
 				    variable
-				    next-variable)
+				    next-variable
+				    compile-me)
   "If the node is needed to be compiled, compile."
   (if (apply-compile-p variable next-variable)
       (progn

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -380,7 +380,8 @@ Tracing until one of variables reached a toplevel tensor (detach-p is t or no ba
 	    (cl-waffe2/vm.nodes:on-finalizing-compiling
 	     (tensor-backward toplevel)
 	     toplevel
-	     called-with-vars))
+	     called-with-vars
+	     nil))
 	 
 
 	 ;; TODO UPDATE

--- a/source/vm/generic-tensor/interpreter.lisp
+++ b/source/vm/generic-tensor/interpreter.lisp
@@ -87,7 +87,8 @@
 	(let ((result (cl-waffe2/vm.nodes:on-finalizing-compiling
 		       node
 		       toplevel
-		       called-with-vars)))
+		       called-with-vars
+		       t)))
 	  (when result
 	    (eval result))))
       

--- a/source/vm/nodes/defnode.lisp
+++ b/source/vm/nodes/defnode.lisp
@@ -6,13 +6,13 @@
 (defparameter *node-reject-case-table* (make-hash-table))
 
 (defgeneric on-finalizing-compiling
-    (current-node variable next-variable)
+    (current-node variable next-variable compile-me)
   (:documentation
    "
 ## [generic] on-finalizing-compiling
 
 ```lisp
-(on-finalizing-compiling current-node variable next-variable)
+(on-finalizing-compiling current-node variable next-variable compile-me)
 ```
 
 The generic function `on-finalizing-compiling` is invoked after the body of `define-impl` is expanded when performing `compile-chain-forward`.
@@ -43,10 +43,12 @@ Return S expression to be embodied in the compiled code if needed, especially, d
 
 `next-variables (i.e.: corresponding variable of MoveTensorNode2)` returns corresponding variable of next node.
 
+`compile-me[boolean]` If t, cl-waffe2 needs compiled code that works instantly.
+
 See also: `the implementation of JITLispTensor`.
 "))
 
-(defmethod on-finalizing-compiling ((current-node AbstractNode) variable next-variables)
+(defmethod on-finalizing-compiling ((current-node AbstractNode) variable next-variables compile-me)
   (declare (ignore variable next-variables))
   (when (next-method-p)
     (call-next-method)))


### PR DESCRIPTION
・`JITCPUTensor` caches the previous compiled codes, and at the last, call `gcc` to reduce compiling times. (only when called with `build`)
・JIT can handle with broadcasted arrays