### PR TITLE
[Fix] JIT Compiler traces duplicated nodes.

### DIFF
--- a/examples/mlp_sin_wave.lisp
+++ b/examples/mlp_sin_wave.lisp
@@ -10,7 +10,11 @@
    :cl-waffe2/base-impl
    :cl-waffe2/vm.generic-tensor
    :cl-waffe2/vm.nodes
-   :cl-waffe2/optimizers))
+   :cl-waffe2/optimizers
+
+   :cl-waffe2/backends.jit.cpu
+   :cl-waffe2/backends.cpu
+   ))
 
 (in-package :cl-waffe2-example1)
 
@@ -38,30 +42,29 @@
 	     :minimize! ((self)
 			 (zero-grads! (model self))
 			 (let ((loss (forward (model self))))
-			   ;;(format t "Training Loss: ~a~%" (tensor-vec loss))
-			   )
+			   (format t "Training Loss: ~a~%" (tensor-vec loss)))
 			 (backward  (model self))
-			 (optimize! (model self))
-			 )
+			 (optimize! (model self)))
 	     :predict ((self x)
 		       (call (model self) x))))
-			 
-			 
-		     
-			 
-	   
+
+
 ;; Training sin wave from random noises
 ;; If we forget to call proceed when making training data?
 ;; -> set-input must return error.
 (defun train (&key
 		(batch-size 100)
-		(iter-num 1))
+		(iter-num 3000))
   (let* ((X (proceed (!sin (ax+b `(,batch-size 100) 0.01 0.1))))
  	 (Y (proceed (!cos (ax+b `(,batch-size 1)   0.01 0.1))))
 	 (trainer (MLPTrainer 100 10 :lr 1e-3)))
-
+    
+    (set-inputs trainer X Y)
     (time
      (loop for nth-epoch fixnum upfrom 0 below iter-num
-	   do (set-inputs trainer X Y)
-	      (minimize! trainer)))))
+	   do (minimize! trainer)))))
+
+(with-devices (JITCPUTensor JITCPUScalarTensor CPUTensor)
+  (train)) 
+
 

--- a/source/backends/JITCPUTensor/ir.lisp
+++ b/source/backends/JITCPUTensor/ir.lisp
@@ -85,6 +85,7 @@ an list of AST_Variable
   (apply #'make-opAST toplevel
 	 (loop for called-var in (tensor-variables toplevel)
 	       if (or (apply-compile-p called-var toplevel)
+		      (not (typep (tensor-backward called-var) 'CPUJIT-Blueprint))
 		      (detach-p called-var))
 		 collect (make-ast-variable called-var)
 	       else

--- a/source/backends/JITCPUTensor/ir.lisp
+++ b/source/backends/JITCPUTensor/ir.lisp
@@ -84,8 +84,10 @@ an list of AST_Variable
   ;; Explore JITAble Nodes deeper:
   (apply #'make-opAST toplevel
 	 (loop for called-var in (tensor-variables toplevel)
-	       if (or (apply-compile-p called-var toplevel)
+	       if (or ;;(apply-compile-p called-var toplevel) ;; !Mul 0
+		      ;;(apply-compile-p toplevel called-var) ;;!softmax
 		      (not (typep (tensor-backward called-var) 'CPUJIT-Blueprint))
+		      (tensor-projected-p called-var)
 		      (detach-p called-var))
 		 collect (make-ast-variable called-var)
 	       else
@@ -123,7 +125,6 @@ an list of AST_Variable
 
   (when (null (tensor-backward (opAST-car opAST)))
     (return-from ir->C))
-  
   
   (loop for var in (opAST-args opAST)
 	if (eql (ast-variable-type var) :opAST)

--- a/source/backends/JITCPUTensor/t/jit.lisp
+++ b/source/backends/JITCPUTensor/t/jit.lisp
@@ -21,40 +21,19 @@
       (tensor-vec (proceed (lisp-case)))
       (tensor-vec (proceed (jit-case))))))
 
-
-(test arithmetic-A+B
-  (is (with-cpu-jit ()
-	(M=
-	 (tensor-vec
-	  (proceed
-	   (!add (ax+b `(3 3) 1 0) (ax+b `(3 3) 1 0))))
-	 (tensor-vec
-	  (ax+b `(3 3) 2 0)))))
-  (is (with-cpu-jit ()
-	(M=
-	 (tensor-vec
-	  (proceed
-	   (!sub (ax+b `(3 3) 1 0) (ax+b `(3 3) 1 0))))
-	 (tensor-vec
-	  (ax+b `(3 3) 0 0))))))
-
-
-;; Broadcasting += Normal
-(test arithmetic-[broadcast]A+B
-  (is (with-cpu-jit ()
-	(M=
-	 (tensor-vec
-	  (proceed
-	   (!add
-	    (!view (ax+b `(1 3) 0 0) `(:broadcast 3))
-	    (ax+b `(3 3) 0 1))))
-	 (tensor-vec
-	  (ax+b `(1 3) 0 3)))))
-  (is (with-test-form
-	(!sum (ax+b `(3 3) 1 0)))))
-
-
 (test softmax-complicated-views-test
   (is (with-test-form (cl-waffe2/nn:!softmax (ax+b `(3 3) 0 1)))))
 
+
+;; Things should also tested:
+;; backward
+
+(test backward-test
+  (is (let ((a (parameter (ax+b `(3 3) 0 1))))
+	(proceed-backward (!sin a))
+	(= (cos 1) (vref (grad a) 0)))))
+
+;;(progn
+;;  (let ((a (parameter (ax+b `(3 3) 0 1))))	      
+ ;;   (forward (build (!mul a (make-tensor 1.0))))))
 

--- a/source/base-impl/mathematics.lisp
+++ b/source/base-impl/mathematics.lisp
@@ -114,10 +114,10 @@ OUT_{copy}\\gets{~(~a~)(X)}
 				   x)))
 			(if ->
 			    (forward (,scal-node-name) x ->)
-			    (forward (,scal-node-name) x (!copy x))))
+			    (forward (,scal-node-name) x (make-clone x))))
 		      (if ->
 			  (forward (,node-name) x ->)
-			  (forward (,node-name) x (!copy x)))))))))
+			  (forward (,node-name) x (make-clone x)))))))))
 
   ;; define-elwise-node will define: nameNode, !name.
 
@@ -281,7 +281,7 @@ Output:
 	       n)))
     (if ->
 	(forward (ExptNode) x -> n)
-	(forward (ExptNode) x (make-input (shape x) nil :dtype (dtype x) :order (order x)) n))))
+	(forward (ExptNode) x (make-clone x) n))))
 
 ;; !pow
 

--- a/source/vm/nodes/node.lisp
+++ b/source/vm/nodes/node.lisp
@@ -436,12 +436,9 @@ inputs      ... inputs called with
 	      (cons
 	       out
 	       `(named-lambda ,(symb (class-name (class-of node)) '-backward) (,dout-place)
-		  ;;(print "=======")
-		  ;;(print ,dout)
 		  (cl-waffe2/vm.generic-tensor:embody-actual-tensor
 		   ,dout
 		   ,dout-place)
-		  ;;(print ,dout)
 		  
 		  ,(with-no-grad
 		     (cl-waffe2/vm.generic-tensor:make-vm-function kernel)))))))))


### PR DESCRIPTION
1. Problem solved where the out parameter of a mathematical function is not detached.
2. mlp_sin_wave has worked
3. But compiling time is still slow and not practical for use. I have to keep working on optimizing codes