### PR TITLE
[Add] AvgPool2D MaxPool2D

### DIFF
--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -70,6 +70,7 @@
 	       (:file "base-impl/logical")
 	       (:file "base-impl/transform")
 	       (:file "base-impl/ir")
+	       (:file "base-impl/reshapers")
 	       
 	       
 

--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -141,6 +141,7 @@
 
 	       (:file "nn/im2col")
 	       (:file "nn/conv")
+	       (:file "nn/pool")
 
 	       (:file "optimizers/impls/sgd")
 	       (:file "optimizers/impls/adam")

--- a/docs/apis/nn.lisp
+++ b/docs/apis/nn.lisp
@@ -30,5 +30,8 @@
 
     (with-nn-doc (find-class 'Conv2D) 't
       (with-example
-	"(LinearLayer 3 5 '(3 3))"))))
+	"(Conv2D 3 5 '(3 3))"))
+
+    (with-nn-doc (find-class 'MaxPool2D) 't)
+    (with-nn-doc (find-class 'AvgPool2D) 't)))
 

--- a/docs/apis/reference.lisp
+++ b/docs/apis/reference.lisp
@@ -197,13 +197,16 @@
     (caller-doc A<scal)
     (caller-doc A>=scal)
     (caller-doc A<=scal)
+    (caller-doc A=scal)
 
     (caller-doc A>B)
     (caller-doc A<B)
     (caller-doc A>=B)
     (caller-doc A<=B)
+    (caller-doc A=B)
 
     (caller-doc padding)
+    (caller-doc broadcast-to)
     ))
 
 

--- a/docs/cl-waffe2-docs/docs/base-impl-nodes.md
+++ b/docs/cl-waffe2-docs/docs/base-impl-nodes.md
@@ -1518,7 +1518,9 @@ A is a target to find a maximum value, and OUT is a place to set the index.
 ✅ Already defined. 
 
 ```lisp
-((self dout da do) (declare (ignore dout da do)) (values nil nil))
+((self dout da do) (declare (ignore do))
+ (let ((mask (a=b da (!view (!max da) (broadcast-to da)))))
+   (values (!mul mask (!view dout (broadcast-to mask))) nil)))
 ```
 
 No need to implement backwards at `define-impl`. (they'd be ignored.)
@@ -1547,7 +1549,9 @@ A is a target to find a minimum value, and OUT is a place to set the index.
 ✅ Already defined. 
 
 ```lisp
-((self dout da do) (declare (ignore dout da do)) (values nil nil))
+((self dout da do) (declare (ignore do))
+ (let ((mask (a=b da (!view (!min da) (broadcast-to da)))))
+   (values (!mul mask (!view dout (broadcast-to mask))) nil)))
 ```
 
 No need to implement backwards at `define-impl`. (they'd be ignored.)

--- a/docs/cl-waffe2-docs/docs/base-impl.md
+++ b/docs/cl-waffe2-docs/docs/base-impl.md
@@ -471,7 +471,7 @@ Note that the case when only the last two aces are subject to be swapped, we ret
 
 `order[list<Fixnum>]` An list of permutation. Note that `:~` could be used once in an order If needed. If the order and the number of dimensions of the entered tensor do not match, the part is automatically stored as long as `:~` is provided.
 
-Tips: If the first element of `order` arguments is a function, the rest arguments of `order` is overwritten with its result. that is, `order` become the value of `(funcall (car order) (tensor-permute-order tensor))` and can be used like: `(!permute tensor #'reverse)` to reverse all permution for example.
+Tips: If the first element of `order` arguments is a function, the rest arguments of `order` is overwritten with its result. that is, `order` become the value of `(funcall (car order) (tensor-permute-order tensor))` and can be used like: `(!permute tensor (compose #'reverse #'tensor-permute-order))` to reverse all permution for example.
 
 ## [function] !reshape
 
@@ -493,7 +493,7 @@ Before and after the operation, the total elements of tensors must correspond.
 Note: If the first element of `shapes` is a function, `shapes` are overwritten with the function's value.
 
 ```lisp
-(!reshape (ax+b `(5 3 2) 1 0) #'reverse) ;; => (2 3 5) Tensor
+(!reshape (ax+b `(5 3 2) 1 0) (compose #'reverse #'shape)) ;; => (2 3 5) Tensor
 ```
 
 ## [function] !view
@@ -546,7 +546,7 @@ Subscripts are following:
 
 Tips: Applying `!view` again to the returned `sliced-tensor` with `broadcast-reverser` will remove broadcasts from the tensor.
 
-Tips: If a function is passed as the first element of `subscript`, the subscript is overwritten based on the return value of the function. The function is called like: `(funcall function (tensor-view tensor))` can be used like: `(!view tensor #'reverse)`.
+Tips: If a function is passed as the first element of `subscript`, the subscript is overwritten based on the return value of the function. The function is called like: `(funcall function tensor)` can be used like: `(!view tensor (compose #'reverse #'tensor-view))`.
 
 ## [function] !flatten
 
@@ -1734,6 +1734,20 @@ The function a<=scal sets `true-then` if the equation: `element <= scal` is t, o
 `scal` number (not a ScalarTensor)
 
 (TODO: ScalarTensor as scal)
+## [function] a=scal
+
+```
+(a=scal A scal &key (out nil) (true-then 1) (false-then 0))
+```
+
+The function a=scal sets `true-then` if the equation: `element = scal` is t, otherwise set `false-then` at the corresponding positions.
+
+### Inputs
+
+`A` AbstractTensor
+`scal` number (not a ScalarTensor)
+
+(TODO: ScalarTensor as scal)
 ## [function] a>b
 
 ```
@@ -1777,6 +1791,18 @@ The function a>=b sets `true-then` if the equation: `A >= B` is t, otherwise set
 ```
 
 The function a<=b sets `true-then` if the equation: `A <= B` is t, otherwise set `false-then` at the corresponding positions.
+
+### Inputs
+
+`A` `B` AbstractTensor to be compared.
+
+## [function] a=b
+
+```
+(a=b A B &key (out nil) (true-then 1) (false-then 0))
+```
+
+The function a=b sets `true-then` if the equation: `A = B` is t, otherwise set `false-then` at the corresponding positions.
 
 ### Inputs
 
@@ -1864,4 +1890,18 @@ If the shapes does not change before/after padding, returns the given tensor as 
   :facet :input
   :requires-grad NIL
   :backward <Node: PROCEEDNODE-T (A[~] -> A[~])>}
+```
+
+## [function] broadcast-to
+
+Returns the subscript of the `!view` that is broadcasting to be the same shape as the `object-tensor`.
+
+For example:
+
+```lisp
+;; x                ... ( 3 3 ) Tensor
+;; (!sum x :axis 1) ... ( 3 1 ) Tensor
+
+;; broadcast-to will return: (t `(:broadcast 3))
+(!mul x (!view (!sum x :axis 1) (broadcast-to x)))
 ```

--- a/docs/cl-waffe2-docs/docs/distributions.md
+++ b/docs/cl-waffe2-docs/docs/distributions.md
@@ -16,11 +16,11 @@ That is, arguments passed to the `make-tensor` function can also be passed direc
 (normal `(10 10) 0.0 1.0 :requires-grad t)
 
 {CPUTENSOR[float] :shape (10 10)  
-  ((-0.0930601   -0.7955518   -0.2320479   ~ -0.19919659  0.5053014    -0.20112497)                    
-   (-0.28931206  -0.87701094  0.3625228    ~ -0.6312274   -2.3019962   0.36486906)   
+  ((-0.7697575   1.2483683    -1.2158309   ~ 0.52224797   -1.1419474   -1.6627157)                    
+   (0.77674264   0.8536477    -0.88968027  ~ -0.11087127  -0.20664303  -0.6662982)   
                  ...
-   (-1.5363529   0.28731748   -0.4586338   ~ -0.73600495  0.95712537   1.6522883)
-   (1.2883565    0.91169834   2.869378     ~ 2.150223     0.7248882    -0.4818239))
+   (0.74001324   0.5370983    -0.19763497  ~ -1.5166254   -1.6220634   0.32480988)
+   (-1.3004369   0.54617184   0.52436066   ~ 2.0269058    0.24235359   -1.114752))
   :facet :exist
   :requires-grad T
   :backward NIL}
@@ -146,9 +146,9 @@ Note: My implementation is unstable, being occurs floating-overflow constantly..
 (beta `(3 3) 5.0 1.0)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((0.8391376  0.96829844 0.3757152)
-   (0.9150053  0.7509756  0.9709161)
-   (0.782447   0.89865106 0.96879745))
+  ((0.9597272  0.87902176 0.5515582)
+   (0.84611875 0.9105894  0.73724747)
+   (0.652607   0.79870707 0.5758165))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -170,9 +170,9 @@ p - Takes 1 with probability p and 0 with probalibity (1-p).
 (bernoulli `(3 3) 0.3)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((1.0 0.0 0.0)
-   (0.0 1.0 0.0)
-   (0.0 0.0 0.0))
+  ((0.0 1.0 0.0)
+   (1.0 0.0 0.0)
+   (0.0 1.0 0.0))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -198,9 +198,9 @@ df - degree of freedom.
 (chisquare `(3 3) 1.0)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((0.0683025   1.0229962   0.023815382)
-   (1.2645968   0.6006345   1.7994667)
-   (0.36835933  0.25498798  0.80459654))
+  ((0.2490411    0.050360017  0.7465566)
+   (1.2320644    5.824656e-4  1.0583801e-5)
+   (0.5605799    0.1357141    0.00883777))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -227,9 +227,9 @@ The function expotential is a family of initializer functions, and samples the e
 (expotential `(3 3))
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((0.8669353   0.24338455  0.121354826)
-   (0.33946362  1.5045028   1.9900182)
-   (0.481504    1.4580338   1.4063467))
+  ((0.36911923  5.6310396   0.47442508)
+   (2.2441757   0.40708888  2.1960976)
+   (0.056219243 0.24608296  1.9622158))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -252,9 +252,9 @@ The function gamma is a family of initializer functions, and samples matrices fr
 (gamma `(3 3) 1.0)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((2.3013742   2.8152425   0.056881204)
-   (0.5659466   2.1788025   1.27337)
-   (0.09022631  0.3975919   1.6128166))
+  ((0.44777983 0.12949242 0.0804264)
+   (1.3410249  0.32795936 2.1225932)
+   (0.5128944  3.0496273  0.5805971))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -309,9 +309,9 @@ Input:
 (uniform-random `(3 3) 2 4)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((3.4028106 2.2382534 2.8039198)
-   (3.294498  2.771839  3.9309936)
-   (3.9023423 3.4698777 3.7805085))
+  ((2.8167884 3.3579736 2.465089)
+   (3.8065217 3.512202  3.681328)
+   (3.5698762 2.210708  3.786309))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -339,9 +339,9 @@ The function randn is a family of initializer functions, and samples the gaussia
 (randn `(3 3))
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((1.9816247    1.8748245    -0.030450566)
-   (0.68228406   -0.88974875  0.62135047)
-   (-0.028420867 -0.89215803  0.20699267))
+  ((-0.042412635 0.20137452   0.61019295)
+   (-1.268877    1.4355178    0.6892139)
+   (1.355975     0.48701808   -0.43723813))
   :facet :exist
   :requires-grad NIL
   :backward NIL}

--- a/docs/cl-waffe2-docs/docs/generic-tensor.md
+++ b/docs/cl-waffe2-docs/docs/generic-tensor.md
@@ -359,7 +359,7 @@ After working with adjustable shape tensor, don't forget to embody the InputTens
 > (setq out (!add (randn `(10 10)) (make-input `(a 10) :X)))
 ```
 ```
-{CPUTENSOR[float] :shape (10 10) :named ChainTMP4420 
+{CPUTENSOR[float] :shape (10 10) :named ChainTMP1671 
   :vec-state [maybe-not-computed]
   <<Not-Embodied (10 10) Tensor>>
   :facet :input
@@ -375,10 +375,10 @@ After working with adjustable shape tensor, don't forget to embody the InputTens
 (<Compiled-Composite
     forward:  #<FUNCTION (LAMBDA ()
                            :IN
-                           "/Users/hikettei/.cache/common-lisp/sbcl-2.3.4-macosx-x64/Users/hikettei/Desktop/cl-waffe-workspace/progs/develop/cl-waffe2/docs/apis/generic-tensor.fasl") {5379D52B}>
+                           "/Users/hikettei/.cache/common-lisp/sbcl-2.3.3-macosx-x64/Users/hikettei/Desktop/cl-waffe-workspace/progs/develop/cl-waffe2/docs/apis/generic-tensor.fasl") {538CE17B}>
     backward: #<FUNCTION (LAMBDA ()
                            :IN
-                           "/Users/hikettei/.cache/common-lisp/sbcl-2.3.4-macosx-x64/Users/hikettei/Desktop/cl-waffe-workspace/progs/develop/cl-waffe2/docs/apis/generic-tensor.fasl") {53AD32EB}>
+                           "/Users/hikettei/.cache/common-lisp/sbcl-2.3.3-macosx-x64/Users/hikettei/Desktop/cl-waffe-workspace/progs/develop/cl-waffe2/docs/apis/generic-tensor.fasl") {5392662B}>
 
 += [Tensors in the computation node] =======+
 

--- a/docs/cl-waffe2-docs/docs/nn.md
+++ b/docs/cl-waffe2-docs/docs/nn.md
@@ -13,13 +13,13 @@ ReLU(x) = max(x, 0)
 ```lisp
 (proceed (!relu (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (10 10) :named ChainTMP4498 
+{CPUTENSOR[float] :shape (10 10) :named ChainTMP1762 
   :vec-state [computed]
-  ((0.62999654  0.2834333   -0.0        ~ 2.1115925   -0.0        -0.0)                   
-   (0.28777036  -0.0        1.07363     ~ -0.0        -0.0        0.12954238)   
+  ((0.54795235  1.6235474   0.5676201   ~ -0.0        0.052415702 0.592523)                   
+   (0.3905703   0.909697    -0.0        ~ 0.7793865   1.1814722   0.70569587)   
                 ...
-   (-0.0        0.4031366   0.94479376  ~ -0.0        0.97784036  0.8090534)
-   (-0.0        -0.0        0.24842498  ~ -0.0        -0.0        0.11140717))
+   (-0.0        -0.0        -0.0        ~ -0.0        0.43317536  0.95860183)
+   (-0.0        0.33624887  -0.0        ~ 2.351149    -0.0        -0.0))
   :facet :input
   :requires-grad NIL
   :backward <Node: PROCEEDNODE-T (A[~] -> A[~])>}
@@ -42,13 +42,13 @@ Sigmoid(x) = \frac{1}{1 + exp(-x)}
 ```lisp
 (proceed (!sigmoid (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (10 10) :named ChainTMP4653 
+{CPUTENSOR[float] :shape (10 10) :named ChainTMP1923 
   :vec-state [computed]
-  ((0.69510037 0.9623018  0.23325357 ~ 0.44287565 0.85087496 0.9183959)                  
-   (0.6346567  0.4834226  0.1025261  ~ 0.47634315 0.23011185 0.5473528)   
-               ...
-   (0.5813357  0.728681   0.10256982 ~ 0.8346204  0.23897697 0.8436653)
-   (0.22710748 0.50760156 0.3690324  ~ 0.66658074 0.6630394  0.7805867))
+  ((0.3162559   0.87631273  0.5881605   ~ 0.18262608  0.42268223  0.11140414)                   
+   (0.30611554  0.73730034  0.44554135  ~ 0.660299    0.6358208   0.63479567)   
+                ...
+   (0.2109514   0.23612864  0.69080406  ~ 0.32275796  0.7881756   0.8983441)
+   (0.47323906  0.6907624   0.41804832  ~ 0.486416    0.71819955  0.7666125))
   :facet :input
   :requires-grad NIL
   :backward <Node: PROCEEDNODE-T (A[~] -> A[~])>}
@@ -75,9 +75,9 @@ In addition, reading the value of a `:reduction` keyword (one of `:mean` `:sum` 
 ```lisp
 (proceed (L1Norm (randn `(10 10)) (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (1 1) -> :view (<(BROADCAST 1)> <(BROADCAST 1)>) -> :visible-shape (1 1) :named ChainTMP4876 
+{CPUTENSOR[float] :shape (1 1) -> :view (<(BROADCAST 1)> <(BROADCAST 1)>) -> :visible-shape (1 1) :named ChainTMP2152 
   :vec-state [computed]
-  ((1.2423713))
+  ((1.0249314))
   :facet :input
   :requires-grad NIL
   :backward <Node: PROCEEDNODE-T (A[~] -> A[~])>}
@@ -102,9 +102,9 @@ In addition, reading the value of a `:reduction` keyword (one of `:mean` `:sum` 
 ```lisp
 (proceed (MSE (randn `(10 10)) (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (1 1) -> :view (<(BROADCAST 1)> <(BROADCAST 1)>) -> :visible-shape (1 1) :named ChainTMP5073 
+{CPUTENSOR[float] :shape (1 1) -> :view (<(BROADCAST 1)> <(BROADCAST 1)>) -> :visible-shape (1 1) :named ChainTMP2349 
   :vec-state [computed]
-  ((1.8533973))
+  ((1.9567565))
   :facet :input
   :requires-grad NIL
   :backward <Node: PROCEEDNODE-T (A[~] -> A[~])>}
@@ -196,7 +196,7 @@ y = xA^\intercal + b
 ```lisp
 (LinearLayer 10 5)
 
-<Composite: LINEARLAYER{W5077}(
+<Composite: LINEARLAYER{W2353}(
     <Input : ((~ BATCH-SIZE 10)) -> Output: ((~ BATCH-SIZE 5))>
 
     WEIGHTS -> (5 10)
@@ -282,12 +282,104 @@ Note: When `Conv2D` is initialised, the output is displayed as -1. This is becau
 ### Example
 
 ```lisp
-(LinearLayer 3 5 '(3 3))
+(Conv2D 3 5 '(3 3))
 
-<Composite: LINEARLAYER{W5083}(
-    <Input : ((~ BATCH-SIZE 3)) -> Output: ((~ BATCH-SIZE 5))>
+<Composite: CONV2D{W2359}(
+    <Input : ((N 3 H_IN W_IN)) -> Output: ((N 5 -1 -1))>
 
-    WEIGHTS -> (5 3)
-    BIAS    -> (5)
+    WEIGHT -> (5 3 3 3)
+    BIAS   -> (5)
 )>
 ```
+
+## [model] MAXPOOL2D
+
+```
+(maxpool2d KERNEL-SIZE &KEY (STRIDE 1) (PADDING 0) (DILATION 1) &AUX (STRIDE
+                                                            (MAYBE-TUPLE STRIDE
+                                                                         'STRIDE)) (PADDING
+                                                                                    (MAYBE-TUPLE
+                                                                                     PADDING
+                                                                                     'PADDING)) (DILATION
+                                                                                                 (MAYBE-TUPLE
+                                                                                                  DILATION
+                                                                                                  'DILATION)))
+```
+
+
+which transformation of shapes are defined as:
+```
+(INPUT[N C H_IN W_IN] -> OUTPUT[N C H_OUT W_OUT] WHERE H_OUT =
+ (IF (NUMBERP H_IN)
+     (CONV-OUT-SIZE H_IN (CAR PADDING) (CAR DILATION) (CAR KERNEL-SIZE)
+      (CAR STRIDE))
+     -1)
+ W_OUT =
+ (IF (NUMBERP W_OUT)
+     (CONV-OUT-SIZE W_IN (SECOND PADDING) (SECOND DILATION)
+      (SECOND KERNEL-SIZE) (SECOND STRIDE))
+     -1))
+```
+### Description
+
+
+Applies a 2D max pooling over an input signal composed of several input planes.
+
+### Inputs
+
+`kernel-size[list]` the size of window
+
+`stride[fixnum or list]` the stride of window
+
+`padding[fixnum or list]` adds 0 padding
+
+`dilation[fixnum or list]` a parameter that controls the stride of elements in the window.
+
+Likewise `Conv2D`, these parameters can be set for both X and Y axis directions.
+
+
+## [model] AVGPOOL2D
+
+```
+(avgpool2d KERNEL-SIZE &KEY (STRIDE 1) (PADDING 0) (DILATION 1) &AUX (STRIDE
+                                                            (MAYBE-TUPLE STRIDE
+                                                                         'STRIDE)) (PADDING
+                                                                                    (MAYBE-TUPLE
+                                                                                     PADDING
+                                                                                     'PADDING)) (DILATION
+                                                                                                 (MAYBE-TUPLE
+                                                                                                  DILATION
+                                                                                                  'DILATION)))
+```
+
+
+which transformation of shapes are defined as:
+```
+(INPUT[N C H_IN W_IN] -> OUTPUT[N C H_OUT W_OUT] WHERE H_OUT =
+ (IF (NUMBERP H_IN)
+     (CONV-OUT-SIZE H_IN (CAR PADDING) (CAR DILATION) (CAR KERNEL-SIZE)
+      (CAR STRIDE))
+     -1)
+ W_OUT =
+ (IF (NUMBERP W_OUT)
+     (CONV-OUT-SIZE W_IN (SECOND PADDING) (SECOND DILATION)
+      (SECOND KERNEL-SIZE) (SECOND STRIDE))
+     -1))
+```
+### Description
+
+
+Applies a 2D average pooling over an input signal composed of several input planes.
+
+### Inputs
+
+`kernel-size[list]` the size of window
+
+`stride[fixnum or list]` the stride of window
+
+`padding[fixnum or list]` adds 0 padding
+
+`dilation[fixnum or list]` a parameter that controls the stride of elements in the window.
+
+Likewise `Conv2D`, these parameters can be set for both X and Y axis directions.
+

--- a/source/base-impl/fundamental.lisp
+++ b/source/base-impl/fundamental.lisp
@@ -274,10 +274,10 @@ Subscripts are following:
 
 Tips: Applying `!view` again to the returned `sliced-tensor` with `broadcast-reverser` will remove broadcasts from the tensor.
 
-Tips: If a function is passed as the first element of `subscript`, the subscript is overwritten based on the return value of the function. The function is called like: `(funcall function (tensor-view tensor))` can be used like: `(!view tensor #'reverse)`.
+Tips: If a function is passed as the first element of `subscript`, the subscript is overwritten based on the return value of the function. The function is called like: `(funcall function tensor)` can be used like: `(!view tensor (compose #'reverse #'tensor-view))`.
 "
   (let* ((subscripts (if (functionp (car subscripts))
-			 (funcall (car subscripts) (tensor-view tensor))
+			 (funcall (car subscripts) tensor)
 			 subscripts))
 	 (out (apply #'cl-waffe2/vm.generic-tensor::view tensor subscripts))
 	 (broadcast-reverser
@@ -359,13 +359,13 @@ Before and after the operation, the total elements of tensors must correspond.
 Note: If the first element of `shapes` is a function, `shapes` are overwritten with the function's value.
 
 ```lisp
-(!reshape (ax+b `(5 3 2) 1 0) #'reverse) ;; => (2 3 5) Tensor
+(!reshape (ax+b `(5 3 2) 1 0) (compose #'reverse #'shape)) ;; => (2 3 5) Tensor
 ```
 "
   (declare (type AbstractTensor tensor))
   
   (let* ((shapes (if (functionp (car shapes))
-		     (funcall (car shapes) (shape tensor))
+		     (funcall (car shapes) tensor)
 		     shapes))
 	 (shapes (parse-reshape-args (shape tensor) shapes))
 	 (result (make-input shapes nil
@@ -887,7 +887,7 @@ Note that the case when only the last two aces are subject to be swapped, we ret
 
 `order[list<Fixnum>]` An list of permutation. Note that `:~` could be used once in an order If needed. If the order and the number of dimensions of the entered tensor do not match, the part is automatically stored as long as `:~` is provided.
 
-Tips: If the first element of `order` arguments is a function, the rest arguments of `order` is overwritten with its result. that is, `order` become the value of `(funcall (car order) (tensor-permute-order tensor))` and can be used like: `(!permute tensor #'reverse)` to reverse all permution for example.
+Tips: If the first element of `order` arguments is a function, the rest arguments of `order` is overwritten with its result. that is, `order` become the value of `(funcall (car order) (tensor-permute-order tensor))` and can be used like: `(!permute tensor (compose #'reverse #'tensor-permute-order))` to reverse all permution for example.
 "
   ;; If only the last two axes are subject to swapped.
   ;; Return a special node LazyTranspose instead.
@@ -898,7 +898,7 @@ Tips: If the first element of `order` arguments is a function, the rest argument
   ;;		  a)
   ;;
   (let* ((orders (if (functionp (car orders))
-		     (funcall (car orders) (cl-waffe2/vm.generic-tensor::tensor-permute-order tensor))
+		     (funcall (car orders) tensor)
 		     orders))
 	 (new-tensor (apply #'permute* tensor orders))
 	 (diff       (list-diff (cl-waffe2/vm.generic-tensor::tensor-permute-order tensor)

--- a/source/base-impl/logical.lisp
+++ b/source/base-impl/logical.lisp
@@ -190,7 +190,8 @@ The function ~(~a~) sets `true-then` if the equation: `element ~a scal` is t, ot
   (define-cmp-scal-operation A>scal >)
   (define-cmp-scal-operation A<scal <)
   (define-cmp-scal-operation A>=scal >=)
-  (define-cmp-scal-operation A<=scal <=))
+  (define-cmp-scal-operation A<=scal <=)
+  (define-cmp-scal-operation A=scal =))
 
 (macrolet ((define-cmp-mat-operation (name operator)
 	     `(eval-when (:compile-toplevel :load-toplevel :execute)
@@ -220,6 +221,7 @@ The function ~(~a~) sets `true-then` if the equation: `A ~a B` is t, otherwise s
   (define-cmp-mat-operation A>B >)
   (define-cmp-mat-operation A<B <)
   (define-cmp-mat-operation A>=B >=)
-  (define-cmp-mat-operation A<=B <=))
+  (define-cmp-mat-operation A<=B <=)
+  (define-cmp-mat-operation A=B =))
 		       
 

--- a/source/base-impl/matrix-ops.lisp
+++ b/source/base-impl/matrix-ops.lisp
@@ -309,9 +309,24 @@ AbstractTensor[uint32] with dimensions behind `axis` is replaced with 1.
 
 (defnode (MaxValue-Node (myself out-size)
 	  :where (A[~] OUT[out-size] -> OUT[out-size])
+	  :save-for-backward (t nil)
 	  :backward ((self dout da do)
-		     (declare (ignore dout da do))
-		     (values nil nil))
+		     (declare (ignore do))
+		     ;; only max values are propagated
+
+		     ;; [forward]
+		     ;;     a       out   argmax(a)
+		     ;;   0 3 1      3       1
+		     ;;   3 4 5   -> 5       2
+
+		     ;; [backward]
+		     ;;    dout        result
+		     ;;   dout_1     0 dout_1 0
+		     ;;   dout_2  -> 0 0 dout_2
+		     ;;
+
+		     (let ((mask (A>=scal da (!view (!max da) (broadcast-to da)))))
+		       (values mask nil)))
 	  :documentation "MaxValue-Node finds a maximum value of all elements in A. `OUT` is overwritten with the result.
 
 A is a target to find a maximum value, and OUT is a place to set the index.

--- a/source/base-impl/matrix-ops.lisp
+++ b/source/base-impl/matrix-ops.lisp
@@ -366,7 +366,7 @@ A is a target to find a maximum value, and OUT is a place to set the index.
 		     ;; mask
 		     ;; 0 1 0
 		     ;; 0 0 1
-		     (let ((mask (A=B  da (!view (!min da) (broadcast-to da)))))
+		     (let ((mask (A=B da (!view (!min da) (broadcast-to da)))))
 		       (values (!mul mask (!view dout (broadcast-to mask))) nil)))
 	  :documentation "MinValue-Node finds a minimum value of all elements in A. `OUT` is overwritten with the result.
 

--- a/source/base-impl/package.lisp
+++ b/source/base-impl/package.lisp
@@ -45,7 +45,10 @@
    #:lazy-print)
   (:export
    :node-x
-   :node-y))
+   :node-y)
+  ;; Reshapers
+  (:export
+   #:broadcast-to))
 
 (in-package :cl-waffe2/base-impl)
 	

--- a/source/base-impl/reshapers.lisp
+++ b/source/base-impl/reshapers.lisp
@@ -1,11 +1,33 @@
 
 (in-package :cl-waffe2/base-impl)
 
-(defun broadcast-to (x)
+(defun broadcast-to (object-tensor)
   "
 ## [function] broadcast-to
+
+Returns the subscript of the `!view` that is broadcasting to be the same shape as the `object-tensor`.
+
+For example:
+
+```lisp
+;; x                ... ( 3 3 ) Tensor
+;; (!sum x :axis 1) ... ( 3 1 ) Tensor
+
+;; broadcast-to will return: (t `(:broadcast 3))
+(!mul x (!view (!sum x :axis 1) (broadcast-to x)))
+```
 "
-  (declare (type AbstractTensor x))
-  #'(lambda (view)
-      
-      ))
+  (declare (type AbstractTensor object-tensor))
+  #'(lambda (tensor)
+      (unless (= (dims tensor) (dims object-tensor))
+	(error "broadcast-to: Couldn't broadcast together because ranks does not match. ~a and ~a" tensor object-tensor))
+      (loop for shape-tbc    in (shape tensor)
+	    for shape-object in (shape object-tensor)
+	    if (= shape-tbc shape-object)
+	      collect t
+	    else
+	      collect (progn
+			(unless (= shape-tbc 1)
+			  (error "broadcast-to: Couldn't broadcast two axes, ~a and ~a" (shape tensor) (shape object-tensor)))
+			`(:broadcast ,shape-object)))))
+

--- a/source/base-impl/reshapers.lisp
+++ b/source/base-impl/reshapers.lisp
@@ -1,0 +1,11 @@
+
+(in-package :cl-waffe2/base-impl)
+
+(defun broadcast-to (x)
+  "
+## [function] broadcast-to
+"
+  (declare (type AbstractTensor x))
+  #'(lambda (view)
+      
+      ))

--- a/source/nn/package.lisp
+++ b/source/nn/package.lisp
@@ -17,7 +17,10 @@
   (:export
    #:Conv2D
    #:apply-conv2d
-   #:!im2col-cpu)
+   #:!im2col-cpu
+
+   #:MaxPool2D
+   #:AvgPool2D)
 
   ;; Criterions
   (:export

--- a/source/nn/pool.lisp
+++ b/source/nn/pool.lisp
@@ -7,6 +7,9 @@
 ;; 
 ;;
 
+
+;; TODO: diff !max/!min
+
 (defun conv-out-size (in padding dilation kernel-size stride)
   (floor
    (+ 1 (/ (+ in
@@ -16,7 +19,6 @@
 	      -1)
 	   stride))))
 
-;; XXPoolingNDを実装 -> 引数でdispatch
 (defmodel (MaxPool2D (self kernel-size
 			   &key
 			   (stride 1)
@@ -44,8 +46,32 @@ Applies a 2D max pooling over an input signal composed of several input planes.
 				       -1))
 	   :on-call-> apply-maxpool2d))
 
-;; call->
-;; !max diff
+(defmodel (AvgPool2D (self kernel-size
+			   &key
+			   (stride 1)
+			   (padding 0)
+			   (dilation 1)
+			   &aux
+			   (stride (maybe-tuple stride 'stride))
+			   (padding (maybe-tuple padding 'padding))
+			   (dilation (maybe-tuple dilation 'dilation)))
+	   :slots ((kernel-size :initarg :kernel-size :type list)
+		   (stride :initarg :stride)
+		   (padding :initarg :padding)
+		   (dilation :initarg :dilation))
+	   :documentation "
+Applies a 2D average pooling over an input signal composed of several input planes.
+"
+	   ;; [TODO]: Delete (if (numberp ...))
+	   :where (Input[N C H_in W_in] -> Output[N C H_out W_out]
+			   where
+			   H_out = (if (numberp H_in)
+				       (conv-out-size H_in (car padding) (car dilation) (car kernel-size) (car stride))
+				       -1)
+			   W_out = (if (numberp W_out)
+				       (conv-out-size W_in (second padding) (second dilation) (second kernel-size) (second stride))
+				       -1))
+	   :on-call-> apply-avgpool2d))
 
 (defmethod apply-maxpool2d ((self MaxPool2D) input)
   (with-slots ((stride stride) (kernel-size kernel-size) (padding padding) (dilation dilation)) self
@@ -69,23 +95,42 @@ Applies a 2D max pooling over an input signal composed of several input planes.
 		    (car stride)))
 		  (car stride)))) ;; (sX - (iW + pX * 2 - (kW - 1) * dX) % sX) % s
 
-	(let* ((padded-input (padding input
-				      `(t
-					t
-					(,(second padding)
-					 ,(+ (second padding) p-y))
-					(,(car padding)
-					 ,(+  (car padding)   p-x)))))
-	       (col (!im2col-cpu padded-input
-				 N
-				 C
-				 (second kernel-size)
-				 (car    kernel-size)
-				 h-out
-				 w-out
-				 (car stride)
-				 (second stride)))
-	       (col (!reshape col t (apply #'* kernel-size)))
-	       (out (!max col :axis 1)))
-	  (!permute (!reshape out N h-out w-out C) 3 0 1 2))))))
+	(call-> input
+		(asnode #'padding    `(t t (,(second padding) ,(+ (second padding) p-y)) (,(car padding) ,(+ (car padding) p-x))))
+		(asnode #'!im2col-cpu N C (second kernel-size) (car kernel-size) h-out w-out (car stride) (second stride))
+		(asnode #'!reshape    t (apply #'* kernel-size))
+		(asnode #'!max        :axis 1)
+		(asnode #'!reshape    N h-out w-out C)
+		(asnode #'!permute    3 0 1 2))))))
+
+
+(defmethod apply-avgpool2d ((self AvgPool2D) input)
+  (with-slots ((stride stride) (kernel-size kernel-size) (padding padding) (dilation dilation)) self
+    (multiple-value-bind (N C H-in W-in) (apply #'values (shape input))
+      (let ((H-out (conv-out-size H-in (car padding) (car dilation) (car kernel-size) (car stride)))
+	    (W-out (conv-out-size W-in (second padding) (second dilation) (second kernel-size) (second stride)))
+	    (p-y (mod
+		  (-
+		   (second stride)
+		   (mod
+		    (+ h-in (* 2 (second padding))
+		       (- (* (second dilation) (- (second kernel-size) 1))))
+		    (second stride)))
+		  (second stride))) ;; (sY - (iH + pY * 2 - (kH - 1) * dY) % sY) % sY
+	    (p-x (mod
+		  (-
+		   (car stride)
+		   (mod
+		    (+ w-in (* 2 (car padding))
+		       (- (* (car dilation) (- (car kernel-size) 1))))
+		    (car stride)))
+		  (car stride)))) ;; (sX - (iW + pX * 2 - (kW - 1) * dX) % sX) % s
+
+	(call-> input
+		(asnode #'padding    `(t t (,(second padding) ,(+ (second padding) p-y)) (,(car padding) ,(+ (car padding) p-x))))
+		(asnode #'!im2col-cpu N C (second kernel-size) (car kernel-size) h-out w-out (car stride) (second stride))
+		(asnode #'!reshape    t (apply #'* kernel-size))
+		(asnode #'!mean       :axis 1)
+		(asnode #'!reshape    N h-out w-out C)
+		(asnode #'!permute    3 0 1 2))))))
 

--- a/source/nn/pool.lisp
+++ b/source/nn/pool.lisp
@@ -7,8 +7,7 @@
 ;; 
 ;;
 
-
-;; TODO: diff !max/!min
+;; TODO: Bugfix of !permute
 
 (defun conv-out-size (in padding dilation kernel-size stride)
   (floor
@@ -34,6 +33,18 @@
 		   (dilation :initarg :dilation))
 	   :documentation "
 Applies a 2D max pooling over an input signal composed of several input planes.
+
+### Inputs
+
+`kernel-size[list]` the size of window
+
+`stride[fixnum or list]` the stride of window
+
+`padding[fixnum or list]` adds 0 padding
+
+`dilation[fixnum or list]` a parameter that controls the stride of elements in the window.
+
+Likewise `Conv2D`, these parameters can be set for both X and Y axis directions.
 "
 	   ;; [TODO]: Delete (if (numberp ...))
 	   :where (Input[N C H_in W_in] -> Output[N C H_out W_out]
@@ -61,6 +72,18 @@ Applies a 2D max pooling over an input signal composed of several input planes.
 		   (dilation :initarg :dilation))
 	   :documentation "
 Applies a 2D average pooling over an input signal composed of several input planes.
+
+### Inputs
+
+`kernel-size[list]` the size of window
+
+`stride[fixnum or list]` the stride of window
+
+`padding[fixnum or list]` adds 0 padding
+
+`dilation[fixnum or list]` a parameter that controls the stride of elements in the window.
+
+Likewise `Conv2D`, these parameters can be set for both X and Y axis directions.
 "
 	   ;; [TODO]: Delete (if (numberp ...))
 	   :where (Input[N C H_in W_in] -> Output[N C H_out W_out]

--- a/source/nn/pool.lisp
+++ b/source/nn/pool.lisp
@@ -1,0 +1,91 @@
+
+(in-package :cl-waffe2/nn)
+
+;;
+;; 
+;; 
+;; 
+;;
+
+(defun conv-out-size (in padding dilation kernel-size stride)
+  (floor
+   (+ 1 (/ (+ in
+	      (* 2 padding)
+	      (* (- dilation)
+		 (- kernel-size 1))
+	      -1)
+	   stride))))
+
+;; XXPoolingNDを実装 -> 引数でdispatch
+(defmodel (MaxPool2D (self kernel-size
+			   &key
+			   (stride 1)
+			   (padding 0)
+			   (dilation 1)
+			   &aux
+			   (stride (maybe-tuple stride 'stride))
+			   (padding (maybe-tuple padding 'padding))
+			   (dilation (maybe-tuple dilation 'dilation)))
+	   :slots ((kernel-size :initarg :kernel-size :type list)
+		   (stride :initarg :stride)
+		   (padding :initarg :padding)
+		   (dilation :initarg :dilation))
+	   :documentation "
+Applies a 2D max pooling over an input signal composed of several input planes.
+"
+	   ;; [TODO]: Delete (if (numberp ...))
+	   :where (Input[N C H_in W_in] -> Output[N C H_out W_out]
+			   where
+			   H_out = (if (numberp H_in)
+				       (conv-out-size H_in (car padding) (car dilation) (car kernel-size) (car stride))
+				       -1)
+			   W_out = (if (numberp W_out)
+				       (conv-out-size W_in (second padding) (second dilation) (second kernel-size) (second stride))
+				       -1))
+	   :on-call-> apply-maxpool2d))
+
+;; call->
+;; !max diff
+
+(defmethod apply-maxpool2d ((self MaxPool2D) input)
+  (with-slots ((stride stride) (kernel-size kernel-size) (padding padding) (dilation dilation)) self
+    (multiple-value-bind (N C H-in W-in) (apply #'values (shape input))
+      (let ((H-out (conv-out-size H-in (car padding) (car dilation) (car kernel-size) (car stride)))
+	    (W-out (conv-out-size W-in (second padding) (second dilation) (second kernel-size) (second stride)))
+	    (p-y (mod
+		  (-
+		   (second stride)
+		   (mod
+		    (+ h-in (* 2 (second padding))
+		       (- (* (second dilation) (- (second kernel-size) 1))))
+		    (second stride)))
+		  (second stride))) ;; (sY - (iH + pY * 2 - (kH - 1) * dY) % sY) % sY
+	    (p-x (mod
+		  (-
+		   (car stride)
+		   (mod
+		    (+ w-in (* 2 (car padding))
+		       (- (* (car dilation) (- (car kernel-size) 1))))
+		    (car stride)))
+		  (car stride)))) ;; (sX - (iW + pX * 2 - (kW - 1) * dX) % sX) % s
+
+	(let* ((padded-input (padding input
+				      `(t
+					t
+					(,(second padding)
+					 ,(+ (second padding) p-y))
+					(,(car padding)
+					 ,(+  (car padding)   p-x)))))
+	       (col (!im2col-cpu padded-input
+				 N
+				 C
+				 (second kernel-size)
+				 (car    kernel-size)
+				 h-out
+				 w-out
+				 (car stride)
+				 (second stride)))
+	       (col (!reshape col t (apply #'* kernel-size)))
+	       (out (!max col :axis 1)))
+	  (!permute (!reshape out N h-out w-out C) 3 0 1 2))))))
+


### PR DESCRIPTION
1. added reshapers:

```lisp
;; x                ... ( 3 3 ) Tensor
;; (!sum x :axis 1) ... ( 3 1 ) Tensor

;; broadcast-to will return: (t `(:broadcast 3))
(!mul x (!view (!sum x :axis 1) (broadcast-to x)))
```


2. Added AvgPool2D/MaxPool2D


TODO: backpropagate of `!min` isn't working. backprops of Pooling2D aren't working due to some issues on `!permute`