### PR TITLE
[BugFix] Stablize AD/CNN/define-static-function

### DIFF
--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -28,7 +28,7 @@
 	       (:file "vm/generic-tensor/conditions")
 	       
 	       (:file "vm/generic-tensor/dtype")
-	       (:file "vm/generic-tensor/cache")
+	       
 	       
 	       (:file "vm/generic-tensor/render")
 	       (:file "vm/generic-tensor/default-impls")
@@ -36,6 +36,7 @@
 	       ;; Load package.lisp first. (since scheduling depends on vm/nodes/package, MoveNodeTensor in base-impl/package)
 	       (:file "vm/nodes/package")
 	       (:file "base-impl/package")
+	       (:file "vm/generic-tensor/cache")
 	       (:file "vm/generic-tensor/utils")
 	       (:file "vm/generic-tensor/view")
 	       (:file "vm/generic-tensor/call-with-view")
@@ -57,7 +58,7 @@
 	       (:file "vm/nodes/conditions")
 	       (:file "vm/nodes/defnode")
 	       (:file "vm/nodes/defmodel")
-	       (:file "vm/nodes/utils")	       
+	       (:file "vm/nodes/utils")
 	       (:file "vm/nodes/function")
 	       (:file "vm/nodes/static-node")
 

--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -197,6 +197,7 @@
 	       (:file "backends/JITLispTensor/t/compiler")
 
 	       (:file "nn/t/package")
+	       (:file "nn/t/conv")
 	       (:file "nn/t/activation")
 	       (:file "nn/t/criterion")
 	       (:file "nn/t/regression")

--- a/examples/cnn.lisp
+++ b/examples/cnn.lisp
@@ -13,18 +13,31 @@
 
 (in-package :cl-waffe2-cnn-example)
 
-(defsequence CNN ()
+(defsequence Cifar10-CNN ()
 	     (Conv2D 3 6 `(5 5))
 	     (asnode #'!relu)
-	     (Conv2D 6 12 `(5 5))
+	     (MaxPool2D `(2 2))
+	     (Conv2D 6 16 `(5 5))
 	     (asnode #'!relu)
-	     (asnode #'!reshape t (* 16 5 5))
-	     (LinearLayer (* 16 5 5) 120)
+	     (MaxPool2D `(2 2))
+	     (asnode #'!reshape t (* 16 22 22))
+	     (LinearLayer (* 16 22 22) 120)
 	     (asnode #'!relu)
 	     (LinearLayer 120 84)
 	     (asnode #'!relu)
 	     (LinearLayer 84 10))
 
-(print (CNN))
+;; [TODO]
+;; BugFix on !permute backward.
+;; cl-waffe2/threads:scheduled-pdotimes (i 100) macro
+;;
+
+(defmethod train ((model Cifar10-CNN) x y)
+  (!mean
+   (softmax-cross-entropy
+    (call model x)
+    y)))
+
+(print (Cifar10-CNN))
 
 

--- a/examples/cnn.lisp
+++ b/examples/cnn.lisp
@@ -1,0 +1,30 @@
+
+(in-package :cl-user)
+
+(defpackage :cl-waffe2-cnn-example
+  (:use
+   :cl
+   :cl-waffe2
+   :cl-waffe2/distributions
+   :cl-waffe2/vm.generic-tensor
+   :cl-waffe2/vm.nodes
+   :cl-waffe2/base-impl
+   :cl-waffe2/nn))
+
+(in-package :cl-waffe2-cnn-example)
+
+(defsequence CNN ()
+	     (Conv2D 3 6 `(5 5))
+	     (asnode #'!relu)
+	     (Conv2D 6 12 `(5 5))
+	     (asnode #'!relu)
+	     (asnode #'!reshape t (* 16 5 5))
+	     (LinearLayer (* 16 5 5) 120)
+	     (asnode #'!relu)
+	     (LinearLayer 120 84)
+	     (asnode #'!relu)
+	     (LinearLayer 84 10))
+
+(print (CNN))
+
+

--- a/examples/cnn.lisp
+++ b/examples/cnn.lisp
@@ -9,35 +9,39 @@
    :cl-waffe2/vm.generic-tensor
    :cl-waffe2/vm.nodes
    :cl-waffe2/base-impl
-   :cl-waffe2/nn))
+   :cl-waffe2/nn
+   :cl-waffe2/backends.jit.cpu
+   :cl-waffe2/backends.cpu
+   :cl-waffe2/backends.lisp))
 
 (in-package :cl-waffe2-cnn-example)
 
-(defsequence Cifar10-CNN ()
-	     (Conv2D 3 6 `(5 5))
+;; Parameters: https://www10.cs.fau.de/publications/theses/2022/Master_HolzmannMichael.pdf
+
+(defsequence CNN ()
+	     (Conv2D 3 16  `(3 3))
+	     (asnode #'!relu)     
+	     (MaxPool2D    `(2 2))
+	     (Conv2D 16 32 `(5 5))
 	     (asnode #'!relu)
 	     (MaxPool2D `(2 2))
-	     (Conv2D 6 16 `(5 5))
-	     (asnode #'!relu)
-	     (MaxPool2D `(2 2))
-	     (asnode #'!reshape t (* 16 22 22))
-	     (LinearLayer (* 16 22 22) 120)
-	     (asnode #'!relu)
-	     (LinearLayer 120 84)
-	     (asnode #'!relu)
-	     (LinearLayer 84 10))
+	     (asnode #'!reshape t (* 32 5 5)) 
+	     (LinearLayer (* 32 5 5) 10))
+
 
 ;; [TODO]
 ;; BugFix on !permute backward.
 ;; cl-waffe2/threads:scheduled-pdotimes (i 100) macro
 ;;
 
-(defmethod train ((model Cifar10-CNN) x y)
+(defmethod train ((model CNN) x y)
   (!mean
    (softmax-cross-entropy
     (call model x)
     y)))
 
-(print (Cifar10-CNN))
-
-
+(defun test ()
+  (let ((model (build (train (CNN) (randn `(10 3 32 32)) (randn `(10 10))))))
+    (time (forward model))))
+    
+(print (CNN))

--- a/source/backends/lisp/package.lisp
+++ b/source/backends/lisp/package.lisp
@@ -3,9 +3,11 @@
 
 (defpackage :cl-waffe2/backends.lisp
   (:documentation "cl-waffe2/backends.lisp provides LispBackend provides the Lisp-Backend, which is portable. (only using ANSI Common Lisp)")
-  (:use :cl :cl-waffe2/vm.generic-tensor
-	:cl-waffe2/vm.nodes
-        :cl-waffe2/base-impl)
+  (:use
+   :cl :cl-waffe2/vm.generic-tensor
+   :cl-waffe2/vm.nodes
+   :cl-waffe2/base-impl
+   :cl-waffe2/threads)
   (:export
    #:LispTensor))
 

--- a/source/base-impl/fundamental.lisp
+++ b/source/base-impl/fundamental.lisp
@@ -306,8 +306,8 @@ Tips: If a function is passed as the first element of `subscript`, the subscript
 	     :save-for-backward (t) ;; =T is necessary not to delete MoveTensorNode.
 	     :forward ((self x y)
 		       `(progn
-			  (cl-waffe2/vm.generic-tensor::transfer-vec-information ,y ,x)
-			  ,x)))
+			  (setf (tensor-vec ,y) (tensor-vec ,x))
+			  ,y)))
 
 ;; ===============================================================
 ;; Reshaping APIs
@@ -608,7 +608,7 @@ If `measure-time`=t, ProceedNode wraps with time macro when calling **COMPILED**
 "
   (let* ((node (ProceedNode :measure-time measure-time :compile-mode compile-mode))
 	 ;; Previous Node is already compiled, so detach tensor from nodes.
-	 (out (forward node tensor)))
+	 (out  (forward node tensor)))
     
     ;; Cut off previous backwards
     (setf (tensor-backward tensor) nil)

--- a/source/base-impl/fundamental.lisp
+++ b/source/base-impl/fundamental.lisp
@@ -807,7 +807,7 @@ dout   ... dout values"
 
 (defun permute-backward-order (old-order new-order)
   (loop with rank = (1- (length old-order))
-        for tgt in old-order
+	for tgt in old-order
 	collect (- rank (position tgt new-order))))
 
 (define-and-impl-node (Permute-Node (self before after permute-old)
@@ -820,12 +820,14 @@ dout   ... dout values"
 				     ,a)
 				    out1))
 		       :backward ((self dout a out)
+				  ;;(print (cl-waffe2/vm.generic-tensor::tensor-permute-order a))
+				  ;;(print (cl-waffe2/vm.generic-tensor::tensor-permute-order dout))
 				  (let* ((result
 					   (apply #'!permute
 						  dout
 						  ;; dout.order and a.order -> out.order						     
 						  (permute-backward-order
-						   (cl-waffe2/vm.generic-tensor::tensor-permute-order a)
+						   (loop for i fixnum downfrom (dims a) to 1 collect (1- i))
 						   (cl-waffe2/vm.generic-tensor::tensor-permute-order out)))))
 				    (values result nil))))
   (setf (ignore-shape-error self) t))

--- a/source/base-impl/fundamental.lisp
+++ b/source/base-impl/fundamental.lisp
@@ -900,6 +900,8 @@ Note that the case when only the last two aces are subject to be swapped, we ret
 `order[list<Fixnum>]` An list of permutation. Note that `:~` could be used once in an order If needed. If the order and the number of dimensions of the entered tensor do not match, the part is automatically stored as long as `:~` is provided.
 
 Tips: If the first element of `order` arguments is a function, the rest arguments of `order` is overwritten with its result. that is, `order` become the value of `(funcall (car order) (tensor-permute-order tensor))` and can be used like: `(!permute tensor (compose #'reverse #'tensor-permute-order))` to reverse all permution for example.
+
+Tips: `(!permute tensor (torch-order 2 1 0))` to use the same notation to pytorch.
 "
   ;; If only the last two axes are subject to swapped.
   ;; Return a special node LazyTranspose instead.

--- a/source/base-impl/matrix-ops.lisp
+++ b/source/base-impl/matrix-ops.lisp
@@ -73,6 +73,7 @@ Transposes the last two axes of the given tensor.
 When called with !matmul, the operation is ignored.
 "
 
+  ;; 5 4 3 2 1 0 -> 5 4 3 2 0 1
   (extend-states (!permute tensor :~ 0 1) tensor))
 
 (defun !matmul (x y

--- a/source/base-impl/package.lisp
+++ b/source/base-impl/package.lisp
@@ -48,7 +48,9 @@
    :node-y)
   ;; Reshapers
   (:export
-   #:broadcast-to))
+   #:broadcast-to
+   #:rev-last-two
+   #:torch-order))
 
 (in-package :cl-waffe2/base-impl)
 	

--- a/source/base-impl/reshapers.lisp
+++ b/source/base-impl/reshapers.lisp
@@ -31,3 +31,27 @@ For example:
 			  (error "broadcast-to: Couldn't broadcast two axes, ~a and ~a" (shape tensor) (shape object-tensor)))
 			`(:broadcast ,shape-object)))))
 
+(defun rev-last-two ()
+  "
+## [function] rev-last-two
+"
+
+  #'(lambda (tensor)
+      `(,@(butlast (cl-waffe2/vm.generic-tensor::tensor-permute-order tensor) 2)
+	,@(reverse (last (cl-waffe2/vm.generic-tensor::tensor-permute-order tensor) 2)))))
+
+(defun torch-order (&rest orders)
+  "
+## [function] torch-order
+Translates the given orders into PyTorch's notation
+
+`(!permute a (torch-order 2 1 0))` is the equivalent to `(!permute a 0 1 2)`.
+"
+  #'(lambda (tensor)
+      (let ((dims (1- (dims tensor))))
+	(loop for o in orders
+	      if (eql o :~)
+		collect o
+	      else
+		collect (- dims o)))))
+            

--- a/source/base-impl/t/apis.lisp
+++ b/source/base-impl/t/apis.lisp
@@ -191,4 +191,31 @@
   (is (proceed-continue-test 0))
   (is (proceed-continue-test 1)) ;; 
   (is (proceed-continue-test 2)))
-  
+
+
+(test reshape-permute-test
+  (is (equal `(5 1 5) (shape (proceed (!t (!reshape (ax+b `(5 5) 1 0) 5 5 1))))))
+  (is
+   (let ((a (parameter (ax+b `(3 4 5) 1 0))))
+     (proceed-backward
+      (!sum (!permute (!reshape a 10 3 2 1) 0 3 2 1)))
+     (grad a)))
+  (is
+   (let ((a (parameter (ax+b `(3 4 5) 1 0))))
+     (proceed-backward
+      (!sum (!permute a 1 0 2)))
+     (grad a))))
+
+(test permute-test
+  (is (progn
+	(let ((a (parameter (ax+b `(3 4 5) 1 0))))
+	  (equal (shape (proceed (!permute a 1 0 2))) `(4 5 3))))))
+
+(test permute-composed-test
+  (is (progn
+	(let ((a (parameter (ax+b `(3 4 5) 1 0))))
+	  (proceed-backward
+	   (!permute (!sin (!permute a (torch-order 2 1 0))) 0 1 2))
+	  (grad a)))))
+
+

--- a/source/base-impl/t/apis.lisp
+++ b/source/base-impl/t/apis.lisp
@@ -218,4 +218,16 @@
 	   (!permute (!sin (!permute a (torch-order 2 1 0))) 0 1 2))
 	  (grad a)))))
 
+(test permute-composed-bw-test
+  (is (every #'=
+	     (let ((a (parameter (ax+b `(3 3) 1 0))))
+	       (proceed-backward
+		;;           v
+		(!mul (!t (!add 1.0 a)) (ax+b `(3 3) 1 0)))
+	       (tensor-vec (grad a)))
+	     (let ((a (parameter (ax+b `(3 3) 1 0))))
+	       (proceed-backward
+		;;      v
+		(!mul (!t a) (ax+b `(3 3) 1 0)))
+	       (tensor-vec (grad a))))))
 

--- a/source/nn/conv.lisp
+++ b/source/nn/conv.lisp
@@ -184,5 +184,6 @@ Note: When `Conv2D` is initialised, the output is displayed as -1. This is becau
 
 	    ;; 3 2 1 0 N h-out w-out C_out
 	    ;; 3 0 2 1 N C-out h-out w-out
-	    (!permute (!reshape out (car ~) h-out w-out C-out) 3 0 1 2)))))))
+	    ;; (N h-out w-out c-out) -> (N c-out h-out w-out)
+	    (!permute (!reshape out (car ~) h-out w-out C-out) 3 0 2 1)))))))
 

--- a/source/nn/conv.lisp
+++ b/source/nn/conv.lisp
@@ -176,8 +176,8 @@ Note: When `Conv2D` is initialised, the output is displayed as -1. This is becau
 	  ;; col = im2col(input) ;; (N * h-out w-out, C * kx * ky)
 	  
 	  (let* ((col   (!im2col-cpu input (car ~) in-channels k-h k-w h-out w-out (car stride) (second stride)))
-		 (col-w (!reshape weight t c-out))
-		 (out   (!matmul col col-w))
+		 (col-w (!reshape weight c-out t))
+		 (out   (!matmul col (!t col-w)))
 		 (out   (if bias
 			    (!add out (%transform bias[i] -> [~ i]))
 			    out)))

--- a/source/nn/im2col.lisp
+++ b/source/nn/im2col.lisp
@@ -223,7 +223,9 @@ stride-x stride-y - stride[0], stride[1] respectively.
 			:dtype (dtype padded-x)))
 	 (result (call (Im2ColNode N C k-h k-w h-out w-out stride-x stride-y img-out) padded-x col)))
     (!reshape
-     (!permute result 0 4 5 1 2 3)
+     ;;    [N C k-h k-w h-out w-out]
+     ;; -> N C k-h k-w h-out w-out
+     (!permute result (torch-order 0 4 5 1 2 3))
      (* n h-out w-out)
      t)))
 

--- a/source/nn/im2col.lisp
+++ b/source/nn/im2col.lisp
@@ -128,7 +128,8 @@ stride-x stride-y"
 			(dotimes (a h-out)
 			  (dotimes (b w-out)
 			    ;; img[:, :, y~y_max by stride_y, :, :] += dout[:, :, y, x, :, :]
-			    (incf
+			    ;; [FixME] setf? incf?
+			    (setf
 			     (aref i* (%+ (%* n-i n-stride-o)
 					  (%* c-i c-stride-o)
 					  (%* y-pos h-stride-o)

--- a/source/nn/im2col.lisp
+++ b/source/nn/im2col.lisp
@@ -222,12 +222,12 @@ stride-x stride-y - stride[0], stride[1] respectively.
 			:order (order padded-x)
 			:dtype (dtype padded-x)))
 	 (result (call (Im2ColNode N C k-h k-w h-out w-out stride-x stride-y img-out) padded-x col)))
-    (!reshape
-     ;;    [N C k-h k-w h-out w-out]
-     ;; -> N C k-h k-w h-out w-out
-     (!permute result (torch-order 0 4 5 1 2 3))
-     (* n h-out w-out)
-     t)))
+    
+    ;;    [N C k-h k-w h-out w-out]
+    ;; -> N C k-h k-w h-out w-out
+    (call-> result
+	    (asnode #'!permute (torch-order 0 4 5 1 2 3))
+	    (asnode #'!reshape (* N H-out W-out) t))))
 
 (defun unfold (input dilation kernel-size stride padding)
   "

--- a/source/nn/pool.lisp
+++ b/source/nn/pool.lisp
@@ -7,7 +7,7 @@
 ;; 
 ;;
 
-;; TODO: Bugfix of !permute
+;; TODO: AvgPoolをCopyPasteして書き直す！！
 
 (defun conv-out-size (in padding dilation kernel-size stride)
   (floor
@@ -18,19 +18,20 @@
 	      -1)
 	   stride))))
 
+(defun pool-out-size (in padding kernel-size stride)
+  (floor
+   (+ 1 (/ (+ in (* 2 padding) (- kernel-size)) stride))))
+
 (defmodel (MaxPool2D (self kernel-size
 			   &key
-			   (stride 1)
+			   (stride kernel-size)
 			   (padding 0)
-			   (dilation 1)
 			   &aux
 			   (stride (maybe-tuple stride 'stride))
-			   (padding (maybe-tuple padding 'padding))
-			   (dilation (maybe-tuple dilation 'dilation)))
+			   (padding (maybe-tuple padding 'padding)))
 	   :slots ((kernel-size :initarg :kernel-size :type list)
 		   (stride :initarg :stride)
-		   (padding :initarg :padding)
-		   (dilation :initarg :dilation))
+		   (padding :initarg :padding))
 	   :documentation "
 Applies a 2D max pooling over an input signal composed of several input planes.
 
@@ -42,34 +43,29 @@ Applies a 2D max pooling over an input signal composed of several input planes.
 
 `padding[fixnum or list]` adds 0 padding
 
-`dilation[fixnum or list]` a parameter that controls the stride of elements in the window.
-
 Likewise `Conv2D`, these parameters can be set for both X and Y axis directions.
 "
 	   ;; [TODO]: Delete (if (numberp ...))
 	   :where (Input[N C H_in W_in] -> Output[N C H_out W_out]
 			   where
 			   H_out = (if (numberp H_in)
-				       (conv-out-size H_in (car padding) (car dilation) (car kernel-size) (car stride))
+				       (pool-out-size H_in (car padding) (car kernel-size) (car stride))
 				       -1)
 			   W_out = (if (numberp W_out)
-				       (conv-out-size W_in (second padding) (second dilation) (second kernel-size) (second stride))
+				       (pool-out-size W_in (second padding) (second kernel-size) (second stride))
 				       -1))
 	   :on-call-> apply-maxpool2d))
 
 (defmodel (AvgPool2D (self kernel-size
 			   &key
-			   (stride 1)
+			   (stride kernel-size)
 			   (padding 0)
-			   (dilation 1)
 			   &aux
 			   (stride (maybe-tuple stride 'stride))
-			   (padding (maybe-tuple padding 'padding))
-			   (dilation (maybe-tuple dilation 'dilation)))
+			   (padding (maybe-tuple padding 'padding)))
 	   :slots ((kernel-size :initarg :kernel-size :type list)
 		   (stride :initarg :stride)
-		   (padding :initarg :padding)
-		   (dilation :initarg :dilation))
+		   (padding :initarg :padding))
 	   :documentation "
 Applies a 2D average pooling over an input signal composed of several input planes.
 
@@ -81,42 +77,26 @@ Applies a 2D average pooling over an input signal composed of several input plan
 
 `padding[fixnum or list]` adds 0 padding
 
-`dilation[fixnum or list]` a parameter that controls the stride of elements in the window.
-
 Likewise `Conv2D`, these parameters can be set for both X and Y axis directions.
 "
 	   ;; [TODO]: Delete (if (numberp ...))
 	   :where (Input[N C H_in W_in] -> Output[N C H_out W_out]
 			   where
 			   H_out = (if (numberp H_in)
-				       (conv-out-size H_in (car padding) (car dilation) (car kernel-size) (car stride))
+				       (pool-out-size H_in (car padding)    (car kernel-size) (car stride))
 				       -1)
 			   W_out = (if (numberp W_out)
-				       (conv-out-size W_in (second padding) (second dilation) (second kernel-size) (second stride))
+				       (pool-out-size W_in (second padding) (second kernel-size) (second stride))
 				       -1))
 	   :on-call-> apply-avgpool2d))
 
 (defmethod apply-maxpool2d ((self MaxPool2D) input)
-  (with-slots ((stride stride) (kernel-size kernel-size) (padding padding) (dilation dilation)) self
+  (with-slots ((stride stride) (kernel-size kernel-size) (padding padding)) self
     (multiple-value-bind (N C H-in W-in) (apply #'values (shape input))
-      (let ((H-out (conv-out-size H-in (car padding) (car dilation) (car kernel-size) (car stride)))
-	    (W-out (conv-out-size W-in (second padding) (second dilation) (second kernel-size) (second stride)))
-	    (p-y (mod
-		  (-
-		   (second stride)
-		   (mod
-		    (+ h-in (* 2 (second padding))
-		       (- (* (second dilation) (- (second kernel-size) 1))))
-		    (second stride)))
-		  (second stride))) ;; (sY - (iH + pY * 2 - (kH - 1) * dY) % sY) % sY
-	    (p-x (mod
-		  (-
-		   (car stride)
-		   (mod
-		    (+ w-in (* 2 (car padding))
-		       (- (* (car dilation) (- (car kernel-size) 1))))
-		    (car stride)))
-		  (car stride)))) ;; (sX - (iW + pX * 2 - (kW - 1) * dX) % sX) % s
+      (let* ((H-out (pool-out-size H-in (car padding)    (car kernel-size) (car stride)))
+	     (W-out (pool-out-size W-in (second padding) (second kernel-size) (second stride)))
+	     (p-y (mod H-out (second stride)))
+	     (p-x (mod W-out (car stride))))
 
 	(call-> input
 		(asnode #'padding    `(t t (,(second padding) ,(+ (second padding) p-y)) (,(car padding) ,(+ (car padding) p-x))))
@@ -126,28 +106,13 @@ Likewise `Conv2D`, these parameters can be set for both X and Y axis directions.
 		(asnode #'!reshape    N h-out w-out C)
 		(asnode #'!permute    3 0 1 2))))))
 
-
 (defmethod apply-avgpool2d ((self AvgPool2D) input)
-  (with-slots ((stride stride) (kernel-size kernel-size) (padding padding) (dilation dilation)) self
+  (with-slots ((stride stride) (kernel-size kernel-size) (padding padding)) self
     (multiple-value-bind (N C H-in W-in) (apply #'values (shape input))
-      (let ((H-out (conv-out-size H-in (car padding) (car dilation) (car kernel-size) (car stride)))
-	    (W-out (conv-out-size W-in (second padding) (second dilation) (second kernel-size) (second stride)))
-	    (p-y (mod
-		  (-
-		   (second stride)
-		   (mod
-		    (+ h-in (* 2 (second padding))
-		       (- (* (second dilation) (- (second kernel-size) 1))))
-		    (second stride)))
-		  (second stride))) ;; (sY - (iH + pY * 2 - (kH - 1) * dY) % sY) % sY
-	    (p-x (mod
-		  (-
-		   (car stride)
-		   (mod
-		    (+ w-in (* 2 (car padding))
-		       (- (* (car dilation) (- (car kernel-size) 1))))
-		    (car stride)))
-		  (car stride)))) ;; (sX - (iW + pX * 2 - (kW - 1) * dX) % sX) % s
+      (let* ((H-out (pool-out-size H-in (car padding)    (car kernel-size) (car stride)))
+	     (W-out (pool-out-size W-in (second padding) (second kernel-size) (second stride)))
+	     (p-y (mod H-out (second stride)))
+	     (p-x (mod W-out (car stride))))
 
 	(call-> input
 		(asnode #'padding    `(t t (,(second padding) ,(+ (second padding) p-y)) (,(car padding) ,(+ (car padding) p-x))))
@@ -156,4 +121,3 @@ Likewise `Conv2D`, these parameters can be set for both X and Y axis directions.
 		(asnode #'!mean       :axis 1)
 		(asnode #'!reshape    N h-out w-out C)
 		(asnode #'!permute    3 0 1 2))))))
-

--- a/source/nn/pool.lisp
+++ b/source/nn/pool.lisp
@@ -119,3 +119,4 @@ Likewise `Conv2D`, these parameters can be set for both X and Y axis directions.
 		(asnode #'!mean       :axis 1)
 		(asnode #'!reshape    N h-out w-out C)
 		(asnode #'!permute    3 0 1 2))))))
+

--- a/source/nn/pool.lisp
+++ b/source/nn/pool.lisp
@@ -7,8 +7,6 @@
 ;; 
 ;;
 
-;; TODO: AvgPoolをCopyPasteして書き直す！！
-
 (defun conv-out-size (in padding dilation kernel-size stride)
   (floor
    (+ 1 (/ (+ in

--- a/source/nn/t/conv.lisp
+++ b/source/nn/t/conv.lisp
@@ -91,7 +91,7 @@
 		       (->contiguous
 			(!view (grad prev) i k)))))
 	  (if avg
-	      (setq f (and f (every #'(lambda (x) (= 0.020833334 x)) (tensor-vec window))))
+	      (setq f (and f (every #'(lambda (x) (= 0.0013020834 x)) (tensor-vec window))))
 	      (setq f (and f
 			   (let ((grad-n (count-if #'non-zerop (tensor-vec window)))
 				 (grad-item (find-if #'non-zerop (tensor-vec window))))

--- a/source/nn/t/conv.lisp
+++ b/source/nn/t/conv.lisp
@@ -16,6 +16,18 @@
       (backward compiled-model)
       (let ((ch1)
 	    (f t))
+	#|
+	(print (progn;change-facet
+		(proceed
+		 ;; (N H W C) 3 2 1 0 3 0 1 2
+
+		 ;; (0 1 2 3) kamo
+		 ;; ( 1 0 2 3)
+		 ;; (!permute 2 0 3 1)で(C_out C_in k-h k-w)になる？
+		 ;; (W H N C)
+		 (!reshape (->contiguous (!permute (grad (weight-of model)) 1 0 2 3))
+	6 3 2 2))))
+	|#
 	(print (grad (weight-of model)))
 	(dotimes (i 6)
 	  (dotimes (k 3)

--- a/source/nn/t/conv.lisp
+++ b/source/nn/t/conv.lisp
@@ -4,31 +4,36 @@
 
 (in-suite :nn-test)
 
+(defun conv-2d-forward-test ()
+  (let ((model (Conv2D 3 6 `(2 2))))
+    (equal `(3 6 9 9) (shape (proceed (call model (randn `(3 3 10 10))))))))
+
 (defun conv-2d-fw-bw-test ()
   (let ((model (Conv2D 3 6 `(2 2))))
     (let ((compiled-model
-	    (build (!mean (call model (randn `(3 3 10 10)))))))
+	    (build (!mean (call model (ax+b `(3 3 10 10) 0.001 0))))))
       (forward compiled-model)
       (backward compiled-model)
       (let ((ch1)
 	    (f t))
+	(print (grad (weight-of model)))
 	(dotimes (i 6)
 	  (dotimes (k 3)
 	    (let ((out (proceed (->contiguous (!view (grad (weight-of model)) i k)))))
-	      ;;
-	      ;; (( 0.003 ... ) ( 
-	      ;;
-	      ;;
-	      ;;
+	      ;; [window0]
+	      ;; (ch1.grad ..
+	      ;;  .. ..)
+	      ;;  (ch1.grad ..
+	      ;; .. ..)
+	      ;; ...
+	      
 	      (when (and ch1 f)
 		(setq f (= (vref out 0) ch1)))
 	      (when (every #'= (tensor-vec out))
-		;; bug related to permution?im2col?
+		;; bug related to permution? im2col?
 		(setq f nil))
 	      (setq ch1 (vref out 0)))))
 	f))))
-
-
 
 (defun conv-2d-fw-bw-test-1 ()
   (let ((model (Conv2D 3 6 `(2 2) :bias nil)))
@@ -37,7 +42,7 @@
       (forward compiled-model)
       (backward compiled-model)
       (and
-       (weight-of model)
+       (grad (weight-of model))
        (null (bias-of   model))))))
 
 (defun unfold-test-forward ()
@@ -53,17 +58,22 @@
     (proceed-backward
      (!sum
       (!mul out (ax+b `(2 8) 1 0))))
-    (print (tensor-vec (grad img)))
     (every #'=
 	   #(0.0 1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0 11.0 12.0 13.0 14.0 15.0)
 	   (tensor-vec (grad img)))))
 
 (test conv2d-fw-bw-test
+  (is (conv-2d-forward-test))
   (is (conv-2d-fw-bw-test))
   (is (conv-2d-fw-bw-test-1)))
 
 (test im2col-test
-  (is (unfold-test-forward)))
+  (is (unfold-test-forward))
+  (is (unfold-test-backward)))
 
 
+;; MaxPoolTest
+;; AvgPoolTest
+
+;; Building CNN and proceed it.
 

--- a/source/nn/t/conv.lisp
+++ b/source/nn/t/conv.lisp
@@ -11,24 +11,11 @@
 (defun conv-2d-fw-bw-test ()
   (let ((model (Conv2D 3 6 `(2 2))))
     (let ((compiled-model
-	    (build (!mean (call model (ax+b `(3 3 10 10) 0.001 0))))))
+	    (build
+	     (!mean (call model (ax+b `(3 3 10 10) 0.001 0))))))
       (forward compiled-model)
       (backward compiled-model)
-      (let ((ch1)
-	    (f t))
-	#|
-	(print (progn;change-facet
-		(proceed
-		 ;; (N H W C) 3 2 1 0 3 0 1 2
-
-		 ;; (0 1 2 3) kamo
-		 ;; ( 1 0 2 3)
-		 ;; (!permute 2 0 3 1)で(C_out C_in k-h k-w)になる？
-		 ;; (W H N C)
-		 (!reshape (->contiguous (!permute (grad (weight-of model)) 1 0 2 3))
-	6 3 2 2))))
-	|#
-	(print (grad (weight-of model)))
+      (let ((f t))
 	(dotimes (i 6)
 	  (dotimes (k 3)
 	    (let ((out (proceed (->contiguous (!view (grad (weight-of model)) i k)))))
@@ -39,12 +26,8 @@
 	      ;; .. ..)
 	      ;; ...
 	      
-	      (when (and ch1 f)
-		(setq f (= (vref out 0) ch1)))
-	      (when (every #'= (tensor-vec out))
-		;; bug related to permution? im2col?
-		(setq f nil))
-	      (setq ch1 (vref out 0)))))
+	      (when (and f (every #'(lambda (x) (= x (vref out 0))) (tensor-vec out)))
+		(setq f nil)))))
 	f))))
 
 (defun conv-2d-fw-bw-test-1 ()

--- a/source/nn/t/conv.lisp
+++ b/source/nn/t/conv.lisp
@@ -4,3 +4,66 @@
 
 (in-suite :nn-test)
 
+(defun conv-2d-fw-bw-test ()
+  (let ((model (Conv2D 3 6 `(2 2))))
+    (let ((compiled-model
+	    (build (!mean (call model (randn `(3 3 10 10)))))))
+      (forward compiled-model)
+      (backward compiled-model)
+      (let ((ch1)
+	    (f t))
+	(dotimes (i 6)
+	  (dotimes (k 3)
+	    (let ((out (proceed (->contiguous (!view (grad (weight-of model)) i k)))))
+	      ;;
+	      ;; (( 0.003 ... ) ( 
+	      ;;
+	      ;;
+	      ;;
+	      (when (and ch1 f)
+		(setq f (= (vref out 0) ch1)))
+	      (when (every #'= (tensor-vec out))
+		;; bug related to permution?im2col?
+		(setq f nil))
+	      (setq ch1 (vref out 0)))))
+	f))))
+
+
+
+(defun conv-2d-fw-bw-test-1 ()
+  (let ((model (Conv2D 3 6 `(2 2) :bias nil)))
+    (let ((compiled-model
+	    (build (call model (randn `(3 3 10 10))))))
+      (forward compiled-model)
+      (backward compiled-model)
+      (and
+       (weight-of model)
+       (null (bias-of   model))))))
+
+(defun unfold-test-forward ()
+  (let* ((img (ax+b `(2 2 2 2) 1 0))
+	 (out (cl-waffe2/nn::unfold img `(1 1) `(2 2) `(1 1) `(0 0))))
+    (every #'=
+     #(0.0 1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0 11.0 12.0 13.0 14.0 15.0)
+     (change-facet (proceed out) :direction 'simple-array))))
+
+(defun unfold-test-backward ()
+  (let* ((img (parameter (ax+b `(2 2 2 2) 1 0)))
+	 (out (cl-waffe2/nn::unfold img `(1 1) `(2 2) `(1 1) `(0 0))))
+    (proceed-backward
+     (!sum
+      (!mul out (ax+b `(2 8) 1 0))))
+    (print (tensor-vec (grad img)))
+    (every #'=
+	   #(0.0 1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0 11.0 12.0 13.0 14.0 15.0)
+	   (tensor-vec (grad img)))))
+
+(test conv2d-fw-bw-test
+  (is (conv-2d-fw-bw-test))
+  (is (conv-2d-fw-bw-test-1)))
+
+(test im2col-test
+  (is (unfold-test-forward)))
+
+
+

--- a/source/nn/t/conv.lisp
+++ b/source/nn/t/conv.lisp
@@ -73,8 +73,6 @@
 ;; Building CNN and proceed it.
 
 ;; AvgPool: 0.0208
-;; maxminの逆伝播のテストを挟んだほうがいい
-;; + CNN/MLP学習して最適化のテスト
 
 (defun non-zerop (x) (not (zerop x)))
 
@@ -97,9 +95,9 @@
 	      (setq f (and f
 			   (let ((grad-n (count-if #'non-zerop (tensor-vec window)))
 				 (grad-item (find-if #'non-zerop (tensor-vec window))))
-			     (print grad-n)
+			     ;; randnで奇跡的に衝突する確率=0で計算??
 			     (and
-			      (= grad-n 1)
+			      (= grad-n 16)
 			      (= grad-item 0.020833334)))))))))
     
     f))
@@ -107,4 +105,6 @@
 (test 2d-pool-test
   (is (2d-pool-test nil))
   (is (2d-pool-test t)))
+
+;; Add: CNN/MLP Train tests
 

--- a/source/nn/t/conv.lisp
+++ b/source/nn/t/conv.lisp
@@ -1,0 +1,6 @@
+
+(in-package :cl-waffe2/nn.test)
+
+
+(in-suite :nn-test)
+

--- a/source/nn/t/criterion.lisp
+++ b/source/nn/t/criterion.lisp
@@ -6,6 +6,7 @@
 (defun softmax-cross-entropy-test ()
   (let ((a (parameter (randn `(10 10))))
 	(b (parameter (randn `(10 10)))))
+
     (proceed (!sum (softmax-cross-entropy a b)))))
 
 
@@ -14,12 +15,17 @@
 (defun softmax-cross-entropy-test1 ()
   (let ((a (parameter (randn `(10 10))))
 	(b (parameter (randn `(10 10)))))
-
+    ;;(reset-compiled-function-cache!)
     (proceed-backward (!sum (softmax-cross-entropy (!relu a) (!relu b))))
-    (and
-     (some #'(lambda (x) (not (= x 0))) (tensor-vec (grad a)))
-     (some #'(lambda (x) (not (= x 0))) (tensor-vec (grad b))))))
-    
+    (some #'(lambda (x) (not (= x 0))) (tensor-vec (grad a)))))
+
+;; BugFix
+
+;; (reset-compiled-function-cache!)
+;; (softmax-cross-entropy-test)
+;; (softmax-cross-entropy-test1)
+;; -> error due to MoveTensorNode was ignored.
+;; -> self was duplicated in the cached functions.
 
 (test softmax-cross-entropy-and-static-node-backward
   (is (softmax-cross-entropy-test))

--- a/source/threads.lisp
+++ b/source/threads.lisp
@@ -5,20 +5,43 @@
   (:use :cl :lparallel)
   (:export
    #:*num-cores*
+   #:*multithread-threshold*
+   
    #:with-num-cores
    #:multithread-p
+
    #:maybe-with-lparallel
-   #:maybe-pfuncall))
+
+   #:maybe-pfuncall
+   #:maybe-pdotimes))
 
 (in-package :cl-waffe2/threads)
 
 ;; MultiThreading configs
 
-(defparameter *num-cores* 1 "If 1, Ignored.")
+(defparameter *num-cores* 1 "
+## [parameter] *num-cores*
+
+Indicates the number of cpu cores. Set 1 to disable all multithreading in cl-waffe2.")
+
+(defparameter *multithread-threshold* 80000)
+(declaim (type (unsigned-byte 64) *num-cores* *multithread-threshold*))
+
+(defparameter *under-multi-thread* nil)
 
 (defmacro with-num-cores ((num-core) &body body)
-  `(let ((*num-cores* ,num-core))
-     ,@body))
+  "
+## [macro] with-num-cores
+
+```lisp
+(with-num-cores (num-core) &body body)
+```
+
+Set *num-core*=num-core under the body execution.
+"
+  `(let ((*num-cores* ,num-core)
+	 (*under-multi-thread* (or *under-multi-thread* (= ,num-core 1))))
+     (maybe-with-lparallel ,@body)))
 
 (defun multithread-p ()
   (not (<= (the fixnum *num-cores*) 1)))
@@ -33,4 +56,40 @@
   `(if (multithread-p)
        (pfuncall ,function ,@args)
        (funcall ,function ,@args)))
+
+;; kaettara test
+;; optimize compared to pure dotimes.
+;; gemm ... (with-num-cores (1) ...) is must.
+;; gensym name conflicts?
+(defmacro maybe-pdotimes ((var count) &body body &aux (thread-idx (gensym)))
+  "
+## [macro] maybe-pdotimes
+"
+  (let ((*under-multi-thread* t))
+    (alexandria:with-gensyms (multi-thread-subject count-per-thread multi-thread-part from to)
+      `(flet ((,multi-thread-subject (,from ,to)
+		(declare (type (unsigned-byte 64) ,from ,to))
+		(loop with *under-multi-thread* = t
+		      for ,var fixnum upfrom ,from below ,to
+		      do ,@body)))
+	 (if (or *under-multi-thread*
+		 (= *num-cores* 1)
+		 (< (the fixnum ,count) *multithread-threshold*)
+		 ;; [todo] benchmark
+		 (< (the fixnum ,count) *num-cores*))
+	     ;; If *num-cores* = 1 or count is enough small. ignore parallelize.
+	     (,multi-thread-subject 0 ,count)
+	     (maybe-with-lparallel
+	       (let* ((,count-per-thread  (floor (/ (the fixnum ,count) *num-cores*)))
+		      (,multi-thread-part (* *num-cores* ,count-per-thread)))
+		 (declare (type (unsigned-byte 64) ,count-per-thread ,multi-thread-part))
+		 (pdotimes (,thread-idx *num-cores*)
+		   (locally (declare (type (unsigned-byte 64) ,thread-idx))
+		     (,multi-thread-subject
+		      (the fixnum (* ,thread-idx ,count-per-thread))
+		      (the fixnum (* (1+ ,thread-idx) ,count-per-thread)))))
+		 (,multi-thread-subject
+		  ,multi-thread-part
+		  ,count))))))))
+
 

--- a/source/threads.lisp
+++ b/source/threads.lisp
@@ -13,7 +13,8 @@
    #:maybe-with-lparallel
 
    #:maybe-pfuncall
-   #:maybe-pdotimes))
+   #:maybe-pdotimes
+   #:maybe-ploop))
 
 (in-package :cl-waffe2/threads)
 
@@ -96,4 +97,8 @@ Set *num-core*=num-core under the body execution.
 		  ,multi-thread-part
 		  (the index ,count)))))))))
 
+(defmacro maybe-ploop ((var &key (upfrom 0) (below 0) (by 1)) &body body)
+  `(maybe-pdotimes (,var (- (the index ,below) (the index ,upfrom)))
+     (let ((,var (* ,by (+ ,below ,var))))
+       ,@body)))
 

--- a/source/vm/generic-tensor/call-with-view.lisp
+++ b/source/vm/generic-tensor/call-with-view.lisp
@@ -283,7 +283,6 @@ Return: (values offsets-place form)"
 (defun update-calling-route (value)
   (push value cl-waffe2/vm.nodes::*call-with-view-route*))
 
-
 (defmacro with-bind-shape (&body body)
   `(flet ((original-shape (tensor)
 	    (translate-adjustable-shape (original-shape tensor)))

--- a/source/vm/generic-tensor/interpreter.lisp
+++ b/source/vm/generic-tensor/interpreter.lisp
@@ -201,6 +201,8 @@
 "
   (declare (type AbstractTensor toplevel))
 
+  ;;(reset-compiled-function-cache!) 
+
   (when *force-use-build*
     (return-from vm-build
       (build toplevel :construct-backward? construct-backward? :compile-mode compile-mode)))

--- a/source/vm/generic-tensor/package.lisp
+++ b/source/vm/generic-tensor/package.lisp
@@ -2,7 +2,7 @@
 (in-package :cl-user)
 
 (defpackage :cl-waffe2/vm.generic-tensor
-  (:use :cl :lparallel :bordeaux-threads)
+  (:use :cl :lparallel :bordeaux-threads :cl-waffe2/threads)
 
   (:export
    ;;#:*cache-directory*

--- a/source/vm/generic-tensor/scheduling.lisp
+++ b/source/vm/generic-tensor/scheduling.lisp
@@ -30,8 +30,8 @@
       :non-deterministic))
 
 (defun movetensor-p (node)
-  (or (subtypep (class-of node) 'cl-waffe2/base-impl:MoveTensorNode)
-      (subtypep (class-of node) 'cl-waffe2/base-impl::MoveScalarTensorNode)))
+  (or (subtypep (class-of node) (find-class 'cl-waffe2/base-impl:MoveTensorNode))
+      (subtypep (class-of node) (find-class 'cl-waffe2/base-impl::MoveScalarTensorNode))))
 
 (defmacro ignore-me? (node)
   `(cl-waffe2/base-impl:movetensor-ignore-me ,node))

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -259,8 +259,8 @@ Tensors has a two state:
 		      for o in (tensor-permute-order ,tensor)
 		      for kth upfrom 0
 		      do (let ((pos (- rank o)))
-			   (setf (nth pos ,accessor)
-				 (nth kth copy))))))
+			   (setf (nth kth ,accessor)
+				 (nth pos copy))))))
     (apply-permute (tensor-stride tensor) tensor)
     (apply-permute (tensor-view tensor) tensor)
     (apply-permute (slot-value tensor 'visible-shape) tensor)
@@ -933,7 +933,7 @@ See also: `!permute`
     (error "permute*: The keyword :~~ must be appeared at once.: ~a" orders))
 
   (let* ((tensor-new  (detach-and-clone1 tensor)) ;; Detaching from computation nodes by making a view of T T T....
-	 (old-orders  (tensor-permute-order tensor))
+	 (old-orders (tensor-permute-order tensor))
 	 (pure-orders (remove :~ orders)) ;; order consisted of fixnum
 	 (new-orders
 	   (loop for rank fixnum upfrom 0 below (length (shape tensor))

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -741,8 +741,9 @@ If you added a new backend with having different ptr-type (can't be accessed by 
   ;;  (warn "embody-actual-tensor is gonna destruct ExistTensor: ~a" (shape input-tensor)))
 
   (let ((actual-tensor
-	  (if (and (= (the fixnum (dims actual-tensor)) (the fixnum (dims input-tensor)))
-		   (permuted-p input-tensor))
+	  (if (and (= (the fixnum (dims actual-tensor)) (the fixnum (dims input-tensor)))		   
+		   (permuted-p input-tensor)
+		   (not (equal (shape input-tensor) (shape actual-tensor))))
 	      (apply #'permute* actual-tensor (tensor-permute-order input-tensor))
 	      actual-tensor)))
     

--- a/source/vm/nodes/defnode.lisp
+++ b/source/vm/nodes/defnode.lisp
@@ -104,11 +104,12 @@ reject-when=nil, or (apply reject-when inputs)=t"
   `(let ((*call-with-view-route*))
      ,@body))
 
-(defun vm-kernel-lambda (traceable? name args &rest body)
+(defun vm-kernel-lambda (traceable? name args self &rest body)
   (make-compiled-kernel
    :name name
    :body body
    :args args
+   :self self
    :cache-when-compiled traceable?
    :cache-p (when (and traceable? *call-with-view-route*) t)
    :view-route (if (and traceable? *call-with-view-route*)
@@ -467,7 +468,7 @@ Return nil -> ok
 		      ,@(second forward-body)
 		      (with-tracing-call-with-view
 			(vm-kernel-lambda
-			 ,cache-when-compiled ',fw-name-vm ,inputs
+			 ,cache-when-compiled ',fw-name-vm ,inputs ,forward-self-name
 			 `(named-lambda ,',fw-name-vm ,(map 'list #'tensor-id ,inputs)
 			    (declare (ignorable ,@(map 'list #'tensor-id ,inputs)))
 			    ,,@(car forward-body)))))))


### PR DESCRIPTION
1. Fixed: `MoveTensorNode` `MoveScalarTensorNode` was cached in the same area regardless of `a movetensor-ignore-me` state. Now they're separated without setting cache-when-compiled=t.

2. Fixed: The backward definition of Conv2D/Pool2D was invalid. Now they're working well with new test cases.

3. Fixed: The backward of `!permute` sometimes cause shaping-error. and added `(torch-order )` reshaper.