### PR TITLE
[Enhancement] Improved the user experience on *using-backend*

### DIFF
--- a/source/backends/JITCPUTensor/tensor.lisp
+++ b/source/backends/JITCPUTensor/tensor.lisp
@@ -7,9 +7,17 @@
 "))
 
 (defclass JITCPUScalarTensor (cl-waffe2/vm.generic-tensor:ScalarTensor) nil
-  (:documentation "
-## [AbstractTensor] JITCPUScalarTensor
+  (:documentation "## [AbstractTensor] JITCPUScalarTensor
 "))
+
+(defmethod current-backend-state ((backend-name (eql 'JITCPUTensor)))
+  (format nil "compiler=~a flags=~a viz=~a"
+	  *default-c-compiler*
+	  *compiler-flags*
+	  *viz-compiled-code*))
+
+(defmethod current-backend-state ((backend-name (eql 'JITCPUScalarTensor)))
+  "Use with JITCPUTensor")
 
 (deftype JITAbleTensors ()
   "JITAbleTensor is tensors which are subject to be compiled: JITCPUTensor and ScalarTensor."

--- a/source/backends/JITLispTensor/tensor.lisp
+++ b/source/backends/JITLispTensor/tensor.lisp
@@ -1,26 +1,11 @@
 
 (in-package :cl-waffe2/backends.jit.lisp)
-#|
-(defclass JITLispTensor (AbstractTensor) nil)
 
-(defmethod initialize-instance :before ((tensor JITLispTensor)
-					&rest initargs
-					&key &allow-other-keys)
-  ;; if projected-p -> alloc new vec
-  (let* ((shape (getf initargs :shape))
-	(dtype (dtype->lisp-type (getf initargs :dtype)))
-	(vec   (getf initargs :vec))
-	(facet (getf initargs :facet))
-	(initial-element (coerce (or (getf initargs :initial-element) 0) dtype)))
-    (when (eql facet :exist)
-      (if vec
-	  (setf (tensor-vec tensor) vec)
-	  (setf (tensor-vec tensor)
-		(make-array
-		 (apply #'* shape)
-		 :element-type dtype
-		 :initial-element initial-element))))))
+(defclass JITLispTensor (cl-waffe2/backends.lisp:LispTensor) nil
+  (:documentation "
+## [AbstractTensor] JITLispTensor
+"))
 
-|#
+(defmethod current-backend-state ((backend-name (eql 'JITLispTensor)))
+  "To be deleted in the future release. do not use this.")
 
-(defclass JITLispTensor (cl-waffe2/backends.lisp:LispTensor) nil)

--- a/source/backends/cpu/package.lisp
+++ b/source/backends/cpu/package.lisp
@@ -49,9 +49,12 @@ For example:
   (if (boundp 'cl-user::*cl-waffe-config*)
       (let ((config (list-to-hash (eval 'cl-user::*cl-waffe-config*))))
 	(dolist (path (gethash :libblas config))
-	  (load-foreign-library (pathname path))))
+	  (load-foreign-library (pathname path)))
+	(setf *openblas-found-p* t))
       ;; Continue by finding with default path:
-      (handler-case (load-foreign-library 'blas-lib)
+      (handler-case (progn
+		      (load-foreign-library 'blas-lib)
+		      (setf *openblas-found-p* t))
 	(error (c)
 	  (declare (ignore c))
 	  (could-not-find))))

--- a/source/backends/cpu/package.lisp
+++ b/source/backends/cpu/package.lisp
@@ -5,50 +5,56 @@
   (:documentation "The package :cl-waffe2/backends.cpu provides the BLAS Backend to cl-waffe. Note that this package is SBCL-Dependant.")
   (:use :cl :cl-waffe2/vm.generic-tensor :cl-waffe2/vm.nodes :cffi :cl-waffe2/base-impl)
   (:export
-   :CPUTensor))
+   :CPUTensor
+   :find-and-load-libblas))
 
 (in-package :cl-waffe2/backends.cpu)
 
 
+(defparameter *openblas-found-p* nil)
 ;; Utils
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  
+
 (defun list-to-hash (list)
   (let ((hash (make-hash-table :test 'eql)))
     (dolist (element list)
       (setf (gethash (car element) hash) (cdr element)))
     hash))
 
-;;#+sbcl(setf cl-waffe2/vm.generic-tensor:*using-backend* `(cl-waffe2/backends.cpu:CPUTensor cl-waffe2/backends.lisp:LispTensor))
 (setf cl-waffe2/vm.generic-tensor:*using-backend* `(cl-waffe2/backends.cpu:CPUTensor cl-waffe2/backends.lisp:LispTensor))
 
 ;; TODO: Delete this alert with *cl-waffe-never-use-blas* = t
 (defun could-not-find ()
-  (format t "
-== Note [About CPUTensor's Performance] ========================
-cl-waffe could not find the OpenBLAS shared library (e.g.: libblas.dylib, the path could be found with the locate command or something), continuing without blas, but using the Common Lisp backend. (i.e.:LispTensor)
+  (warn "
+cl-waffe2 tried to use OpenBLAS, but CFFI could not find the OpenBLAS shared library (e.g.: libblas.dylib, the path could be found with the locate command or something), therefore, the operations continuing without blas, and using LispTensor.
 
-To continue with BLAS, Add the following code to the initialisation file and restart your program. (e.g.: ~~/.sbclrc, ~~/.roswell/init.lisp), otherwise **THE PERFORMANCE MAY DECREASE**.
+**`LispTensor` do not provide SIMD-enabled backend and implementation for `MatmulNode`.**
 
+So, if you want to use them, Explict the library path by adding the following code to the initialisation file (e.g.: ~~/.sbclrc, ~~/.roswell/init.lisp), and invoke the (cl-waffe2/backends.cpu:find-and-load-libblas) function. 
+
+For example:
 ```lisp
-
 ;; In ~~/.sbclrc for example:
 (defparameter *cl-waffe-config*
-    `((:libblas \"libblas.dylib for example\")))
-
+    `((:libblas \"libblas.dylib\")))
 ```
-================================================================
 ")
 
   (setf cl-waffe2/vm.generic-tensor:*using-backend* `(cl-waffe2/backends.lisp:LispTensor)))
+
+(cffi:define-foreign-library blas-lib
+  (t (:default "libblas")))
 
 (defun find-and-load-libblas ()
   (if (boundp 'cl-user::*cl-waffe-config*)
       (let ((config (list-to-hash (eval 'cl-user::*cl-waffe-config*))))
 	(dolist (path (gethash :libblas config))
-	  (load-foreign-library
-	   (pathname path))))
-      (could-not-find))
+	  (load-foreign-library (pathname path))))
+      ;; Continue by finding with default path:
+      (handler-case (load-foreign-library 'blas-lib)
+	(error (c)
+	  (declare (ignore c))
+	  (could-not-find))))
   nil)
 
 (defun warn-blas-without-sbcl ()
@@ -60,7 +66,5 @@ To continue with BLAS, Add the following code to the initialisation file and res
 
 ;; Load libblas.dylib
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  (find-and-load-libblas)
-  ;;#-sbcl(warn-blas-without-sbcl)
-  )
+  (find-and-load-libblas))
 

--- a/source/backends/cpu/tensor.lisp
+++ b/source/backends/cpu/tensor.lisp
@@ -4,8 +4,10 @@
 (defclass CPUTensor (AbstractTensor) nil
   (:documentation "
 ## [AbstractTensor] CPUTensor
-
 "))
+
+(defmethod current-backend-state ((backend-name (eql 'CPUTensor)))
+  (format nil "BLAS=~a" *openblas-found-p*))
 
 (defmethod initialize-instance :before ((tensor CPUTensor)
 					&rest initargs

--- a/source/backends/cpu/tensor.lisp
+++ b/source/backends/cpu/tensor.lisp
@@ -7,7 +7,10 @@
 "))
 
 (defmethod current-backend-state ((backend-name (eql 'CPUTensor)))
-  (format nil "BLAS=~a" *openblas-found-p*))
+  (format nil "OpenBLAS=~a"
+	  (if *openblas-found-p*
+	      "available"
+	      "could not find")))
 
 (defmethod initialize-instance :before ((tensor CPUTensor)
 					&rest initargs

--- a/source/backends/lisp/tensor.lisp
+++ b/source/backends/lisp/tensor.lisp
@@ -3,7 +3,11 @@
 
 (defclass LispTensor (AbstractTensor) nil
   (:documentation "
-## [AbstractTensor] LispTensor"))
+## [AbstractTensor] LispTensor
+"))
+
+(defmethod current-backend-state ((backend-name (eql 'LispTensor)))
+  "Common Lisp implementation on matrix operations")
 
 (defmethod initialize-instance :before ((tensor LispTensor)
 					&rest initargs

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -28,6 +28,7 @@
    #:with-row-major
    #:with-cpu
 
+   #:show-backends
    #:set-devices-toplevel
    ;;#:with-cuda
    )

--- a/source/utils.lisp
+++ b/source/utils.lisp
@@ -60,9 +60,6 @@
 
 
 ;; TODO: Add set-config for REPL.
-
-
-
 (defun collect-initarg-slots (slots constructor-arguments)
   (map 'list #'(lambda (slots)
 		 ;; Auto-Generated Constructor is Enabled Only When:
@@ -86,3 +83,78 @@
   
   (setf cl-waffe2/vm.generic-tensor:*using-backend* devices))
 
+(defun find-available-backends (&optional (from (find-class 'cl-waffe2/vm.generic-tensor:AbstractTensor)))
+  (let ((classes (c2mop:class-direct-subclasses from)))
+    (map 'list
+	 #'(lambda (class-from)
+	     `(,class-from ,@(find-available-backends class-from)))
+	 classes)))
+
+(defun rendering-backends-tree-to (tree-top out)
+  (labels ((rendering-helper (tree-from indent-level)
+	     (format out "~%")
+	     (dotimes (i indent-level) (princ " " out))
+	     (let ((using-p (find (format nil "~a" (class-name (car tree-from)))
+				  *using-backend*
+				  :key #'symbol-name
+				  :test #'equal)))
+	       (format out "~a~a~a: ~a"
+		       ;; Now the computation is done under the device?
+		       ;; -> If so, add *
+		       (if (= indent-level 0)
+			   ""
+			   "└")
+		       (if using-p
+			   "[*]"
+			   "[-]")
+		       (class-name (car tree-from))
+		       (current-backend-state (class-name (car tree-from))))
+	       (let ((indent-level (+ indent-level 4)))
+		 (dolist (more (cdr tree-from))
+		   (rendering-helper more indent-level))))))
+    (rendering-helper tree-top 0)))
+
+(defun show-backends (&key (stream t))
+  "
+## [function] show-backends
+
+```lisp
+(show-backends &key (stream t))
+```
+
+collects and displays the current state of devices to the given `stream`
+"
+
+  (format stream "~%~a"
+	  (with-output-to-string (out)
+	    (let ((backends-tree (find-available-backends)))
+	      (dotimes (i 5)  (princ "─" out))
+	      (princ "[All Backends Tree]" out)
+	      (dotimes (i 50) (princ "─" out))
+	      (mapc #'(lambda (tree)
+			(format out "~%")
+			(rendering-backends-tree-to tree out))
+		    backends-tree)
+	      (format out "~%~%([*] : in use, [-] : not in use.)")
+	      (format out "~%Add a current-backend-state method to display the status.~%")
+
+	      
+	      (dotimes (i 5)  (princ "─" out))
+	      (princ "[*using-backend*]" out)
+	      (dotimes (i 51) (princ "─" out))
+
+	      (format out "~%~%")
+	      (let ((total-namelen 0))
+		(dolist (name *using-backend*)
+		  (incf total-namelen (length (symbol-name name))))
+
+		(format out "Priority: Higher <")
+		(dotimes (i total-namelen) (princ "─" out))
+		(format out ">Lower~%")
+		(format out "                  ")
+		(dolist (name *using-backend*)
+		  (princ (symbol-name name) out)
+		  (princ " " out))
+
+		(format out "~%~%(a with-devices macro or set-devices-toplevel function to change this parameter.)~%"))))))
+		

--- a/source/utils.lisp
+++ b/source/utils.lisp
@@ -156,5 +156,5 @@ collects and displays the current state of devices to the given `stream`
 		  (princ (symbol-name name) out)
 		  (princ " " out))
 
-		(format out "~%~%(a with-devices macro or set-devices-toplevel function to change this parameter.)~%"))))))
+		(format out "~%~%(use with-devices macro or set-devices-toplevel function to change this parameter.)~%"))))))
 		

--- a/source/vm/generic-tensor/default-impls.lisp
+++ b/source/vm/generic-tensor/default-impls.lisp
@@ -1,11 +1,9 @@
 
 (in-package :cl-waffe2/vm.generic-tensor)
 
-(defclass DebugTensor (AbstractTensor) nil)
-
 (defclass ScalarTensor (AbstractTensor)
   nil
-  (:documentation "The class ScalarTensor, is used to represent scalar-object."))
+  (:documentation "The class ScalarTensor, is used to represent scalar values."))
 
 (defmethod initialize-instance :before ((tensor ScalarTensor) &rest initargs &key &allow-other-keys)
   (declare (ignore initargs))
@@ -17,4 +15,7 @@
 (defmethod vref ((tensor ScalarTensor) index)
   (declare (ignore index))
   (tensor-vec tensor))
+
+(defmethod current-backend-state ((backend-name (eql 'ScalarTensor)))
+  "is a special tensor for representing scalar values.")
 

--- a/source/vm/generic-tensor/package.lisp
+++ b/source/vm/generic-tensor/package.lisp
@@ -18,6 +18,8 @@
   (:export
    #:AbstractTensor
    #:ScalarTensor
+
+   #:current-backend-state
    
    #:tensor-backward
    #:read-result

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -159,6 +159,12 @@ Users can define a new implementation following `(define-impl (Name :device MyBa
 
 (See the examples to understand how this could be achieved at ./source/backends/lisp/tensor.lisp. or ./source/backends/cpu.)
 
+Note: add `print-tensor-state` method like: `(defmethod current-backend-state (device (eql 'YourDeviceName)) \"It is working\")` in order for `(show-backends)` function display your backends state.
+
+```lisp
+(defmethod current-backend-state ((backend-name (eql 'YourBackendName)))
+  \"This is MyTensor\")
+```
 ### [function] shape
 
 Returns a visible shape of tensor
@@ -257,6 +263,15 @@ Tensors has a two state:
 ...
 
 "))
+
+
+(defgeneric current-backend-state (backend-name)
+  (:documentation "The generic function current-backend-state is used to rendering (show-backends) function."))
+
+(defmethod current-backend-state ((backend-name t))
+  (if (next-method-p)
+      (call-next-method)
+      "No status."))
 
 (defun sync-permute! (tensor)
   (declare (type AbstractTensor tensor))


### PR DESCRIPTION
## Added a (show-backends) function.

```lisp
CL-WAFFE2-REPL> (show-backends)

─────[All Backends Tree]──────────────────────────────────────────────────

[*]CPUTENSOR: OpenBLAS=available
    └[-]JITCPUTENSOR: compiler=gcc flags=(-fPIC -O3 -march=native) viz=NIL

[*]LISPTENSOR: Common Lisp implementation on matrix operations
    └[-]JITLISPTENSOR: To be deleted in the future release. do not use this.

[-]SCALARTENSOR: is a special tensor for representing scalar values.
    └[-]JITCPUSCALARTENSOR: Use with JITCPUTensor

[-]DEBUGTENSOR: Not anymore used.

([*] : in use, [-] : not in use.)
Add a current-backend-state method to display the status.
─────[*using-backend*]───────────────────────────────────────────────────

Priority: Higher <───────────────────>Lower
                  CPUTENSOR LISPTENSOR 

(use a with-devices macro or set-devices-toplevel function to change this parameter.)
```

## CPUTensor tries to find `libblas.dylib` without any configurations.