### PR TITLE
[Refactor] Moved the definition of Im2ColNode/Col2ImNode

### DIFF
--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -95,6 +95,7 @@
 	       (:file "base-impl/transform")
 	       (:file "base-impl/ir")
 	       (:file "base-impl/reshapers")
+	       (:file "base-impl/unfold")
 
 	       
 	       (:file "vm/ir")

--- a/docs/apis/nn.lisp
+++ b/docs/apis/nn.lisp
@@ -33,5 +33,6 @@
 	"(Conv2D 3 5 '(3 3))"))
 
     (with-nn-doc (find-class 'MaxPool2D) 't)
-    (with-nn-doc (find-class 'AvgPool2D) 't)))
+    (with-nn-doc (find-class 'AvgPool2D) 't)
+    (with-nn-doc 'unfold 'function)))
 

--- a/docs/apis/reference.lisp
+++ b/docs/apis/reference.lisp
@@ -106,6 +106,9 @@
 
     (nodedoc Where-Operation-Node)
     (nodedoc Compare-Operation-Node)
+
+    (nodedoc Im2ColNode)
+    (nodedoc Col2ImNode)
     ))
 
 

--- a/docs/cl-waffe2-docs/docs/distributions.md
+++ b/docs/cl-waffe2-docs/docs/distributions.md
@@ -16,11 +16,11 @@ That is, arguments passed to the `make-tensor` function can also be passed direc
 (normal `(10 10) 0.0 1.0 :requires-grad t)
 
 {CPUTENSOR[float] :shape (10 10)  
-  ((0.35961813   -0.2059159   1.4001919    ~ 0.077898845  -0.44244626  1.0635623)                    
-   (-1.016495    1.9627005    -1.1844752   ~ 0.15047064   -0.95344716  -1.6598125)   
+  ((0.16792156   -0.10029652  1.2373703    ~ -0.6597983   0.5364762    0.04105287)                    
+   (1.0244042    -0.13725741  -0.047362786 ~ -1.8057569   -0.619261    1.5115738)   
                  ...
-   (-1.2152638   0.30550015   0.012917101  ~ -0.06799416  -0.3919469   0.2048984)
-   (0.16792156   -0.10029652  1.2373703    ~ -0.6597983   0.5364762    0.04105287))
+   (2.33992      1.6060683    0.9300644    ~ -0.054281436 -1.0800586   0.50296426)
+   (-0.055973418 0.49441746   0.88600993   ~ -0.7703765   -1.3059596   -0.53699577))
   :facet :exist
   :requires-grad T
   :backward NIL}
@@ -146,9 +146,9 @@ Note: My implementation is unstable, being occurs floating-overflow constantly..
 (beta `(3 3) 5.0 1.0)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((0.69012284 0.75272816 0.8312693)
-   (0.9785166  0.80858713 0.95975447)
-   (0.6866892  0.903407   0.97475606))
+  ((0.8778268  0.66983104 0.9397397)
+   (0.89210486 0.9729618  0.9380881)
+   (0.6186232  0.7804173  0.8834279))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -170,8 +170,8 @@ p - Takes 1 with probability p and 0 with probalibity (1-p).
 (bernoulli `(3 3) 0.3)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((1.0 0.0 0.0)
-   (0.0 1.0 1.0)
+  ((0.0 0.0 0.0)
+   (0.0 0.0 0.0)
    (0.0 0.0 0.0))
   :facet :exist
   :requires-grad NIL
@@ -198,9 +198,9 @@ df - degree of freedom.
 (chisquare `(3 3) 1.0)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((0.3276539    0.16197506   0.92448807)
-   (0.65705556   3.8677952e-4 0.33302397)
-   (0.30150574   0.2048448    1.2764052))
+  ((0.9639289   0.024341421 0.12964393)
+   (0.1518384   0.46994787  0.18374352)
+   (0.10620031  0.03474931  0.27505326))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -227,9 +227,9 @@ The function expotential is a family of initializer functions, and samples the e
 (expotential `(3 3))
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((2.0468602   0.42217332  0.035641003)
-   (1.5259378   0.16441894  0.5597292)
-   (4.225213    0.08620251  0.68291944))
+  ((0.74278194 0.495115   0.45115978)
+   (0.40994883 0.5290213  0.45308283)
+   (0.7578804  0.2420781  0.82110137))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -252,9 +252,9 @@ The function gamma is a family of initializer functions, and samples matrices fr
 (gamma `(3 3) 1.0)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((0.019726882 0.37907955  0.17126423)
-   (2.2088544   0.9756858   1.9436338)
-   (4.3594155   0.21998532  0.91787076))
+  ((0.44128695 1.8462971  0.31028208)
+   (3.9424787  1.4556859  0.0943238)
+   (0.63110554 0.6477464  0.33288977))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -309,9 +309,9 @@ Input:
 (uniform-random `(3 3) 2 4)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((3.263076  3.1209097 2.6771405)
-   (2.324503  3.5176752 3.7175438)
-   (3.8339875 3.1028507 3.2144558))
+  ((2.0554366 2.1221638 3.6959133)
+   (2.976297  2.7592049 2.0000896)
+   (3.0157723 3.9196885 3.6060781))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -339,9 +339,9 @@ The function randn is a family of initializer functions, and samples the gaussia
 (randn `(3 3))
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((1.5321895  0.46990195 1.4406842)
-   (0.56609684 -0.5118705 0.561935)
-   (0.8702531  1.035412   -1.2831343))
+  ((1.2832842   -0.450628   -1.5319579)
+   (0.25592577  0.14667411  -0.5028152)
+   (-0.22918718 -0.03554478 1.3815418))
   :facet :exist
   :requires-grad NIL
   :backward NIL}

--- a/docs/cl-waffe2-docs/docs/generic-tensor.md
+++ b/docs/cl-waffe2-docs/docs/generic-tensor.md
@@ -368,7 +368,7 @@ After working with adjustable shape tensor, don't forget to embody the InputTens
 > (setq out (!add (randn `(10 10)) (make-input `(a 10) :X)))
 ```
 ```
-{CPUTENSOR[float] :shape (10 10) :named ChainTMP855 
+{CPUTENSOR[float] :shape (10 10) :named ChainTMP991 
   :vec-state [maybe-not-computed]
   <<Not-Embodied (10 10) Tensor>>
   :facet :input
@@ -384,10 +384,10 @@ After working with adjustable shape tensor, don't forget to embody the InputTens
 (<Compiled-Composite
     forward:  #<FUNCTION (LAMBDA ()
                            :IN
-                           "/Users/hikettei/.cache/common-lisp/sbcl-2.3.4-macosx-x64/Users/hikettei/Desktop/cl-waffe-workspace/progs/develop/waffe2-develop-latest/cl-waffe2/docs/apis/generic-tensor.fasl") {53A7DB4B}>
+                           "/Users/hikettei/.cache/common-lisp/sbcl-2.3.4-macosx-x64/Users/hikettei/Desktop/cl-waffe-workspace/progs/develop/waffe2-develop-latest/cl-waffe2/docs/apis/generic-tensor.fasl") {53A466CB}>
     backward: #<FUNCTION (LAMBDA ()
                            :IN
-                           "/Users/hikettei/.cache/common-lisp/sbcl-2.3.4-macosx-x64/Users/hikettei/Desktop/cl-waffe-workspace/progs/develop/waffe2-develop-latest/cl-waffe2/docs/apis/generic-tensor.fasl") {53A7DDCB}>
+                           "/Users/hikettei/.cache/common-lisp/sbcl-2.3.4-macosx-x64/Users/hikettei/Desktop/cl-waffe-workspace/progs/develop/waffe2-develop-latest/cl-waffe2/docs/apis/generic-tensor.fasl") {53A45D6B}>
 
 += [Tensors in the computation node] =======+
 

--- a/docs/cl-waffe2-docs/docs/nn.md
+++ b/docs/cl-waffe2-docs/docs/nn.md
@@ -13,13 +13,13 @@ ReLU(x) = max(x, 0)
 ```lisp
 (proceed (!relu (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (10 10) :named ChainTMP944 
+{CPUTENSOR[float] :shape (10 10) :named ChainTMP1080 
   :vec-state [computed]
-  ((2.4517038    -0.0         0.3958751    ~ 1.2826939    1.3563212    -0.0)                    
-   (-0.0         2.0355937    0.87400746   ~ 0.5758207    0.32484004   -0.0)   
-                 ...
-   (0.76103824   0.080851234  -0.0         ~ 0.1685591    -0.0         -0.0)
-   (-0.0         0.14430979   1.6049826    ~ 0.66292197   -0.0         -0.0))
+  ((0.14430979  1.6049826   0.69115645  ~ -0.0        -0.0        -0.0)                   
+   (-0.0        -0.0        0.17293061  ~ -0.0        -0.0        0.37313056)   
+                ...
+   (0.7793865   1.1814722   0.70569587  ~ -0.0        -0.0        -0.0)
+   (0.4090601   -0.0        -0.0        ~ -0.0        -0.0        1.4335165))
   :facet :input
   :requires-grad NIL
   :backward <Node: PROCEEDNODE-T (A[~] -> A[~])>}
@@ -42,13 +42,13 @@ Sigmoid(x) = \frac{1}{1 + exp(-x)}
 ```lisp
 (proceed (!sigmoid (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (10 10) :named ChainTMP1212 
+{CPUTENSOR[float] :shape (10 10) :named ChainTMP1348 
   :vec-state [computed]
-  ((0.22403896  0.38870513  0.31420857  ~ 0.052870475 0.44819808  0.48854244)                   
-   (0.59221524  0.49752915  0.45874146  ~ 0.33162943  0.3568413   0.26439044)   
-                ...
-   (0.33826295  0.6008625   0.28127894  ~ 0.41916075  0.1272022   0.43307915)
-   (0.8074486   0.17289545  0.40895566  ~ 0.5744591   0.66711944  0.48927152))
+  ((0.17289545 0.40895566 0.6800641  ~ 0.66711944 0.48927152 0.7403083)                  
+   (0.42706847 0.89801675 0.45782068 ~ 0.42497367 0.7186789  0.88597995)   
+               ...
+   (0.660299   0.6358208  0.63479567 ~ 0.37265834 0.9108884  0.33976826)
+   (0.94103944 0.17914216 0.16671297 ~ 0.52181995 0.68677187 0.78604746))
   :facet :input
   :requires-grad NIL
   :backward <Node: PROCEEDNODE-T (A[~] -> A[~])>}
@@ -75,9 +75,9 @@ In addition, reading the value of a `:reduction` keyword (one of `:mean` `:sum` 
 ```lisp
 (proceed (L1Norm (randn `(10 10)) (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (1 1) -> :view (<(BROADCAST 1)> <(BROADCAST 1)>) -> :visible-shape (1 1) :named ChainTMP1581 
+{CPUTENSOR[float] :shape (1 1) -> :view (<(BROADCAST 1)> <(BROADCAST 1)>) -> :visible-shape (1 1) :named ChainTMP1717 
   :vec-state [computed]
-  ((1.2146416))
+  ((1.1279733))
   :facet :input
   :requires-grad NIL
   :backward <Node: PROCEEDNODE-T (A[~] -> A[~])>}
@@ -102,9 +102,9 @@ In addition, reading the value of a `:reduction` keyword (one of `:mean` `:sum` 
 ```lisp
 (proceed (MSE (randn `(10 10)) (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (1 1) -> :view (<(BROADCAST 1)> <(BROADCAST 1)>) -> :visible-shape (1 1) :named ChainTMP1898 
+{CPUTENSOR[float] :shape (1 1) -> :view (<(BROADCAST 1)> <(BROADCAST 1)>) -> :visible-shape (1 1) :named ChainTMP2034 
   :vec-state [computed]
-  ((1.4518497))
+  ((1.3892205))
   :facet :input
   :requires-grad NIL
   :backward <Node: PROCEEDNODE-T (A[~] -> A[~])>}
@@ -196,7 +196,7 @@ y = xA^\intercal + b
 ```lisp
 (LinearLayer 10 5)
 
-<Composite: LINEARLAYER{W1905}(
+<Composite: LINEARLAYER{W2041}(
     <Input : ((~ BATCH-SIZE 10)) -> Output: ((~ BATCH-SIZE 5))>
 
     WEIGHTS -> (5 10)
@@ -284,7 +284,7 @@ Note: When `Conv2D` is initialised, the output is displayed as -1. This is becau
 ```lisp
 (Conv2D 3 5 '(3 3))
 
-<Composite: CONV2D{W1915}(
+<Composite: CONV2D{W2051}(
     <Input : ((N 3 H_IN W_IN)) -> Output: ((N 5 -1 -1))>
 
     WEIGHT -> (5 3 3 3)
@@ -369,3 +369,31 @@ Applies a 2D average pooling over an input signal composed of several input plan
 
 Likewise `Conv2D`, these parameters can be set for both X and Y axis directions.
 
+
+## [function] unfold
+
+```lisp
+(unfold input dilation kernel-size stride padding)
+```
+
+Extracts sliding local blocks from a batched input tensor. The detailed specifications follow PyTorch: [nn.Unfold](https://pytorch.org/docs/stable/generated/torch.nn.Unfold.html).
+
+As of this writing, `input` must be a 4D Tensor even when `N=batch-size=1`.
+
+Corresponding nodes: `cl-waffe2/base-impl:Im2ColNode`, `cl-waffe2/base-impl:Col2ImNode`
+
+### Inputs
+
+Note that `dilation`, `kernel-size`, `stride`, and `padding` are given in this form:
+
+`(list y-direction(Height) x-direction(Width))`
+
+`input[AbstractTensor]` the tensor to be unfold.
+
+`dilation[list]` a parameter that controls the stride of elements within the neighborhood.
+
+`kernel-size[list]` the size of sliding blocks.
+
+`padding[list]` implicts the number of zero-padding to be added on both sides of input.
+
+`stride[list]` the number of stride of the sliding blocks.

--- a/docs/cl-waffe2-docs/docs/utils.md
+++ b/docs/cl-waffe2-docs/docs/utils.md
@@ -160,4 +160,8 @@ Priority: Higher <───────────────────>Lowe
 
 ## [function] set-devices-toplevel
 
+```lisp
+(set-devices-toplevel &rest devices)
+```
+
 Declares devices to use.

--- a/source/base-impl/unfold.lisp
+++ b/source/base-impl/unfold.lisp
@@ -1,6 +1,51 @@
 
 (in-package :cl-waffe2/base-impl)
 
-;; TODO: Include it in cl-waffe2.asd
+;; Provides im2col/col2im node
 
+(export '(Im2ColNode N C k-h k-w h-out w-out stride-x stride-y img-out img-out-of h h-of w w-of))
+(defnode (Im2ColNode (self N C k-h k-w h-out w-out stride-x stride-y img-out)
+	  :slots ((N :initarg :N)
+		  (C :initarg :C)
+		  (k-h :initarg :k-h)
+		  (k-w :initarg :k-w)
+		  (h-out :initarg :h-out)
+		  (w-out :initarg :w-out)
+		  (stride-x :initarg :stride-x)
+		  (stride-y :initarg :stride-y)
+		  (img-out :initarg :img-out :reader img-out-of)
+		  (h :accessor h-of)
+		  (w :accessor w-of))
+	  :documentation "Im2ColNode is `AbstractNode` which implements forward propagation of [nn.Unfold](https://pytorch.org/docs/stable/generated/torch.nn.Unfold.html).
+
+The node is only executed through the `cl-waffe2/nn:unfold` function, so arguments for constructors are dispatched automatically. In addition, the tensor `X` it receive will be the one after padding has been performed.
+
+`N` indicates the number of batch-size, `C` is a channel-size. `k-h`, `k-w` represents the size of kernel, height and width respectively. `h-out` `w-out` is the size of output. `stride-x` `stride-y` is the number of stride, for the most case, specified by the stride argument in `Pooling2D` or `Conv2D`. `img-out` is AbstractTensor with the shape of `(N C H-in W-in)`, can be read by `img-out-of`. All symbols are exported from `cl-waffe2/base-impl` package.
+
+In order to implement device-specific implementation of `Unfold`, define-impl `Im2ColNode` and `Col2ImNode`.
+"
+	  ;; Backward: Col[N C k-h k-w h-out w-out] -> X[N C H W] Col[N C k-h k-w h-out w-out]
+	  :where (X[N C H W] Col[N C k-h k-w h-out w-out] -> Col[N C k-h k-w h-out w-out])
+	  :backward ((self dout x col)
+		     (declare (ignore x col))
+		     (with-slots ((N N) (C C) (k-h k-h) (k-w k-w) (h-out h-out) (w-out w-out) (stride-x stride-x) (stride-y stride-y)) self
+		       (values
+			(call (Col2ImNode N C (h-of self) (w-of self) k-h k-w h-out w-out stride-x stride-y (img-out-of self)) dout)
+			nil)))))
+
+(export 'Col2ImNode)
+(defnode (Col2ImNode (self N C H W k-h k-w h-out w-out stride-x stride-y img-out)
+	  :slots ((N :initarg :N)
+		  (C :initarg :C)
+		  (k-h :initarg :k-h)
+		  (k-w :initarg :k-w)
+		  (h-out :initarg :h-out)
+		  (w-out :initarg :w-out)
+		  (stride-x :initarg :stride-x)
+		  (stride-y :initarg :stride-y)
+		  (img-out :initarg :img-out :reader img-out-of))
+	  :documentation "Col2ImNode is `AbstractNode` which implements backward propagation of [nn.Unfold](https://pytorch.org/docs/stable/generated/torch.nn.Unfold.html).
+
+See also: `Im2ColNode` documentation for argument descriptions."
+	  :where (Col[N C k-h k-w h-out w-out] -> X[N C H W])))
 

--- a/source/nn/conv.lisp
+++ b/source/nn/conv.lisp
@@ -175,7 +175,7 @@ Note: When `Conv2D` is initialised, the output is displayed as -1. This is becau
 	  
 	  ;; col = im2col(input) ;; (N * h-out w-out, C * kx * ky)
 	  
-	  (let* ((col   (!im2col-cpu input (car ~) in-channels k-h k-w h-out w-out (car stride) (second stride)))
+	  (let* ((col   (!im2col  input (car ~) in-channels k-h k-w h-out w-out (car stride) (second stride)))
 		 (col-w (!reshape weight c-out t))
 		 (out   (!matmul col (!t col-w)))
 		 (out   (if bias

--- a/source/nn/im2col.lisp
+++ b/source/nn/im2col.lisp
@@ -157,55 +157,27 @@ stride-x stride-y"
 	   stride-x
 	   stride-y))
 
-(define-and-impl-node
-    (Im2ColNode (self N C k-h k-w h-out w-out stride-x stride-y img-out)
-     :slots ((N :initarg :N)
-	     (C :initarg :C)
-	     (k-h :initarg :k-h)
-	     (k-w :initarg :k-w)
-	     (h-out :initarg :h-out)
-	     (w-out :initarg :w-out)
-	     (stride-x :initarg :stride-x)
-	     (stride-y :initarg :stride-y)
-	     (img-out :initarg :img-out :reader img-out-of)
-	     (h :accessor h-of)
-	     (w :accessor w-of))
-     :cache-when-compiled nil
-     ;; Backward: Col[N C k-h k-w h-out w-out] -> X[N C H W] Col[N C k-h k-w h-out w-out]
-     :where (X[N C H W] Col[N C k-h k-w h-out w-out] -> Col[N C k-h k-w h-out w-out])
-     :forward ((self x col)
-	       (setf (h-of self) (nth 2 (shape x))
-		     (w-of self) (nth 3 (shape x)))
-	       `(with-slots ((N N) (C C) (k-h k-h) (k-w k-w) (h-out h-out) (w-out w-out) (stride-x stride-x) (stride-y stride-y)) ,self
-		  (call-im2col-kernel ,x ,col n c k-h k-w h-out w-out stride-x stride-y)))
-     :backward ((self dout x col)
-		(declare (ignore x col))
-		(with-slots ((N N) (C C) (k-h k-h) (k-w k-w) (h-out h-out) (w-out w-out) (stride-x stride-x) (stride-y stride-y)) self
-		  (values
-		   (call (Col2ImNode N C (h-of self) (w-of self) k-h k-w h-out w-out stride-x stride-y (img-out-of self)) dout)
-		   nil)))))
+(define-impl (Im2ColNode
+	      :device cl-waffe2/backends.lisp:LispTensor
+	      :cache-when-compiled nil)
+	     :forward ((self x col)
+		       (setf (h-of self) (nth 2 (shape x))
+			     (w-of self) (nth 3 (shape x)))
+		       `(with-slots ((N N) (C C) (k-h k-h) (k-w k-w) (h-out h-out) (w-out w-out) (stride-x stride-x) (stride-y stride-y)) ,self
+			  (call-im2col-kernel ,x ,col n c k-h k-w h-out w-out stride-x stride-y))))
 
-(define-and-impl-node (Col2ImNode (self N C H W k-h k-w h-out w-out stride-x stride-y img-out)
-		       :slots ((N :initarg :N)
-			       (C :initarg :C)
-			       (k-h :initarg :k-h)
-			       (k-w :initarg :k-w)
-			       (h-out :initarg :h-out)
-			       (w-out :initarg :w-out)
-			       (stride-x :initarg :stride-x)
-			       (stride-y :initarg :stride-y)
-			       (img-out :initarg :img-out :reader img-out-of))
-		       :cache-when-compiled nil
-		       :where (Col[N C k-h k-w h-out w-out] -> X[N C H W])
-		       :forward ((self dout)
-				 `(with-slots ((N N) (C C) (k-h k-h) (k-w k-w) (h-out h-out) (w-out w-out) (stride-x stride-x) (stride-y stride-y)) ,self
-				    (values (∂im2col/∂out ,dout (img-out-of ,self) N C k-h k-w h-out w-out stride-x stride-y) nil)))))
+(define-impl (Col2ImNode
+	      :device cl-waffe2/backends.lisp:LispTensor
+	      :cache-when-compiled nil)
+	     :forward ((self dout)
+		       `(with-slots ((N N) (C C) (k-h k-h) (k-w k-w) (h-out h-out) (w-out w-out) (stride-x stride-x) (stride-y stride-y)) ,self
+			  (values (∂im2col/∂out ,dout (img-out-of ,self) N C k-h k-w h-out w-out stride-x stride-y) nil))))
 
 
 
-(defun !im2col-cpu (padded-x N C k-h k-w h-out w-out stride-x stride-y)
+(defun !im2col (padded-x N C k-h k-w h-out w-out stride-x stride-y)
   "
-## [function] !im2col-cpu
+## [function] !im2col
 
 N - batch-size
 C - in-channels
@@ -231,11 +203,36 @@ stride-x stride-y - stride[0], stride[1] respectively.
 	    (asnode #'!permute (torch-order 0 4 5 1 2 3))
 	    (asnode #'!reshape (* N H-out W-out) t))))
 
-;; TODO: UnfoldNode for every (CPU/CUDA/Metal) devices...
+
 (defun unfold (input dilation kernel-size stride padding)
   "
 ## [function] unfold
 
+```lisp
+(unfold input dilation kernel-size stride padding)
+```
+
+Extracts sliding local blocks from a batched input tensor. The detailed specifications follow PyTorch: [nn.Unfold](https://pytorch.org/docs/stable/generated/torch.nn.Unfold.html).
+
+As of this writing, `input` must be a 4D Tensor even when `N=batch-size=1`.
+
+Corresponding nodes: `cl-waffe2/base-impl:Im2ColNode`, `cl-waffe2/base-impl:Col2ImNode`
+
+### Inputs
+
+Note that `dilation`, `kernel-size`, `stride`, and `padding` are given in this form:
+
+`(list y-direction(Height) x-direction(Width))`
+
+`input[AbstractTensor]` the tensor to be unfold.
+
+`dilation[list]` a parameter that controls the stride of elements within the neighborhood.
+
+`kernel-size[list]` the size of sliding blocks.
+
+`padding[list]` implicts the number of zero-padding to be added on both sides of input.
+
+`stride[list]` the number of stride of the sliding blocks.
 "
 
   (multiple-value-bind (N C H-in W-in) (apply #'values (shape input))
@@ -246,6 +243,6 @@ stride-x stride-y - stride[0], stride[1] respectively.
 
       (call-> input
 	      (asnode #'padding    `(t t (,(second padding) ,(+ (second padding) p-y)) (,(car padding) ,(+ (car padding) p-x))))
-	      (asnode #'!im2col-cpu N C (second kernel-size) (car kernel-size) h-out w-out (car stride) (second stride))))))
+	      (asnode #'!im2col N C (second kernel-size) (car kernel-size) h-out w-out (car stride) (second stride))))))
 
 

--- a/source/nn/package.lisp
+++ b/source/nn/package.lisp
@@ -17,7 +17,8 @@
   (:export
    #:Conv2D
    #:apply-conv2d
-   #:!im2col-cpu
+   #:!im2col
+   #:unfold
 
    #:MaxPool2D
    #:AvgPool2D)

--- a/source/nn/pool.lisp
+++ b/source/nn/pool.lisp
@@ -98,7 +98,7 @@ Likewise `Conv2D`, these parameters can be set for both X and Y axis directions.
 
 	(call-> input
 		(asnode #'padding    `(t t (,(second padding) ,(+ (second padding) p-y)) (,(car padding) ,(+ (car padding) p-x))))
-		(asnode #'!im2col-cpu N C (second kernel-size) (car kernel-size) h-out w-out (car stride) (second stride))
+		(asnode #'!im2col     N C (second kernel-size) (car kernel-size) h-out w-out (car stride) (second stride))
 		(asnode #'!reshape    t (apply #'* kernel-size))
 		(asnode #'!max        :axis 1)
 		(asnode #'!reshape    N h-out w-out C)
@@ -114,7 +114,7 @@ Likewise `Conv2D`, these parameters can be set for both X and Y axis directions.
 
 	(call-> input
 		(asnode #'padding    `(t t (,(second padding) ,(+ (second padding) p-y)) (,(car padding) ,(+ (car padding) p-x))))
-		(asnode #'!im2col-cpu N C (second kernel-size) (car kernel-size) h-out w-out (car stride) (second stride))
+		(asnode #'!im2col     N C (second kernel-size) (car kernel-size) h-out w-out (car stride) (second stride))
 		(asnode #'!reshape    t (apply #'* kernel-size))
 		(asnode #'!mean       :axis 1)
 		(asnode #'!reshape    N h-out w-out C)

--- a/source/utils.lisp
+++ b/source/utils.lisp
@@ -77,6 +77,10 @@
   "
 ## [function] set-devices-toplevel
 
+```lisp
+(set-devices-toplevel &rest devices)
+```
+
 Declares devices to use.
 "
   (assert (every #'(lambda (x) (subtypep x 'AbstractTensor)) devices)


### PR DESCRIPTION
Now `Im2ColNode`, `Col2ImNode` is defined as `AbstractNode`. Users can define hardware-specific implementation for unfold later.