### PR TITLE
[Optimize] 1.5x times faster training of MLP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "third_party"]
+	path = third_party
+	url = https://github.com/shibatch/sleef.git
+[submodule "third_party/sleef"]
+	path = third_party/sleef
+	url = https://github.com/shibatch/sleef.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "third_party"]
-	path = third_party
-	url = https://github.com/shibatch/sleef.git
 [submodule "third_party/sleef"]
 	path = third_party/sleef
 	url = https://github.com/shibatch/sleef.git

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -134,3 +134,11 @@ delete_simd_extension: ./source/backends/cpu/cl-waffe2-simd/kernels/cl-waffe2-si
 .PHONY: download_assets
 download_assets: ## Downloads training data sample codes use.
 	cd ./examples/mnist && $(PYTHON) train_data.py
+
+.PHONY: example_mnist
+example_mnist: ## Start MNIST Example and Benchmarking. (download_assets must be called in advance)
+	$(SBCL) $(SBCL_OPTIONS) \
+		--load ./cl-waffe2.asd --load ./examples/mnist/mnist.asd \
+		--eval '(ql:quickload :mnist-sample)' \
+		--eval '(mnist-sample::train-and-valid-mlp :epoch-num 10)'
+

--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -64,7 +64,7 @@
 	       (:file "vm/generic-tensor/view")
 	       (:file "vm/generic-tensor/call-with-view")
 	       (:file "vm/generic-tensor/memory-pool")
-
+	       
 	       (:file "optimizers/package")
 	       
 	       (:file "vm/generic-tensor/acceptor")
@@ -119,6 +119,7 @@
 	       (:file "backends/cpu/blas-functions")
 	       (:file "backends/cpu/arithmetic")
 	       (:file "backends/cpu/matrix-ops")
+	       (:file "backends/cpu/mathematics")
 	       (:file "backends/cpu/logical")
 	       
 

--- a/examples/mnist/Readme.md
+++ b/examples/mnist/Readme.md
@@ -5,3 +5,13 @@
 python train_data.py
 ```
 
+## Usage
+
+```lisp
+(load "./cl-waffe2.asd")
+(load "./examples/mnist/mnist.asd")
+(ql:quickload :mnist-sample)
+(mnist-sample::train-and-valid-mlp :epoch-num 10)
+```
+
+This process is included in `GNUmakefile`

--- a/examples/mnist/mlp.lisp
+++ b/examples/mnist/mlp.lisp
@@ -82,6 +82,17 @@
     ;; TODO: Validate, Trying Adam
     (with-no-grad
       (format t "Valid Accuracy: ~a~%" (accuracy model test-img test-label)))
+
+    (format t "Benchmaking (Forward Step, 1Epoch)...~%")
+
+    (proceed-bench
+     (!sum (softmax-cross-entropy
+	    (call
+	     (MLP-Sequence 784 256 10)
+	     (randn `(100 784)))
+	    (randn `(100 10))))
+     :n-sample 1000
+     :backward nil)
     model))
 
 ;; PyTorch ... 7sec

--- a/examples/mnist/mlp.lisp
+++ b/examples/mnist/mlp.lisp
@@ -47,75 +47,35 @@
 ;; TODO: Adam, Dropout
 ;; Goal: MNIST 96~7% with MLP. (OK)
 
-#|
-For benchmarking the training time without loading training data
+;; Changing the visible area without making a copy:
+(defun tensor-displace-to (tensor index)
+  (setf (tensor-initial-offset tensor) (* index (second (shape tensor))))
+  tensor)
+
 (defun train-and-valid-mlp (&key
 			      (epoch-num 10))
   (let* ((model (MLPTrainer 784 10 :lr 1e-3)) ;; lr = 1e-2 for SGD
 	 ;; Flatten Inputs
 	 (train-img  (proceed (!div (!reshape *train-data*  t (* 28 28)) 255.0)))
 	 (test-img   (proceed (!div (!reshape *test-data*   t (* 28 28)) 255.0)))
-	 (train-label *train-label*)
+	 
+	 (train-img-window (view train-img `(0 100) t))
+	 
+	 (train-label (view *train-label* `(0 100) t))
 	 (test-label  *test-label*)
 	 (total-loss 0.0))
     (format t "[Log] Start Training...~%")
     (dotimes (nth-epoch epoch-num)
       (format t "~ath Epoch...~%" nth-epoch)
 
-      (let ((batch 0))
-      (let ((end (+ batch 100)))
-	;; :X = Train[batch:batch+100, :]
-	(set-inputs model
-		    ;; Instead, increase offset?
-		    (proceed (->contiguous (view train-img   `(,batch ,end) t)))
-		    (proceed (->contiguous (view train-label `(,batch ,end) t)))
-
-		    )))
-      ;;(time
       (time
-      (loop for batch fixnum upfrom 0 below 60000 by 100 do
-
-	;; Set training data.
-	;;(let ((end (+ batch 100)))
-	  ;; :X = Train[batch:batch+100, :]
-	  ;;(set-inputs model
-		      ;; Instead, increase offset?
-	;;	      (proceed (->contiguous (view train-img   `(,batch ,end) t)))
-	;;	      (proceed (->contiguous (view train-label `(,batch ,end) t)))
-
-	;;	      ))
-	(incf total-loss (minimize! model))))
-      (format t "Training Loss: ~a~%" (/ total-loss 600))
-      (setq total-loss 0.0))
-
-    ;; TODO: Validate, Trying Adam
-    (with-no-grad
-      (format t "Valid Accuracy: ~a~%" (accuracy model test-img test-label)))
-model))
-|#
-
-(defun train-and-valid-mlp (&key
-			      (epoch-num 10))
-  (let* ((model (MLPTrainer 784 10 :lr 1e-3)) ;; lr = 1e-2 for SGD
-	 ;; Flatten Inputs
-	 (train-img  (proceed (!div (!reshape *train-data*  t (* 28 28)) 255.0)))
-	 (test-img   (proceed (!div (!reshape *test-data*   t (* 28 28)) 255.0)))
-	 (train-label *train-label*)
-	 (test-label  *test-label*)
-	 (total-loss 0.0))
-    (format t "[Log] Start Training...~%")
-    (dotimes (nth-epoch epoch-num)
-      (format t "~ath Epoch...~%" nth-epoch)
-
-      
-      (loop for batch fixnum upfrom 0 below 60000 by 100 do	 
-	(let ((end (+ batch 100)))
-	  ;; :X = Train[batch:batch+100, :]
-	  (set-inputs model
-		      ;; Instead, increase offset?
-		      (proceed (->contiguous (view train-img   `(,batch ,end) t)))
-		      (proceed (->contiguous (view train-label `(,batch ,end) t)))))
-	(incf total-loss (minimize! model)))
+       (loop for batch fixnum upfrom 0 below 60000 by 100 do
+	 ;; :X = Train[batch:batch+100, :]
+	 (set-inputs model
+		     ;; Instead, increase offset?
+		     (tensor-displace-to train-img-window batch)
+		     (tensor-displace-to train-label     batch))
+	 (incf total-loss (minimize! model))))
       (format t "Training Loss: ~a~%" (/ total-loss 600))
       (setq total-loss 0.0))
 
@@ -126,6 +86,7 @@ model))
 
 ;; PyTorch ... 7sec
 ;; 1Epoch 13s(cl-waffe2) -> 6s (cl-waffe)
+;; 2023/08/23 6~7sec
 ;;(progn;;with-cpu-jit (CPUTensor LispTensor)
 ;;  (format t "MLP(hidden_size=256) optimizer=Adam batch-size=100~%")
 ;;  (train-and-valid-mlp :epoch-num 10))

--- a/source/backends/JITCPUTensor/t/jit.lisp
+++ b/source/backends/JITCPUTensor/t/jit.lisp
@@ -10,6 +10,9 @@
 (defun M= (a b)
   (every #'= a b))
 
+(defun ~= (x y)
+  (< (- x y) 0.00001))
+
 (defmacro with-test-form (&body body)
   `(flet ((lisp-case ()
 	    (with-devices (cl-waffe2/backends.lisp:LispTensor)
@@ -31,7 +34,7 @@
 (test backward-test
   (is (let ((a (parameter (ax+b `(3 3) 0 1))))
 	(proceed-backward (!sin a))
-	(= (cos 1) (vref (grad a) 0)))))
+	(~= (cos 1) (vref (grad a) 0)))))
 
 ;;(progn
 ;;  (let ((a (parameter (ax+b `(3 3) 0 1))))	      

--- a/source/backends/cpu/cl-waffe2-simd/api.lisp
+++ b/source/backends/cpu/cl-waffe2-simd/api.lisp
@@ -213,6 +213,10 @@
   (define-math-op sqrt)
   (define-math-op cbrt))
 
+(export '(waffe2-sloge waffe2-dloge))
+(defun waffe2-sloge (n x incx y incy) (waffe2-slog n x incx y incy))
+(defun waffe2-dloge (n x incx y incy) (waffe2-dlog n x incx y incy))
+
 (macrolet ((define-math-op1 (opname)
 	     `(progn
 		;;size xptr incx xptr incy

--- a/source/backends/cpu/cl-waffe2-simd/api.lisp
+++ b/source/backends/cpu/cl-waffe2-simd/api.lisp
@@ -173,5 +173,62 @@
   (define-cmp-op ge))
 
 ;; Math APIs sin/cos/tan/exp/log/abs/sign etc...
+(macrolet ((define-math-op (opname)
+	     `(progn
+		;;size xptr incx xptr incy
+		,@(loop for prefix in `(:d :s)
+			for dtype  in `(:double :float)
+			collect
+			`(progn
+			   (export ',(intern (uformat nil "waffe2-~a~a" prefix opname)))
+			   (declaim (inline ,(intern (uformat nil "waffe2-~a~a" prefix opname))))
+			   (defcfun ,(dformat nil "waffe2_~a~a" prefix opname) :void
+			     (n :long)
+			     (x (:pointer ,dtype))
+			     (incx :long)
+			     (y (:pointer ,dtype))
+			     (incy :long)))))))
+  (define-math-op sin)
+  (define-math-op cos)
+  (define-math-op tan)
+
+  (define-math-op asin)
+  (define-math-op acos)
+  (define-math-op atan)
+
+  (define-math-op sinh)
+  (define-math-op cosh)
+  (define-math-op tanh)
+
+  (define-math-op asinh)
+  (define-math-op acosh)
+  (define-math-op atanh)
+
+  (define-math-op log)
+  (define-math-op log2)
+  (define-math-op log10)
+
+  (define-math-op abs)
+  (define-math-op exp)
+  (define-math-op sqrt)
+  (define-math-op cbrt))
+
+(macrolet ((define-math-op1 (opname)
+	     `(progn
+		;;size xptr incx xptr incy
+		,@(loop for prefix in `(:d :s)
+			for dtype  in `(:double :float)
+			collect
+			`(progn
+			   (export ',(intern (uformat nil "waffe2-~a~a" prefix opname)))
+			   (declaim (inline ,(intern (uformat nil "waffe2-~a~a" prefix opname))))
+			   (defcfun ,(dformat nil "waffe2_~a~a" prefix opname) :void
+			     (n :long)
+			     (x (:pointer ,dtype))
+			     (incx :long)
+			     (pow-n ,dtype)
+			     (y (:pointer ,dtype))
+			     (incy :long)))))))
+  (define-math-op1 pow))
 
 ;; Unfold

--- a/source/backends/cpu/cl-waffe2-simd/kernels/cl-waffe2-simd.h
+++ b/source/backends/cpu/cl-waffe2-simd/kernels/cl-waffe2-simd.h
@@ -152,3 +152,73 @@ _define_cmp(i, u32, ge, SIMD_SINGLE_STRIDE,     uint32_t, ge, >=);
 _define_cmp(i, u16, ge, SIMD_SINGLE_STRIDE * 2, uint16_t, ge, >=);
 _define_cmp(i, u8,  ge, SIMD_SINGLE_STRIDE * 4, uint8_t,  ge, >=);
 
+
+
+#define _define_math_func(define_as, stride, prefix, dtype, simd_op_name, reminder_op_name) \
+     void waffe2_##define_as(const long n, dtype* x, const long incx, dtype* y, const long incy)				
+
+_define_math_func(dsin, SIMD_DOUBLE_STRIDE, d, double, waffe2_simd_dsin, sin);
+_define_math_func(ssin, SIMD_SINGLE_STRIDE, s, float,  waffe2_simd_ssin, sin);
+
+_define_math_func(dcos, SIMD_DOUBLE_STRIDE, d, double, waffe2_simd_dcos, cos);
+_define_math_func(scos, SIMD_SINGLE_STRIDE, s, float,  waffe2_simd_scos, cos);
+
+_define_math_func(dtan, SIMD_DOUBLE_STRIDE, d, double, waffe2_simd_dtan, tan);
+_define_math_func(stan, SIMD_SINGLE_STRIDE, s, float,  waffe2_simd_stan, tan);
+
+
+_define_math_func(dasin, SIMD_DOUBLE_STRIDE, d, double, waffe2_simd_dasin, asin);
+_define_math_func(sasin, SIMD_SINGLE_STRIDE, s, float,  waffe2_simd_sasin, asin);
+
+_define_math_func(dacos, SIMD_DOUBLE_STRIDE, d, double, waffe2_simd_dacos, acos);
+_define_math_func(sacos, SIMD_SINGLE_STRIDE, s, float,  waffe2_simd_sacos, acos);
+
+_define_math_func(datan, SIMD_DOUBLE_STRIDE, d, double, waffe2_simd_datan, atan);
+_define_math_func(satan, SIMD_SINGLE_STRIDE, s, float,  waffe2_simd_satan, atan);
+
+_define_math_func(dsinh, SIMD_DOUBLE_STRIDE, d, double, waffe2_simd_dsinh, sinh);
+_define_math_func(ssinh, SIMD_SINGLE_STRIDE, s, float,  waffe2_simd_ssinh, sinh);
+
+_define_math_func(dcosh, SIMD_DOUBLE_STRIDE, d, double, waffe2_simd_dcosh, cosh);
+_define_math_func(scosh, SIMD_SINGLE_STRIDE, s, float,  waffe2_simd_scosh, cosh);
+
+_define_math_func(dtanh, SIMD_DOUBLE_STRIDE, d, double, waffe2_simd_dtanh, tanh);
+_define_math_func(stanh, SIMD_SINGLE_STRIDE, s, float,  waffe2_simd_stanh, tanh);
+
+_define_math_func(dasinh, SIMD_DOUBLE_STRIDE, d, double, waffe2_simd_dsinh, asinh);
+_define_math_func(sasinh, SIMD_SINGLE_STRIDE, s, float,  waffe2_simd_ssinh, asinh);
+
+_define_math_func(dacosh, SIMD_DOUBLE_STRIDE, d, double, waffe2_simd_dcosh, acosh);
+_define_math_func(sacosh, SIMD_SINGLE_STRIDE, s, float,  waffe2_simd_scosh, acosh);
+
+_define_math_func(datanh, SIMD_DOUBLE_STRIDE, d, double, waffe2_simd_dtanh, atanh);
+_define_math_func(satanh, SIMD_SINGLE_STRIDE, s, float,  waffe2_simd_stanh, atanh);
+
+// loge log2 log10
+
+_define_math_func(dlog, SIMD_DOUBLE_STRIDE, d, double, waffe2_simd_dlog, log);
+_define_math_func(slog, SIMD_SINGLE_STRIDE, s, float,  waffe2_simd_slog, log);
+
+_define_math_func(dlog2, SIMD_DOUBLE_STRIDE, d, double, waffe2_simd_dlog2, log2);
+_define_math_func(slog2, SIMD_SINGLE_STRIDE, s, float,  waffe2_simd_slog2, log2);
+
+_define_math_func(dlog10, SIMD_DOUBLE_STRIDE, d, double, waffe2_simd_dlog10, log10);
+_define_math_func(slog10, SIMD_SINGLE_STRIDE, s, float,  waffe2_simd_slog10, log10);
+
+_define_math_func(dexp, SIMD_DOUBLE_STRIDE, d, double, waffe2_simd_dexp, exp);
+_define_math_func(sexp, SIMD_SINGLE_STRIDE, s, float,  waffe2_simd_sexp, exp);
+
+_define_math_func(dabs, SIMD_DOUBLE_STRIDE, d, double, waffe2_simd_dabs, fabs);
+_define_math_func(sabs, SIMD_SINGLE_STRIDE, s, float,  waffe2_simd_sabs, fabs);
+
+_define_math_func(dsqrt, SIMD_DOUBLE_STRIDE, d, double, waffe2_simd_dsqrt, sqrt);
+_define_math_func(ssqrt, SIMD_SINGLE_STRIDE, s, float,  waffe2_simd_ssqrt, sqrt);
+
+_define_math_func(dcbrt, SIMD_DOUBLE_STRIDE, d, double, waffe2_simd_dcbrt, cbrt);
+_define_math_func(scbrt, SIMD_SINGLE_STRIDE, s, float,  waffe2_simd_scbrt, cbrt);
+
+#define _define_math_func_pow(define_as, stride, prefix, dtype, simd_op_name, reminder_op_name) \
+  void waffe2_##define_as(const long n, dtype* x, const long incx, dtype pow_n, dtype* y, const long incy)
+
+_define_math_func_pow(dpow, SIMD_DOUBLE_STRIDE, d, double, waffe2_simd_dpow, pow);
+_define_math_func_pow(spow, SIMD_SINGLE_STRIDE, s, float,  waffe2_simd_spow, pow);

--- a/source/backends/cpu/cl-waffe2-simd/kernels/simd/x86_64/avx2.h
+++ b/source/backends/cpu/cl-waffe2-simd/kernels/simd/x86_64/avx2.h
@@ -7,6 +7,8 @@ sparse matrix supporting
   ...
 */
 
+#include <sleef.h>
+
 // single-float
 typedef __m256 waffe2_svec;
 
@@ -252,8 +254,79 @@ waffe2_ivec static inline waffe2_simd_u32blendv(waffe2_ivec x, waffe2_ivec y, wa
 waffe2_ivec static inline waffe2_simd_u16blendv(waffe2_ivec x, waffe2_ivec y, waffe2_ivec mask) { return _mm256_blendv_epi8(x, y, mask); }
 waffe2_ivec static inline waffe2_simd_u8blendv(waffe2_ivec x, waffe2_ivec y, waffe2_ivec mask) { return _mm256_blendv_epi8(x, y, mask); }
 
-// TO ADD:
-// Mathematical Functions
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// SLEEF Mathematical Functions
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-// Unfold
+// Always choose the lowest precision
+// sin/cos/tan
 
+waffe2_dvec static inline waffe2_simd_dsin(waffe2_dvec x) { return Sleef_sind4_u10avx2(x); }
+waffe2_svec static inline waffe2_simd_ssin(waffe2_svec x) { return Sleef_sinf8_u10avx2(x); }
+
+waffe2_dvec static inline waffe2_simd_dcos(waffe2_dvec x) { return Sleef_cosd4_u10avx2(x); }
+waffe2_svec static inline waffe2_simd_scos(waffe2_svec x) { return Sleef_cosf8_u10avx2(x); }
+
+waffe2_dvec static inline waffe2_simd_dtan(waffe2_dvec x) { return Sleef_tand4_u10avx2(x); }
+waffe2_svec static inline waffe2_simd_stan(waffe2_svec x) { return Sleef_tanf8_u10avx2(x); }
+
+// asin acos atan
+waffe2_dvec static inline waffe2_simd_dasin(waffe2_dvec x) { return Sleef_asind4_u10avx2(x); }
+waffe2_svec static inline waffe2_simd_sasin(waffe2_svec x) { return Sleef_asinf8_u10avx2(x); }
+
+waffe2_dvec static inline waffe2_simd_dacos(waffe2_dvec x) { return Sleef_acosd4_u10avx2(x); }
+waffe2_svec static inline waffe2_simd_sacos(waffe2_svec x) { return Sleef_acosf8_u10avx2(x); }
+
+waffe2_dvec static inline waffe2_simd_datan(waffe2_dvec x) { return Sleef_atand4_u10avx2(x); }
+waffe2_svec static inline waffe2_simd_satan(waffe2_svec x) { return Sleef_atanf8_u10avx2(x); }
+
+// sinh cosh tanh
+waffe2_dvec static inline waffe2_simd_dsinh(waffe2_dvec x) { return Sleef_sinhd4_u10avx2(x); }
+waffe2_svec static inline waffe2_simd_ssinh(waffe2_svec x) { return Sleef_sinhf8_u10avx2(x); }
+
+waffe2_dvec static inline waffe2_simd_dcosh(waffe2_dvec x) { return Sleef_coshd4_u10avx2(x); }
+waffe2_svec static inline waffe2_simd_scosh(waffe2_svec x) { return Sleef_coshf8_u10avx2(x); }
+
+waffe2_dvec static inline waffe2_simd_dtanh(waffe2_dvec x) { return Sleef_tanhd4_u10avx2(x); }
+waffe2_svec static inline waffe2_simd_stanh(waffe2_svec x) { return Sleef_tanhf8_u10avx2(x); }
+
+// asinh acosh atanh
+waffe2_dvec static inline waffe2_simd_dasinh(waffe2_dvec x) { return Sleef_asinhd4_u10avx2(x); }
+waffe2_svec static inline waffe2_simd_sasinh(waffe2_svec x) { return Sleef_asinhf8_u10avx2(x); }
+
+waffe2_dvec static inline waffe2_simd_dacosh(waffe2_dvec x) { return Sleef_acoshd4_u10avx2(x); }
+waffe2_svec static inline waffe2_simd_sacosh(waffe2_svec x) { return Sleef_acoshf8_u10avx2(x); }
+
+waffe2_dvec static inline waffe2_simd_datanh(waffe2_dvec x) { return Sleef_atanhd4_u10avx2(x); }
+waffe2_svec static inline waffe2_simd_satanh(waffe2_svec x) { return Sleef_atanhf8_u10avx2(x); }
+
+
+waffe2_dvec static inline waffe2_simd_dpow(waffe2_dvec x, waffe2_dvec y) { return Sleef_powd4_u10avx2(x, y); }
+waffe2_svec static inline waffe2_simd_spow(waffe2_svec x, waffe2_svec y) { return Sleef_powf8_u10avx2(x, y); }
+
+// loge
+waffe2_dvec static inline waffe2_simd_dlog(waffe2_dvec x) { return Sleef_logd4_u10avx2(x); }
+waffe2_svec static inline waffe2_simd_slog(waffe2_svec x) { return Sleef_logf8_u10avx2(x); }
+
+waffe2_dvec static inline waffe2_simd_dlog10(waffe2_dvec x) { return Sleef_log10d4_u10avx2(x); }
+waffe2_svec static inline waffe2_simd_slog10(waffe2_svec x) { return Sleef_log10f8_u10avx2(x); }
+
+waffe2_dvec static inline waffe2_simd_dlog2(waffe2_dvec x) { return Sleef_log2d4_u10avx2(x); }
+waffe2_svec static inline waffe2_simd_slog2(waffe2_svec x) { return Sleef_log2f8_u10avx2(x); }
+
+// TODO: FuseOps with log(x+1)
+
+waffe2_dvec static inline waffe2_simd_dexp(waffe2_dvec x) { return Sleef_expd4_u10avx2(x); }
+waffe2_svec static inline waffe2_simd_sexp(waffe2_svec x) { return Sleef_expf8_u10avx2(x); }
+
+waffe2_dvec static inline waffe2_simd_dsqrt(waffe2_dvec x) { return Sleef_sqrtd4_u05avx2(x); }
+waffe2_svec static inline waffe2_simd_ssqrt(waffe2_svec x) { return Sleef_sqrtf8_u05avx2(x); }
+
+waffe2_dvec static inline waffe2_simd_dcbrt(waffe2_dvec x) { return Sleef_cbrtd4_u10avx2(x); }
+waffe2_svec static inline waffe2_simd_scbrt(waffe2_svec x) { return Sleef_cbrtf8_u10avx2(x); }
+
+
+waffe2_dvec static inline waffe2_simd_dabs(waffe2_dvec x) { return Sleef_fabsd4_avx2(x); }
+waffe2_svec static inline waffe2_simd_sabs(waffe2_svec x) { return Sleef_fabsf8_avx2(x); }
+
+// Unfold with oneDNN?

--- a/source/backends/cpu/mathematics.lisp
+++ b/source/backends/cpu/mathematics.lisp
@@ -1,0 +1,79 @@
+
+(in-package :cl-waffe2/backends.cpu)
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (defun symb (&rest inputs)
+    (intern (with-output-to-string (out) (dolist (sym inputs) (princ sym out))))))
+
+(macrolet ((define-math-impl (name)
+	     (let ((node-name (symb name 'Node))
+		   (sop-name   (symb 'waffe2-s name))
+		   (dop-name   (symb 'waffe2-d name)))
+	       `(define-impl (,node-name
+			      :device CPUTensor
+			      :reject-p #'simd-extension-p)
+			     :forward ((self x out)
+				       (let ((x-ptr (gensym "PTR"))
+					     (o-ptr (gensym "PTR")))
+					 `(locally (declare (optimize (speed 1)))
+					    (with-tensor-ptrs ((,x-ptr ,x)
+							       (,o-ptr ,out))
+					      ,(call-with-view
+						#'(lambda (x-view o-view)
+						    `(,(case (dtype x)
+							 (:float ',sop-name)
+							 (:double ',dop-name)
+							 (T (error "~a-CPUTensor has no implementation for ~a" ',node-name (dtype x))))
+						      ,(size-of x-view 0)
+						      (incf-tensor-ptr ,x ,x-ptr :offset ,(offset-of x-view 0))
+						      ,(stride-of x-view 0)
+						      (incf-tensor-ptr ,out ,o-ptr :offset ,(offset-of o-view 0))
+						      ,(stride-of o-view 0)))
+						`(,x ,out))
+					      ,out))))))))					   
+  (define-math-impl Sin)
+  (define-math-impl Cos)
+  (define-math-impl Tan)
+
+  (define-math-impl ASin)
+  (define-math-impl ACos)
+  (define-math-impl ATan)
+
+  (define-math-impl SinH)
+  (define-math-impl CosH)
+  (define-math-impl TanH)
+
+  (define-math-impl Abs)
+  (define-math-impl Exp)
+  (define-math-impl LogE)
+  (define-math-impl Log2)
+  (define-math-impl Log10)
+
+  (define-math-impl Sqrt))
+
+(define-impl (ExptNode
+	      :device CPUTensor
+	      :cache-when-compiled nil
+	      :reject-p #'simd-extension-p)
+	     :forward ((self x out n)
+		       (let ((x-ptr (gensym "PTR"))
+			     (o-ptr (gensym "PTR"))
+			     (n-ptr (gensym "PTR")))
+			 `(locally (declare (optimize (speed 1)))
+			    (with-tensor-ptrs ((,x-ptr ,x)
+					       (,o-ptr ,out))
+			      (let ((,n-ptr (coerce (tensor-vec ,n) ',(dtype->lisp-type (dtype x)))))
+				,(call-with-view
+				  #'(lambda (x-view o-view)
+				      `(,(case (dtype x)
+					   (:float 'waffe2-spow)
+					   (:double 'waffe2-dpow)
+					   (T (error "ExptNode-CPUTensor do not provide an implementation for ~a tensors" (dtype x))))
+					,(size-of x-view 0)
+					(incf-tensor-ptr ,x ,x-ptr :offset ,(offset-of x-view 0))
+					,(stride-of x-view 0)
+					,n-ptr
+					(incf-tensor-ptr ,out ,o-ptr :offset ,(offset-of o-view 0))
+					,(stride-of o-view 0)))
+				  `(,x ,out))
+				,out))))))

--- a/source/backends/cpu/t/arithmetic.lisp
+++ b/source/backends/cpu/t/arithmetic.lisp
@@ -14,6 +14,8 @@
 (max-tester CPUTensor)
 (min-tester CPUTensor)
 (comparison-test-set CPUTensor)
+
+(mathematical-test-set CPUTensor)
 )
 
 (defun max-diff-test ()

--- a/source/base-impl/mathematics.lisp
+++ b/source/base-impl/mathematics.lisp
@@ -275,6 +275,7 @@ Inputs:
 
 Output:
    out - AbstractTensor"
+  (declare (type AbstractTensor x))
   (let ((n (if (numberp n)
 	       (make-tensor n)
 	       n)))

--- a/source/base-impl/package.lisp
+++ b/source/base-impl/package.lisp
@@ -71,6 +71,7 @@
    flexible-p
    transposed-p"
   (setf (tensor-flexible-p result) (tensor-flexible-p extend-from))
+  (setf (tensor-initial-offset result) (tensor-initial-offset extend-from))
   result)
 
 (defun tensor-permuted-p (tensor)

--- a/source/base-impl/t/mathematical.lisp
+++ b/source/base-impl/t/mathematical.lisp
@@ -41,14 +41,14 @@
 			(all-p t))
 		    (loop while all-p
 			  for i upfrom 0 below 900
-			  do (setq all-p (= (vref c i) (funcall ,lisp-op 1))))
+			  do (setq all-p (~= (vref c i) (funcall ,lisp-op 1))))
 		    (when all-p
 		      (let ((a (make-tensor `(30 30) :initial-element 1 :requires-grad t)))
 			(proceed-backward (,wf-op a))
 			(let ((all-p t))
 			  (loop while all-p
 				for i upfrom 0 below 900
-				do (setq all-p (= (vref (grad a) i) (funcall ,bw-lisp 1))))
+				do (setq all-p (~= (vref (grad a) i) (funcall ,bw-lisp 1))))
 			  (if all-p
 			      t
 			      :backward)))))))))

--- a/source/vm/generic-tensor/call-with-view.lisp
+++ b/source/vm/generic-tensor/call-with-view.lisp
@@ -219,7 +219,9 @@ Return: (values offsets-place form)"
 
   `(let ((,offset-name-place (tensor-gensym-list ,tensors)))
      ;; Initializing Offsets with 0
-     `(let*-ignorable (,@(loop for name in ,offset-name-place collect `(,name 0)))
+     `(let*-ignorable (,@(loop for name in ,offset-name-place
+			       for tensor in tensors
+			       collect `(,name (tensor-initial-offset ,tensor))))
 	(locally (declare (type fixnum ,@,offset-name-place))
 	  ,,@body))))
 

--- a/source/vm/generic-tensor/package.lisp
+++ b/source/vm/generic-tensor/package.lisp
@@ -31,6 +31,7 @@
    #:tensor-stride
    #:tensor-name
    #:shape-with-broadcastable
+   #:tensor-initial-offset
    #:dtype
    #:tensor-attribute
    #:tensor-protect-me

--- a/source/vm/generic-tensor/t/backward.lisp
+++ b/source/vm/generic-tensor/t/backward.lisp
@@ -9,21 +9,21 @@
   (with-devices (cl-waffe2/backends.lisp:LispTensor)
     (let ((a (make-tensor `(15 15) :initial-element 1.0 :requires-grad t)))
       (proceed-backward (!mul (!sum a) 1.0))
-      (= (vref (grad a) 0) 1.0))))
+      (~= (vref (grad a) 0) 1.0))))
 
 ;; !mul/!div Swapping/X->X,Y
 (defun chain-test2 ()
   (with-devices (cl-waffe2/backends.lisp:LispTensor)
     (let ((a (make-tensor `(15 15) :initial-element 1.0 :requires-grad t)))
       (proceed-backward (!div (!sum a) 1.0))
-      (= (vref (grad a) 0) 1.0))))
+      (~= (vref (grad a) 0) 1.0))))
 
 ;; No side eff?
 (defun chain-test3 ()
   (with-devices (cl-waffe2/backends.lisp:LispTensor)
     (let ((a (make-tensor `(15 15) :initial-element 1.0 :requires-grad t)))
       (proceed-backward (!div (!sum a) 2.0))
-      (= (vref (grad a) 0) 0.5))))
+      (~= (vref (grad a) 0) 0.5))))
 
 (defun chain-test4 ()
   (with-devices (cl-waffe2/backends.lisp:LispTensor)
@@ -31,7 +31,7 @@
 	  (b (make-tensor (* 15.0 15.0) :requires-grad t)))
       ;; (!div scal mat) -> (!mul (!sas-div 1 scal) mat)
       (proceed-backward (!div (!sum a) b))
-      (= (vref (grad a) 0) (float (/ (* 15 15)))))))
+      (~= (vref (grad a) 0) (float (/ (* 15 15)))))))
 
 (defun chain-test5 ()
   (with-devices (cl-waffe2/backends.lisp:LispTensor)
@@ -39,7 +39,7 @@
 	  (b (* 15.0 15.0)))
       ;; (!div scal mat) -> (!mul (!sas-div 1 scal) mat)
       (proceed-backward (!div (!sum a) b))
-      (= (vref (grad a) 0) (float (/ (* 15 15)))))))
+      (~= (vref (grad a) 0) (float (/ (* 15 15)))))))
 ;; =======================================================================
 
 ;; ???
@@ -48,13 +48,13 @@
     (let ((a (make-tensor `(15 15) :initial-element 1.0 :requires-grad t))
 	  (b (* 15.0 15.0)))
       (proceed-backward (!sum (!add (!sin a) b)))
-      (= (vref (grad a) 0) (cos 1)))))
+      (~= (vref (grad a) 0) (cos 1)))))
 
 (defun chain-test7 ()
   (with-devices (cl-waffe2/backends.lisp:LispTensor)
     (let ((a (make-tensor `(15 15) :initial-element 1.0 :requires-grad t)))
       (proceed-backward (!sin (!sin a)))
-      (= (vref (grad a) 0) (* (cos (sin 1)) (cos 1))))))
+      (~= (vref (grad a) 0) (* (cos (sin 1)) (cos 1))))))
 
 (defun backward-being-not-destructed ()
   (with-devices (cl-waffe2/backends.lisp:LispTensor)
@@ -62,8 +62,8 @@
 	  (b (parameter (make-tensor `(15 15) :initial-element 6 :requires-grad t))))
       (proceed-backward (!sum (!mul (!sin a) (!sin b))))
       (and
-       (= (vref a 0) 3.0)
-       (= (vref b 0) 6.0)))))
+       (~= (vref a 0) 3.0)
+       (~= (vref b 0) 6.0)))))
 
 (defun chain-test8 ()
   (let ((a (parameter (cl-waffe2/distributions:ax+b `(3 3) 0 3)))
@@ -78,9 +78,9 @@
     ;;(print (grad b))
     ;;(print (grad c))
     (and
-     (= (vref (grad a) 0) 2)
-     (= (vref (grad b) 0) 3)
-     (= (vref (grad c) 0) 1))))
+     (~= (vref (grad a) 0) 2)
+     (~= (vref (grad b) 0) 3)
+     (~= (vref (grad c) 0) 1))))
 
 (defun chain-test9 ()
   (let ((a (parameter (cl-waffe2/distributions:ax+b `(3 3) 0 3)))
@@ -93,11 +93,11 @@
       (proceed-backward (!sum (!add (!mul a1 prev-layer) c1))))
 
     (and
-     (= (vref (grad a)  0) 4)
-     (= (vref (grad b)  0) 6)
-     (= (vref (grad c)  0) 2)
-     (= (vref (grad a1) 0) 7)
-     (= (vref (grad c1) 0) 1))))
+     (~= (vref (grad a)  0) 4)
+     (~= (vref (grad b)  0) 6)
+     (~= (vref (grad c)  0) 2)
+     (~= (vref (grad a1) 0) 7)
+     (~= (vref (grad c1) 0) 1))))
     
      
      
@@ -113,7 +113,7 @@
   (is (chain-test8))
   (is (chain-test9)))
 
-(test backward-side-effect-test
+(test backward-si de-effect-test
   (is (backward-being-not-destructed)))
   
 ;; save-for-backward test

--- a/source/vm/generic-tensor/t/package.lisp
+++ b/source/vm/generic-tensor/t/package.lisp
@@ -14,3 +14,6 @@
 (def-suite :test-tensor)
 (in-suite :test-tensor)
 
+(defun ~= (x y)
+  (< (- x y) 0.00001))
+

--- a/source/vm/generic-tensor/utils.lisp
+++ b/source/vm/generic-tensor/utils.lisp
@@ -98,6 +98,7 @@
 	 (out (if broadcasted-p
 		  (apply #'view out broadcasts)
 		  out)))
+    (setf (tensor-initial-offset out) (tensor-initial-offset tensor))
     out))
 
 (deftype compile-option-t ()

--- a/source/vm/nodes/node.lisp
+++ b/source/vm/nodes/node.lisp
@@ -271,6 +271,7 @@ Here's a list of reports.
 
 				   (when (cl-waffe2/vm.generic-tensor::vec input)
 				     (setf (tensor-vec next-tensor) (tensor-vec input)
+					   (cl-waffe2/vm.generic-tensor:tensor-initial-offset next-tensor) (cl-waffe2/vm.generic-tensor:tensor-initial-offset input)
 					   (cl-waffe2/vm.generic-tensor::tensor-facet input) :exist))))
 			       
 			       (setf (cl-waffe2/vm.generic-tensor:ancestor-param-p next-tensor) ancestor-param-p)

--- a/source/vm/nodes/t/package.lisp
+++ b/source/vm/nodes/t/package.lisp
@@ -16,3 +16,5 @@
 (def-suite :test-nodes)
 (in-suite :test-nodes)
 
+(defun ~= (x y)
+  (< (- x y) 0.00001))

--- a/source/vm/nodes/t/static-node.lisp
+++ b/source/vm/nodes/t/static-node.lisp
@@ -42,23 +42,23 @@
 (defun test-composite-diff ()
   (let ((a (parameter (ax+b `(3 3) 0 1))))
     (proceed-backward (call (SinNode-Static) a))
-    (= (cos 1) (vref (grad a) 0))))
+    (~= (cos 1) (vref (grad a) 0))))
 
 (defun composite-with-build ()
   (let* ((a (parameter (ax+b `(3 3) 0 1)))
 	 (model (build (call (SinNode-static) a))))
     (forward model)
     (backward model)
-    (let ((f1 (= (cos 1) (vref (grad a) 0))))
+    (let ((f1 (~= (cos 1) (vref (grad a) 0))))
       (forward model)
       (backward model)
 
-      (let ((f2 (= (+ (cos 1) (cos 1)) (vref (grad a) 0))))
+      (let ((f2 (~= (+ (cos 1) (cos 1)) (vref (grad a) 0))))
 	(forward model)
 	(backward model)
 
 	(and f1 f2
-	     (= (+ (cos 1) (cos 1) (cos 1))
+	     (~= (+ (cos 1) (cos 1) (cos 1))
 		(vref (grad a) 0)))))))
 
 (defun composite-with-build1 ()
@@ -67,11 +67,11 @@
 	 (grad (* (cos (sin 1)) (cos 1))))
     (forward model)
     (backward model)
-    (let ((f1 (= (vref (grad a) 0) grad)))
+    (let ((f1 (~= (vref (grad a) 0) grad)))
       (forward model)
       (backward model)
       (and f1
-	   (= (vref (grad a) 0) (+ grad grad))))))
+	   (~= (vref (grad a) 0) (+ grad grad))))))
 
 (test composite-static-function-diff-test
   (is (test-composite-diff))


### PR DESCRIPTION
## Changes

1. CPUTensor is now able to use `SLEEF`.
2. When loading training data, there's no need to make a copy
3. Benchmarking MLP Training is now included in `GNUmakefile`