### PR TITLE
[BugFix] In-place-mutation should consider the reference from reverse mode, when compiling trainable forward mode

### DIFF
--- a/examples/mlp_sin_wave.lisp
+++ b/examples/mlp_sin_wave.lisp
@@ -64,7 +64,6 @@
      (loop for nth-epoch fixnum upfrom 0 below iter-num
 	   do (minimize! trainer)))))
 
-(with-devices (JITCPUTensor JITCPUScalarTensor CPUTensor)
-  (train)) 
+(train)
 
 

--- a/examples/mnist/mlp.lisp
+++ b/examples/mnist/mlp.lisp
@@ -92,7 +92,7 @@
 	     (randn `(100 784)))
 	    (randn `(100 10))))
      :n-sample 1000
-     :backward nil)
+     :backward t)
     model))
 
 ;; PyTorch ... 7sec

--- a/source/vm/compile.lisp
+++ b/source/vm/compile.lisp
@@ -196,8 +196,14 @@ Tips: `disassemble-waffe2-ir` to display compiled Instruction Sequence.
 	(node-compile-into-vm toplevel :fuse-p fuse-p)
       ;; Set grad-count=0 if any
       (map 'list #'(lambda (tensor) (setf (tensor-grad-count tensor) 0)) leaves)
-      
-      (apply-in-place-mutation! iseq-forward leaves)
+
+      ;; [FixME] In the training mode, apply-in-place-mutation! will produce the destruction of gradients...
+      ;; Analyze and pursuit for the reason and update the algorithm.
+
+      (when (or (null (ancestor-param-p toplevel))
+		*no-grad*
+		(not need-backward))
+	(apply-in-place-mutation! iseq-forward leaves))
 
       (let* ((out-symbol-p (some #'symbolp (shape toplevel)))
 	     (dout (when need-backward


### PR DESCRIPTION
Fix: MNIST, MLP