### PR TITLE
[Refactor] Eliminate style-warning

### DIFF
--- a/docs/cl-waffe2-docs/docs/distributions.md
+++ b/docs/cl-waffe2-docs/docs/distributions.md
@@ -16,11 +16,11 @@ That is, arguments passed to the `make-tensor` function can also be passed direc
 (normal `(10 10) 0.0 1.0 :requires-grad t)
 
 {CPUTENSOR[float] :shape (10 10)  
-  ((-1.1236498   -0.1235727   1.0795678    ~ 0.5167976    -0.253564    0.83076507)                    
-   (1.2503045    -0.15088722  0.4455899    ~ 0.3841458    0.3456047    -0.5160026)   
+  ((1.5115738    0.9725089    -1.0936631   ~ 0.17250857   -1.4037871   -1.44131)                    
+   (2.1897004    -0.17695138  -1.3162626   ~ -0.1235727   1.0795678    0.6481894)   
                  ...
-   (-1.8842889   -0.9365434   -0.81541514  ~ 1.086627     0.060432516  1.0375235)
-   (0.3352498    0.09079093   0.7702261    ~ -1.3832288   -1.2449193   0.36575747))
+   (-0.53699577  1.2856944    0.7377964    ~ 0.37622315   -0.36406124  -0.8471199)
+   (-1.6954373   -0.03045375  0.5100822    ~ -0.9365434   -0.81541514  -0.5227519))
   :facet :exist
   :requires-grad T
   :backward NIL}
@@ -146,9 +146,9 @@ Note: My implementation is unstable, being occurs floating-overflow constantly..
 (beta `(3 3) 5.0 1.0)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((0.8794548  0.89790976 0.965478)
-   (0.8467557  0.88322854 0.967886)
-   (0.81026894 0.995359   0.81870794))
+  ((0.8069441  0.8917125  0.96506965)
+   (0.96857363 0.7456689  0.9551224)
+   (0.99162805 0.9728971  0.588258))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -172,7 +172,7 @@ p - Takes 1 with probability p and 0 with probalibity (1-p).
 {CPUTENSOR[float] :shape (3 3)  
   ((0.0 0.0 0.0)
    (1.0 1.0 0.0)
-   (1.0 0.0 0.0))
+   (0.0 1.0 1.0))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -198,9 +198,9 @@ df - degree of freedom.
 (chisquare `(3 3) 1.0)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((0.18740644   0.06128042   0.081882045)
-   (0.086288996  0.02799087   1.0929034e-5)
-   (0.8890431    0.8464497    6.0179354e-5))
+  ((0.450386    3.9978566   1.1185445)
+   (0.34794423  2.4055214   0.061351057)
+   (0.96774584  0.18740644  0.06128042))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -227,9 +227,9 @@ The function expotential is a family of initializer functions, and samples the e
 (expotential `(3 3))
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((1.2825115  0.7454035  1.0342281)
-   (1.5999789  1.0538887  1.743031)
-   (2.9901898  0.96151936 1.7187847))
+  ((2.4553554   0.48428777  1.8976698)
+   (0.029658696 0.4880833   0.90490985)
+   (1.882453    0.30332613  1.1383042))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -252,9 +252,9 @@ The function gamma is a family of initializer functions, and samples matrices fr
 (gamma `(3 3) 1.0)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((0.009736213 0.010634866 0.3016977)
-   (2.275747    0.8112303   1.1955572)
-   (0.4171324   0.2600739   4.120788))
+  ((0.33288977  0.34304306  1.308418)
+   (1.0670236   0.1850702   0.004951466)
+   (1.0860988   3.0920405   0.83050084))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -309,9 +309,9 @@ Input:
 (uniform-random `(3 3) 2 4)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((3.6277761 2.5326838 2.3060157)
-   (2.6935544 2.8556156 3.563751)
-   (2.4688196 3.3255188 2.7563367))
+  ((2.9296012 2.8507779 2.9876168)
+   (2.0018864 3.2901318 3.8843534)
+   (3.2729285 2.2384753 3.8098881))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -339,9 +339,9 @@ The function randn is a family of initializer functions, and samples the gaussia
 (randn `(3 3))
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((0.32484004  -0.6475724  1.1069025)
-   (-1.8247509  0.9794315   -0.61835325)
-   (-1.0684173  0.33708817  0.8596226))
+  ((-0.42705044 -1.4939032  -1.0580381)
+   (-2.4483833  -0.6945629  0.7788397)
+   (0.4639567   -0.29027873 -1.3298852))
   :facet :exist
   :requires-grad NIL
   :backward NIL}

--- a/docs/cl-waffe2-docs/docs/generic-tensor.md
+++ b/docs/cl-waffe2-docs/docs/generic-tensor.md
@@ -417,7 +417,7 @@ Compiles the given computation node starting from `toplevel`. The docstring of `
 > (setq out (!add (make-input `(a 10) :X) (make-input `(a 10) :Y)))
 ```
 ```
-{CPUTENSOR[float] :shape (A 10) :named ChainTMP1195 
+{CPUTENSOR[float] :shape (A 10) :named ChainTMP940 
   :vec-state [maybe-not-computed]
   <<Not-Embodied (A 10) Tensor>>
   :facet :input

--- a/docs/cl-waffe2-docs/docs/nn.md
+++ b/docs/cl-waffe2-docs/docs/nn.md
@@ -13,13 +13,13 @@ ReLU(x) = max(x, 0)
 ```lisp
 (proceed (!relu (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (10 10) :named ChainTMP1245 
+{CPUTENSOR[float] :shape (10 10) :named ChainTMP979 
   :vec-state [computed]
-  ((0.8900292    0.88597333   -0.0         ~ 1.4355178    0.6892139    1.355975)                    
-   (0.48701808   -0.0         -0.0         ~ -0.0         2.085678     -0.0)   
+  ((-0.0         -0.0         -0.0         ~ -0.0         0.66437244   -0.0)                    
+   (0.5758207    0.32484004   -0.0         ~ -0.0         0.33708817   0.8596226)   
                  ...
-   (2.0839996    -0.0         -0.0         ~ -0.0         -0.0         -0.0)
-   (1.3144796    0.04638508   0.21334499   ~ -0.0         1.8804568    0.986707))
+   (0.1685591    -0.0         -0.0         ~ 0.9847253    0.40561935   0.115193695)
+   (0.66292197   -0.0         -0.0         ~ 0.36703286   -0.0         1.7522626))
   :facet :input
   :requires-grad NIL
   :backward <Node: PROCEEDNODE-T (A[~] -> A[~])>}
@@ -42,13 +42,13 @@ Sigmoid(x) = \frac{1}{1 + exp(-x)}
 ```lisp
 (proceed (!sigmoid (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (10 10) :named ChainTMP1409 
+{CPUTENSOR[float] :shape (10 10) :named ChainTMP1143 
   :vec-state [computed]
-  ((0.631219   0.62524664 0.5741438  ~ 0.4615509  0.45974594 0.65860546)                  
-   (0.36433932 0.53884435 0.7618514  ~ 0.4647735  0.4935272  0.6336604)   
-               ...
-   (0.69857574 0.09652317 0.27568597 ~ 0.80563885 0.53765744 0.77151203)
-   (0.5960395  0.6833214  0.65358615 ~ 0.2943471  0.23736556 0.32364336))
+  ((0.052870475 0.44819808  0.48854244  ~ 0.23942728  0.8893383   0.46183863)                   
+   (0.33162943  0.3568413   0.26439044  ~ 0.19734775  0.78826183  0.5115942)   
+                ...
+   (0.41916075  0.1272022   0.43307915  ~ 0.5208803   0.76300204  0.52910817)
+   (0.5744591   0.66711944  0.48927152  ~ 0.71474916  0.5147265   0.43981186))
   :facet :input
   :requires-grad NIL
   :backward <Node: PROCEEDNODE-T (A[~] -> A[~])>}
@@ -75,9 +75,9 @@ In addition, reading the value of a `:reduction` keyword (one of `:mean` `:sum` 
 ```lisp
 (proceed (L1Norm (randn `(10 10)) (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (1 1) -> :view (<(BROADCAST 1)> <(BROADCAST 1)>) -> :visible-shape (1 1) :named ChainTMP1597 
+{CPUTENSOR[float] :shape (1 1) -> :view (<(BROADCAST 1)> <(BROADCAST 1)>) -> :visible-shape (1 1) :named ChainTMP1331 
   :vec-state [computed]
-  ((1.1810243))
+  ((1.2025735))
   :facet :input
   :requires-grad NIL
   :backward <Node: PROCEEDNODE-T (A[~] -> A[~])>}
@@ -102,9 +102,9 @@ In addition, reading the value of a `:reduction` keyword (one of `:mean` `:sum` 
 ```lisp
 (proceed (MSE (randn `(10 10)) (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (1 1) -> :view (<(BROADCAST 1)> <(BROADCAST 1)>) -> :visible-shape (1 1) :named ChainTMP1760 
+{CPUTENSOR[float] :shape (1 1) -> :view (<(BROADCAST 1)> <(BROADCAST 1)>) -> :visible-shape (1 1) :named ChainTMP1494 
   :vec-state [computed]
-  ((1.4625806))
+  ((1.4828944))
   :facet :input
   :requires-grad NIL
   :backward <Node: PROCEEDNODE-T (A[~] -> A[~])>}
@@ -196,7 +196,7 @@ y = xA^\intercal + b
 ```lisp
 (LinearLayer 10 5)
 
-<Composite: LINEARLAYER{W1814}(
+<Composite: LINEARLAYER{W1548}(
     <Input : ((~ BATCH-SIZE 10)) -> Output: ((~ BATCH-SIZE 5))>
 
     WEIGHTS -> (5 10)
@@ -284,7 +284,7 @@ Note: When `Conv2D` is initialised, the output is displayed as -1. This is becau
 ```lisp
 (Conv2D 3 5 '(3 3))
 
-<Composite: CONV2D{W1824}(
+<Composite: CONV2D{W1558}(
     <Input : ((N 3 H_IN W_IN)) -> Output: ((N 5 -1 -1))>
 
     WEIGHT -> (5 3 3 3)

--- a/docs/cl-waffe2-docs/docs/nodes.md
+++ b/docs/cl-waffe2-docs/docs/nodes.md
@@ -418,12 +418,9 @@ Declares a new `AbstractNode`.
 	  :documentation "
 ```math
 C\gets{gemm(1.0, A, B, 0.0, C)}
-```
-"))
-```
+```"))
 
-You can invoke the forward/backward by using the method forward/backward. `(forward node arg1 arg2...)` `(backward node dout1 arg1 arg2...).
-`
+You can invoke the forward/backward by using the method forward/backward. `(forward node arg1 arg2...)` `(backward node dout1 arg1 arg2...)`.
 
 ## [macro] define-impl
 
@@ -682,6 +679,8 @@ Directly defines a `call` method. Arguments must be: `(self arg1 arg2...)`
 
 Redefines a Composite as a new function or AbstractNode specified in the `:asif` keyword. Further functions or `Differentiable AbstractNode` can be defined based on existing Composites (also called as `model` and defined by `defmodel` macro) which bundles several `AbstractNodes`, as long as `:where` form is fulfilled.
 
+**Note that the expanded form includes eval function! So this macro should be placed in the toplevel!**
+
 ### Example
 
 ```lisp
@@ -690,7 +689,7 @@ Redefines a Composite as a new function or AbstractNode specified in the `:asif`
 
 ### Inputs
 
-`target-model[Composite]` a form to initialize the composite. This from is executed before running the code, and accordingly static.
+`target-model[Composite]` a form to initialize the composite. ~~This from is executed before running the code, and accordingly static.~~
 
 `where[Subscript DSL or null]` If the model has no `:where` declaration, this macro uses this `:where` form instead. Therefore, as long as `defmodel` provides `:where` declaration, this form should be OK if set as nil.
 

--- a/source/viz/dprint.lisp
+++ b/source/viz/dprint.lisp
@@ -7,82 +7,87 @@
 (defparameter *indent-with* " ")
 
 ;; └┘
-(defun dprint (toplevel &key (stream t) (print-device t) (indent-width 4) &aux (seen nil))
+(defun dprint (toplevel &key (stream t) (print-device t) (indent-width 4) (initial-indent 0) (max-count nil) &aux (seen nil) (count 0))
   "
 ## [function] dprint
 "
   (declare (type AbstractNode))
 
-  ;;(cl-waffe2/vm:disassemble-waffe2-ir toplevel)
-  
-  (labels ((indent (stream)
-	     (dotimes (i *indent-level*) (princ *indent-with* stream)))
-	   (print-tensor (stream tensor)
-	     (let* ((tensor-name (format nil "┌<~a:~a>┐"
-					 (if (slot-value tensor 'requires-grad)
-					     "Param"
-					     (if (eql (tensor-attribute tensor) :input)
-						 "TMP"
-						 "Input"))
-					 (class-name (class-of tensor))))
-		    (midpoint (floor (/ (length tensor-name) 2)))
-		    (tensor-info (format nil "~a~a"
-					 (tensor-id tensor)
-					 (if (scalar-p tensor)
-					     "(1)"
-					     (shape tensor)))))
-	       (indent stream)
-	       (format stream "~a~%" tensor-name)
-	       (indent stream)
-	       (format stream "└")
-	       
-	       
-	       (let ((*indent-level* (1- (- midpoint (floor (/ (length tensor-info) 2)))))
-		     (*indent-with* "─"))
-		 (indent stream)
-		 (format stream "~a" tensor-info)
-		 (indent stream)
-		 (format stream "┘~%"))))
-	   
-	   (print-edge (stream tensor)
-	     (let* ((node-name (cl-ppcre:split "-" (format nil "~a" (class-name (class-of (tensor-backward tensor))))))
-		    (op-name (apply
-			      #'concatenate
-			      'string
-			      (butlast node-name)))
-		    (device-name (if print-device (format nil " ~a" (class-name (class-of tensor))) ""))
-		    (line1       (format nil "┌Node:~a ~a┐" device-name op-name))
-		    (midline (floor (/ (length line1) 2)))
-		    (tensor-info (format nil "~a~a"
-					 (tensor-id tensor)
-					 (if (scalar-p tensor)
-					     "(1)"
-					     (shape tensor)))))
-	       (indent stream)
-	       (format stream "~a~%" line1)
-	       (indent stream)
-	       (format stream "└")
-	       (let ((*indent-level* (1- (- midline (floor (/ (length tensor-info) 2)))))
-		     (*indent-with* "─"))
-		 (indent stream)
-		 (format stream "~a" tensor-info)
-		 (indent stream)
-		 (format stream "┘~%"))))
-
-	   (explore-node (stream tensor)
-	     (when (null (find (tensor-iid tensor) seen))
-	       (push (tensor-iid tensor) seen)
-	       (if (or (detach-p tensor)
-		       (null (tensor-backward tensor)))
-		   (print-tensor stream tensor)
-		   (print-edge stream tensor)))
-
-	     (let ((*indent-level* (+ indent-width *indent-level*)))
-	       (dolist (var (tensor-variables tensor))
-		 (explore-node stream var)))))
+  (let ((*indent-level* initial-indent))
+    ;;(cl-waffe2/vm:disassemble-waffe2-ir toplevel)
     
+    (labels ((indent (stream)
+	       (dotimes (i *indent-level*) (princ *indent-with* stream)))
+	     (print-tensor (stream tensor)
+	       (let* ((tensor-name (format nil "┌<~a:~a>┐"
+					   (if (slot-value tensor 'requires-grad)
+					       "Param"
+					       (if (eql (tensor-attribute tensor) :input)
+						   "TMP"
+						   "Input"))
+					   (class-name (class-of tensor))))
+		      (midpoint (floor (/ (length tensor-name) 2)))
+		      (tensor-info (format nil "~a~a"
+					   (tensor-id tensor)
+					   (if (scalar-p tensor)
+					       "(1)"
+					       (shape tensor)))))
+		 (indent stream)
+		 (format stream "~a~%" tensor-name)
+		 (indent stream)
+		 (format stream "└")
+		 
+		 
+		 (let ((*indent-level* (1- (- midpoint (floor (/ (length tensor-info) 2)))))
+		       (*indent-with* "─"))
+		   (indent stream)
+		   (format stream "~a" tensor-info)
+		   (indent stream)
+		   (format stream "┘~%"))))
+	     
+	     (print-edge (stream tensor)
+	       (let* ((node-name (cl-ppcre:split "-" (format nil "~a" (class-name (class-of (tensor-backward tensor))))))
+		      (op-name (apply
+				#'concatenate
+				'string
+				(butlast node-name)))
+		      (device-name (if print-device (format nil " ~a" (class-name (class-of tensor))) ""))
+		      (line1       (format nil "┌Node:~a ~a┐" device-name op-name))
+		      (midline (floor (/ (length line1) 2)))
+		      (tensor-info (format nil "~a~a"
+					   (tensor-id tensor)
+					   (if (scalar-p tensor)
+					       "(1)"
+					       (shape tensor)))))
+		 (indent stream)
+		 (format stream "~a~%" line1)
+		 (indent stream)
+		 (format stream "└")
+		 (let ((*indent-level* (1- (- midline (floor (/ (length tensor-info) 2)))))
+		       (*indent-with* "─"))
+		   (indent stream)
+		   (format stream "~a" tensor-info)
+		   (indent stream)
+		   (format stream "┘~%"))))
 
-    (format stream "~%~a"
-	    (with-output-to-string (out)
-	      (explore-node out toplevel)))
-    toplevel))
+	     (explore-node (stream tensor)
+	       (when (null (find (tensor-iid tensor) seen))
+		 (incf count)
+		 (when (and max-count
+			    (>= count max-count))
+		   (return-from explore-node))
+		 (push (tensor-iid tensor) seen)
+		 (if (or (detach-p tensor)
+			 (null (tensor-backward tensor)))
+		     (print-tensor stream tensor)
+		     (print-edge stream tensor)))
+
+	       (let ((*indent-level* (+ indent-width *indent-level*)))
+		 (dolist (var (tensor-variables tensor))
+		   (explore-node stream var)))))
+      
+
+      (format stream "~%~a"
+	      (with-output-to-string (out)
+		(explore-node out toplevel)))
+      toplevel)))

--- a/source/vm/nodes/conditions.lisp
+++ b/source/vm/nodes/conditions.lisp
@@ -44,9 +44,27 @@ Content  : ~a"
   ((node :initarg :node))
   (:report
    (lambda (c s)
-     (format s "Couldn't find any implementation of ~a for ~a.~a"
+     (format s "
+forward:
+  (forward (~a) ...)
+            └── Couldn't find any implementation
+
+  The AbstractNode ~a is undoubtedly declared by defnode, but cl-waffe2 couldn't find any valid implementation (given by define-impl) from current devices.
+
+    
+    Current Devices: ~a
+
+=>
+   1. Explict devices you want to use with the macro with-devices
+   2. Add an implementation to the node with whichever you like: define-impl or define-impl-op
+   ~a
+~a"
+	     (slot-value c 'node)
 	     (slot-value c 'node)
 	     *using-backend*
+	     (if (subtypep (slot-value c 'node) 'cl-waffe2/base-impl::MatmulNode)
+		 "3. OpenBLAS may not be loaded correctly if you want to use the CPUTensor backend."
+		 "")
 	     (if *facet-monopoly-mode*
 		 "~%With *facet-monopoly-mode* = t, cl-waffe only uses the first-priority device."
 		 "")))))

--- a/source/vm/nodes/defmodel.lisp
+++ b/source/vm/nodes/defmodel.lisp
@@ -364,8 +364,7 @@ Directly defines a `call` method. Arguments must be: `(self arg1 arg2...)`
 				      "")
 				  documentation)))
 
-       (defmethod read-where ((model ,name))
-	 ',where)
+       (defmethod read-where ((model ,name)) ',where)
        
        ;; Creates a constructor named (linearlayer constructor-arguments)
        (defun ,name (,@constructor-arguments)

--- a/source/vm/nodes/defmodel.lisp
+++ b/source/vm/nodes/defmodel.lisp
@@ -42,8 +42,12 @@ This generic function is used to customize how the model is printed on the displ
 `call` is a generic function which is used to `:forward`/`:on-call->` forms for an `AbstractNode`/`Composite` class respectively."))
 
 (defmethod call :before ((model Composite) &rest inputs)
-  (declare (ignore inputs))
   ;; Update States?
+
+  (let ((linter-p (read-where model)))
+    (when linter-p
+      (apply #'shape-compatible? model inputs)))
+  
   (assert (subtypep (class-of model) 'Composite)
 	  nil
 	  "Assertion Failed with call method, because the model ~a isn't subtype of cl-waffe2/vm.nodes:Composite." model))

--- a/source/vm/nodes/defnode.lisp
+++ b/source/vm/nodes/defnode.lisp
@@ -326,12 +326,9 @@ Declares a new `AbstractNode`.
 	  :documentation \"
 ```math
 C\\gets{gemm(1.0, A, B, 0.0, C)}
-```
-\"))
-```
+```\"))
 
-You can invoke the forward/backward by using the method forward/backward. `(forward node arg1 arg2...)` `(backward node dout1 arg1 arg2...).
-`
+You can invoke the forward/backward by using the method forward/backward. `(forward node arg1 arg2...)` `(backward node dout1 arg1 arg2...)`.
 "
 
   (when (null where)

--- a/source/vm/nodes/defnode.lisp
+++ b/source/vm/nodes/defnode.lisp
@@ -399,6 +399,7 @@ You can invoke the forward/backward by using the method forward/backward. `(forw
 		(,(car constructor-arguments)
 		  (make-instance
 		   (determine-facet-of-nodes ',abstract-name *using-backend* ,@(get-params (cdr constructor-arguments)))
+		   :where-decl ',where
 		   :function-node  (car ,subscript-p)
 		   :function-node1 (car ,subscript-p1)
 		   :uprank-state   (third ,subscript-p)

--- a/source/vm/nodes/defnode.lisp
+++ b/source/vm/nodes/defnode.lisp
@@ -185,6 +185,9 @@ The order of priority would be `(,@backend-priority ScalarTensor t). (t is a spe
 	    (warn "~a is not a subtype of cl-waffe2/vm.generic-tensor:AbstractTensor. If you want to extend device, extend this class first."
 		  x)))
       *using-backend*)
+
+     (when (null *using-backend*)
+       (warn "with-devices: *using-backend* is set to nil, which means no any tensor could be initialized!."))
      ,@body))
 
 (defmacro with-single-device ((device-name) &body body)
@@ -221,7 +224,7 @@ The order of priority would be `(,@backend-priority ScalarTensor t). (t is a spe
 
 	     (when *facet-monopoly-mode*
 	       (error 'node-not-found :node abstract-name))))
-
+  
   (error 'node-not-found :node abstract-name))
 
 
@@ -555,7 +558,6 @@ Gives an implementation of `abstract-name` as a function form.
 	 (backward-body (cdr backward))
 	 
 	 (impl-name     (subnode-name abstract-name device))
-	 
 	 (fw-name-vm    (symb abstract-name device '-vm-function)))
     
     (eval-when (:compile-toplevel :load-toplevel :execute)

--- a/source/vm/nodes/model-compiler.lisp
+++ b/source/vm/nodes/model-compiler.lisp
@@ -394,6 +394,43 @@ Or
 	     asif
 	     (car target-model)))
 
+    ;; Check :where form
+    (multiple-value-bind (in-names out-names in-state out-state lets) (parse-subscript where-decl-to-use)
+      (declare (ignore lets))
+
+      (let ((in (or (null in-names)
+		    (not (= (length in-names) (length in-state)))))
+	    (out (or (null out-names)
+		     (not (= (length out-names) (length out-state))))))
+	(when (or in out)
+	  (error "defmodel-as: Every subscript should be given their own names by its :where.
+
+~a
+~a"
+		 (if in
+		     "Position: Before ->"
+		     "Position: After  ->")
+		 
+		 (if (null where)
+		     ;; From defmodel
+		     (format nil "
+    (defmodel (~a (self ...)
+                  ...
+                  :where ~a
+                          └── Specify the name to use. (e.g.: A[i j])
+                  ...))"
+			     (car target-model)
+			     where-decl-to-use)
+		     ;; From defmodel-as
+		     (format nil "
+    (defmodel-as ~a
+                  ...
+                  :where ~a
+                          └── Specify the name to use. (e.g.: A[i j])
+                  ...))"
+			     target-model
+			     where-decl-to-use))))))
+
     (when (and (read-where composite) where)
       (warn "defmodel-as: As both the composite ~a and defmodel-as form declared :where form, defmodel was used in preference.
 
@@ -421,6 +458,6 @@ Or
 			 (cl-waffe2/base-impl::A*=B X grad)))))
 
 (defmodel-as (Multiply-Gradients)
-  :where (X[~] Grad[~] -> X[~])
+  :where (X[~] Grad[~] -> OUT[~])
   :asif :function
   :named multiply-grads-static)

--- a/source/vm/nodes/shape-error.lisp
+++ b/source/vm/nodes/shape-error.lisp
@@ -32,7 +32,6 @@
 	  (dtype      tensor)
 	  (shape tensor)))
 
-;; [TODO] 前後の計算ノードをPrintする
 (defun build-shape-error (forward-or-call model
 			  where-decl
 			  received predicted shape-error-list
@@ -75,7 +74,7 @@ Suggestion"
     (format out "[Shaping Error]:")
 
     (if (eql forward-or-call :call)
-	(format out " The Comosite ~a was called with invaild arguments." model-name)
+	(format out " The Composite ~a was called with invaild arguments." model-name)
 	(case (checkpoint-state *shape-error-when*)
 	  (:forward
 	   (format out " The AbstractNode ~a was called with invaild arguments." model-name))

--- a/source/vm/nodes/shape-error.lisp
+++ b/source/vm/nodes/shape-error.lisp
@@ -11,92 +11,202 @@
 ;;                          ^--- ...
 ;;
 
-(defstruct Rank-Error
-  "Rank Error"
-  (position 0 :type fixnum)
-  (excepted-rank 0 :type fixnum)
-  (butgot 0 :type fixnum))
-
 (defstruct Number-of-Args
   "f(x, y) with (call f x)"
   first-state
   out-state
   previous-subscripts)
 
-(defstruct Rank-Atleast-error
-  "A[~ i j] with (1)"
-  position
-  first-state
-  butgot)
+(defstruct (shape-error-message
+	    (:conc-name msgof-))
+  (position 0 :type fixnum)
+  (place-me-last nil :type boolean)
+  (in-short "" :type string)
+  (content "" :type string)
+  (suggestion "" :type string))
 
-(defstruct rank-mismatch-error
-  "(5 3 2) (5 3) in [~ i] [~ i]"
-  position
-  excepted
-  butgot)
+(defun describe-tensor (tensor)
+  (declare (type AbstractTensor tensor))
+  (format nil "~a{~a}~a"
+	  (class-name (class-of tensor))
+	  (dtype      tensor)
+	  (shape tensor)))
 
-(defstruct flex-mismatch-error
-  "~ do not match"
-  position
-  excepted
-  butgot)
-
-(defstruct shape-mismatch-error
-  "Shapes do not match"
-  position
-  excepted
-  butgot)
-
-(deftype call-form-error-t ()
-  `(or number-of-args))
-
-(deftype rank-error-t ()
-  "A family of Rank-Error struct"
-  `(or rank-error
-       rank-atleast-error))
-
-(defun compile-call-form-error (nth errorlist)
-  (declare (type list errorlist))
-  (with-output-to-string (result)
-    (format result "== ~:R, calling form is invaild. ==~%" nth)
-    (let ((target (car errorlist)))
-      (when (typep target 'call-form-error-t)
-	(let ((nargs  (length (number-of-args-first-state target)))
-	      (butgot (length (number-of-args-previous-subscripts target))))
-	  (format result "~%Since the node is declared as: ~a -> ~a, the number of arguments must correspond.
-
-It is too ~a: ~a"
-
-		(number-of-args-first-state target)
-		(number-of-args-out-state   target)
-		(if (> butgot nargs)
-		    "many"
-		    "few")
-		(number-of-args-previous-subscripts target)))))))
-  
-(defun compile-rank-error (nth errorlist)
-  (declare (type list errorlist))
-  (with-output-to-string (result)
-    (format result "== ~:R, rank error is detected. ==~%" nth)
-
-    ))
-
-(defun build-shape-error (shape-error-list)
+;; [TODO] 前後の計算ノードをPrintする
+(defun build-shape-error (forward-or-call model
+			  where-decl
+			  received predicted shape-error-list
+			  &aux
+			    (model-name (class-name (class-of model))))
   "
 ShapeError Template:
 
-[shape-error] Shape Error was detected when doing ...
+Shaping-Error: Can't forward/call the Node/Composite because shapings are invaild.
+
+At: [A] [B]
+     ----
+       |
+      Here
+
+Received: (call (MODEL ...) A(a) B(a) C(10))
+                              L(1) |    |
+                                   L(2) |
+                                       (3)
+
+Excepted: (call (MODEL ...) A(10 10) B(10 10))
 
 <<Call Form Attempted>>
 
 <<Definitions>>
 
-<<RankError>> or <<Dimension Do Not Match?>> or <<Shapes undetermined>>"
+<<RankError>> or <<Dimension Do Not Match?>> or <<Shapes undetermined>>
+
+Suggestion"
 
   ;; Design:
   ;;
   ;; (A B C)
   ;;    ^ Set B = 1
-  (declare (ignore shape-error-list))
-  )
+  (declare (type (and keyword (member :forward :call)) forward-or-call)
+	   (type symbol model-name)
+	   (type (or AbstractNode Composite)))
 
+  (with-output-to-string (out)
+    (format out "[Shaping Error]:")
+
+    (if (eql forward-or-call :call)
+	(format out " The Comosite ~a was called with invaild arguments." model-name)
+	(case (checkpoint-state *shape-error-when*)
+	  (:forward
+	   (format out " The AbstractNode ~a was called with invaild arguments." model-name))
+	  (:backward
+	   (format out " The AbstractNode ~a inside backward definition was called with invaild arguments.
+
+    (define-impl (~a (self ...)
+        ...
+        :backward ((self ...)
+                    ...
+                   (forward (~a ...) ...)
+                              └── Detected when during the backward construction.
+                   ...)))"
+		   model-name (class-name (class-of (checkpoint-node-at *shape-error-when*)))
+		   model-name))))
+
+    (let* ((caller-name  (if (eql forward-or-call :forward) "forward" "call"))
+	   (subject-name (if (eql forward-or-call :call) model-name
+			     (if (eql (checkpoint-state *shape-error-when*) :backward)
+				 (class-name (class-of (checkpoint-node-at *shape-error-when*)))
+				 model-name)))
+	   (parsed (multiple-value-list (parse-subscript where-decl)))
+	   (in-args (car parsed)))
+
+      (format out "~%~% The constraint:~%    ~a: ~a~%" subject-name where-decl)
+
+      (if (find 'number-of-args shape-error-list :test #'subtypep :key #'class-of)
+	  (progn
+	    (format out "
+Received:
+    (~a
+        (~a ...)~a)
+              └── Received Too ~a Arguments.
+  
+Excepted:
+    (~a (~a ...)~a)
+"
+		    caller-name model-name
+		    (with-output-to-string (args)
+		      (dolist (r received)
+			(princ #\newline args)
+			(princ "         " args)
+			(princ (describe-tensor r) args)))
+		    (if (>= (length received) (length in-args))
+			"Many"
+			"Few")
+		    caller-name model-name
+		    (with-output-to-string (args)
+		      (dolist (n in-args)
+			(princ " " args)
+			(princ n args)))))
+	  ;; More Errors
+	  (let* ((more-errors (loop for er in shape-error-list
+				    if (msgof-place-me-last er) collect er))
+		 (shape-error-list (loop for er in shape-error-list
+					 unless (msgof-place-me-last er) collect er))
+		 (error-by-position (make-list (length received)))
+		 (print-laters))
+	    (dolist (err shape-error-list)
+	      (push err (nth (msgof-position err) error-by-position)))
+	    (format out "
+Received:
+    (~a
+        (~a ...)~a
+        )
+~a
+Excepted:
+    (~a
+        (~a ...)~a
+        )
+~a
+Predicted outputs of ~a:  ~a
+~a
+The operation was:
+~a
+"
+		    caller-name model-name
+		    (with-output-to-string (args)
+		      (loop for errors in error-by-position
+			    for act in received
+			    for nth fixnum upfrom 0
+			    for in-name in in-args
+			    if errors do
+			      (princ #\Newline args)
+			      (princ "         " args)
+			      (princ (describe-tensor act) args)
+			      ;; If errors are too many: move into another place
+			      (if (> (length errors) 1)
+				  (progn
+				    (format args " ─ ~a: " in-name)
+				    (push nth print-laters)
+				    (dolist (err errors)
+				      (princ (msgof-in-short err) args)
+				      (princ " " args)))
+				  (progn
+				    (format args " ── ~a" (msgof-content (car errors)))))))
+		    ;; print-laters
+		    (if print-laters
+			(with-output-to-string (tmp)			  
+			  (dolist (nth print-laters)
+			    (format tmp "~%~a:~%" (nth nth in-args))
+			    (dolist (err (nth nth error-by-position))
+			      (format tmp "    ─ ~a~%" (msgof-content err)))))
+			"")
+		    ;; Displays Predicted Outputs and suggestions If any
+		    caller-name model-name
+		    (with-output-to-string (args)
+		      (loop for errors in error-by-position
+			    for name in in-args
+			    for act  in received
+			    for nth upfrom 0
+			    if errors do
+			      (princ #\Newline args)
+			      (princ "        " args)
+			      (format args "~a~a" name (shape act))
+			      (if (> (length errors) 1)
+				  (format args " ─> ~a: " name)
+				  (format args " ── ~a" (msgof-suggestion (car errors))))))
+		    (if print-laters
+			(with-output-to-string (tmp)
+			  (dolist (nth print-laters)
+			    (format tmp "~%~a:~%" (nth nth in-args))
+			    (dolist (err (nth nth error-by-position))
+			      (format tmp "    ─ ~a~%" (msgof-suggestion err)))))
+			"")
+		    model-name
+		    predicted
+		    (if more-errors
+			(with-output-to-string (tmp)
+			  (format tmp "More:~%")
+			  (dolist (m more-errors)
+			    (format tmp "~a~%" (msgof-content m))))
+			"")
+		    model))))))

--- a/source/vm/nodes/shape.lisp
+++ b/source/vm/nodes/shape.lisp
@@ -305,11 +305,11 @@ Return: (values names subscripts where)
 (defun get-common-symbols (symbols)
   (remove-duplicates (flatten symbols) :test #'symbol-eq))
 
-(defun build-subscript-note (position called-as excepted butgot states)
+(defun build-subscript-note (nth-pos position called-as excepted butgot states)
   (make-shape-error-message
    :position position
    :in-short   (format nil "~a should be ~a but got ~a." called-as excepted butgot)
-   :content    (format nil "is ~a. ~a should be ~a but got ~a." states called-as excepted butgot)
+   :content    (format nil "the ~ath shape is ~a. ~a should be ~a but got ~a." nth-pos states called-as excepted butgot)
    :suggestion (format nil "In ~a, set ~a=~a." states called-as excepted)))
 
 
@@ -547,7 +547,7 @@ Example:
 							      (not
 							       (equal ,var (nth ,nth-arg ,shape))))
 						     (push
-						      (build-subscript-note ,i ',var ,var (nth ,nth-arg ,shape) ',subscript)
+						      (build-subscript-note ,nth-arg ,i ',var ,var (nth ,nth-arg ,shape) ',subscript)
 						      ,all-conditions))
 						   (num-major-setq ,var (nth ,nth-arg ,shape)))
 						  ((> (- (length ,shape) ,nth-arg) ,pos1)
@@ -564,7 +564,7 @@ Example:
 								(not
 								 (equal ,var (nth ,pos ,shape))))
 						       (push
-							(build-subscript-note ,i ',var ,var (nth ,nth-arg ,shape) ',subscript)
+							(build-subscript-note ,nth-arg ,i ',var ,var (nth ,nth-arg ,shape) ',subscript)
 							,all-conditions))
 						     (num-major-setq ,var (nth ,pos ,shape)))))
 				     else
@@ -586,14 +586,14 @@ Example:
 							 :content  (format nil "~~ is already determined as ~a but the tensor attempted to make it ~a."
 									   (nth ,pos ,undetermined-shape-tmp)
 									   (nth ,pos ,shape))
-							 :suggestion (format nil "the shape should be: ~a or broadcasted." (nth ,pos ,undetermined-shape-tmp)))
+							 :suggestion (format nil "the ~ath shape should be: ~a or broadcasted." (1+ ,pos) (nth ,pos ,undetermined-shape-tmp)))
 							,all-conditions)
 						       ;; the mismatch of dimehsions originated error.
 						       (push
 							(make-shape-error-message
 							 :position ,i
 							 :in-short "The length of ~~ do not match."
-							 :content (format nil "is ~a but it violates ~~ = ~a" ,shape (replace-nil ,undetermined-shape-tmp))
+							 :content (format nil "the ~ath shape is ~a but it violates ~~ = ~a" (1+ ,pos) ,shape (replace-nil ,undetermined-shape-tmp))
 							 :suggestion "")
 							,all-conditions)))
 						 (num-major-setf (nth ,pos ,undetermined-shape-tmp) (nth ,pos ,shape)))))))

--- a/source/vm/nodes/shape.lisp
+++ b/source/vm/nodes/shape.lisp
@@ -1,9 +1,6 @@
 
 (in-package :cl-waffe2/vm.nodes)
 
-(defun range (start end)
-  (loop for i upfrom start below end collect i))
-
 (defun symbol-eq (x y)
   (and
    (symbolp x)

--- a/source/vm/nodes/shape.lisp
+++ b/source/vm/nodes/shape.lisp
@@ -219,7 +219,7 @@ variables := variable variables
 
 variable := [shape-subscripts]
 
-where [a[0~t]] -> [a[x]] let x = shape (defnode引数を引用)
+where [a[0~t]] -> [a[x]] let x = shape (local variables are accesible)
 
 BASIC Format:
 
@@ -279,7 +279,6 @@ Return: (values names subscripts where)
 	    (reverse parsed-subscripts)
 	    (reverse let-bindings))))
 
-;; (print (parse-transform-syntax `(A[i j] -> B[j k] -> C[k i] where k = 1)))
 
 ;; Bug: [~] A[~] -> B [~]
 (defun where->backward (subscripts)
@@ -306,31 +305,13 @@ Return: (values names subscripts where)
 (defun get-common-symbols (symbols)
   (remove-duplicates (flatten symbols) :test #'symbol-eq))
 
-(defun build-subscript-error-note (&key
-				     all-subscript
-				     determined-shape
-				     determined-out
-				     symbol
-				     excepted
-				     but-got
-				     nth-argument
-				     target-shape)
-  (format nil "Inconsistency of subscripts.
-The Function is defined as :  ~a
-Determined Shape           :  ~a -> ~a
-Excepted: ~a = ~a
-Butgot  : ~a = ~a
-Because : The actual ~ath argument given has a shape of ~a.
-"
-	  all-subscript
-	  determined-shape
-	  determined-out
-	  symbol
-	  excepted
-	  symbol
-	  but-got
-	  nth-argument
-	  target-shape))
+(defun build-subscript-note (position called-as excepted butgot states)
+  (make-shape-error-message
+   :position position
+   :in-short   (format nil "~a should be ~a but got ~a." called-as excepted butgot)
+   :content    (format nil "is ~a. ~a should be ~a but got ~a." states called-as excepted butgot)
+   :suggestion (format nil "In ~a, set ~a=~a." states called-as excepted)))
+
 
 (defun find-symbols (list)
   (loop for l in list
@@ -357,17 +338,12 @@ Because : The actual ~ath argument given has a shape of ~a.
 	  (length list2))
        (shape-equal (nth pos list1) (nth pos list2))))
 
-(defun replace-nil (list)
-  (map 'list #'(lambda (l) (if l l '?)) list))
+(defun replace-nil (list)  (map 'list #'(lambda (l) (if l l '?)) list))
 
-;; 二度とこのコード読みたくない
-;; Fix: subscript = [shape] where shape = `(1 2 3)
-;; => ndimension doesn't match. (Currently avoided by using ~)
-;; signifcantly slow compilation...
-;; Optimize Me...
-;; TODO: call it when defnode is called
-;; Rewrite this program...
+
 ;; TODO: Rewrite this ugly code, and print better error-notes
+;; In order to use AOT Compiler, the function below is expands S-exp and seems ugly aaaa ><
+;; I'm considering this refactoring
 (defun create-subscript-p (subscripts
 			   &key
 			     (allow-symbol nil)
@@ -402,9 +378,7 @@ Example:
     ;; [~ a b] [a b ~]
     ;; [~ a b] [~ k b] let k = (/ b 2)
     ;; boundp
-    ;; TopLevelNode -> Shape決定
     ;; [a b c] [a b c] -> [a b c] let k = 1
-    ;; let k = listを許す
     ;; Priority: 1. let-binding, defparameter 2. determined by cl-waffe
     ;; [x y z] let x = 1. In this case, x is 1. and y and z are 2.
 
@@ -451,7 +425,7 @@ Example:
 		(declare (optimize (speed 1) (compilation-speed 3))
 			 #+sbcl(sb-ext:muffle-conditions cl:style-warning sb-ext:compiler-note)
 			 )
-		;; previous-suscriptsから次のSubscriptsを作成
+		
 		;; If any, return error condition
 		;; "Return: (values next-state condition)"
 		;; TODO: Judge At-Least dims and return error.
@@ -461,9 +435,7 @@ Example:
 		(unless (= (length ,previous-subscripts)
 			   (length ',least-required-dims))
 		  (push
-		   (format nil "The function is declared as: ~a -> ~a
-but the actual argument given was: ~a.
-=> Check that the number of arguments is correct." ',first-state ',out-state ,previous-subscripts)
+		   (make-number-of-args)
 		   ,all-conditions))
 
 		,(when flexdim-n
@@ -475,18 +447,20 @@ but the actual argument given was: ~a.
 			         (setq accd k)
 			    unless (= dim (length (nth k ,previous-subscripts)))
 			      do (push
-				  (format nil "The dimensions of the ~ath input do not match.
-Excepted Dimensions -> ~a (in accordance with ~ath input)
-Butgot              -> ~a (shape=~a)
-=> Consider using the function !flexible which enables broadcasting."
-					  k
-					  dim
-					  accd
-					  (length (nth k ,previous-subscripts))
-					  (nth k ,previous-subscripts))
+				  (make-shape-error-message
+				   :position k
+				   :in-short
+				   (if (< dim (length (nth k ,previous-subscripts)))
+				       "The Rank is too tall"
+				       "The Rank is too low")
+				   :content
+				   (format nil "The given rank ~a do not match declared: ~a" dim (nth k ,previous-subscripts))
+				   :suggestion
+				   (if (< dim (length (nth k ,previous-subscripts)))
+				       "Use (!rankup tensor -ntimes) to degrade the rank of tensors."
+				       "Use (!flexible tensor) to explict a rank-up rule of broadcasting."))
 				  ,all-conditions))))
 			  
-
 		;; The Number of dimensions error.
 		(mapc
 		 #'(lambda (nth-arg declared act)
@@ -494,16 +468,11 @@ Butgot              -> ~a (shape=~a)
 		       (and
 			(setq ,rank-error-p t)
 			(push
-			 (format
-			  nil
-			  "The number of dimensions must satisfy: dimensions >= ~a
-Because the function is declared as: ~a -> ~a.
-=> However, the actual ~ath argument given was ~a."
-			  declared
-			  ',first-state
-			  ',out-state
-			  (1+ nth-arg)
-			  act)
+			 (make-shape-error-message
+			  :position nth-arg
+			  :in-short (format nil "The rank is incompatible")
+			  :content  (format nil "is declared as: ~a and the rank must at least satisfy: >= ~a" (nth nth-arg ',first-state) declared)
+			  :suggestion "If you believe this error is false, set (ignore-shape-error self) = t")
 			 ,all-conditions))))
 		 (range 0 (length ,previous-subscripts))
 		 ',least-required-dims
@@ -516,18 +485,12 @@ Because the function is declared as: ~a -> ~a.
 		       (and
 			(setq ,rank-error-p t)
 			(push
-			 (format
-			  nil
-			  "The ~ath argument is declared as: ~a
-Accordingly, the argument must satisfy: dimensions = ~a
-=> However, the actual ~ath argument given was ~a"
-			  (1+ nth-arg)
-			  (nth nth-arg ',first-state)
-			  declared
-			  (1+ nth-arg)
-			  act)
-			 ,all-conditions))))
-		 
+			 (make-shape-error-message
+			  :position nth-arg
+			  :in-short (format nil "Rank must be ~a" declared)
+			  :content  (format nil "is declared as: ~a" (nth nth-arg ',first-state))
+			  :suggestion "Check the definition.")
+			 ,all-conditions))))		 
 		 (range 0 (length ,previous-subscripts))
 		 ',max-required-dims
 		 ,previous-subscripts)
@@ -571,6 +534,7 @@ Accordingly, the argument must satisfy: dimensions = ~a
 				     unless (symbol-eq var '~)
 				       collect `(cond
 						  ((< ,nth-arg ,pos1)
+						   ;; ~ <- Broadcastingの範囲のShapeError
 						   ;; here, we can detect errors
 						   ;; ,var is determined and determined shapes doesn't match.
 						   (when (and (not (null ,var))
@@ -583,15 +547,7 @@ Accordingly, the argument must satisfy: dimensions = ~a
 							      (not
 							       (equal ,var (nth ,nth-arg ,shape))))
 						     (push
-						      (build-subscript-error-note
-						       :all-subscript ',subscripts
-						       :determined-shape (list ,@(map 'list #'(lambda (x) `(list ,@x)) first-state))
-						       :determined-out (list ,@(map 'list #'(lambda (x) `(list ,@x)) out-state))
-						       :symbol ',var
-						       :excepted ,var
-						       :but-got (nth ,nth-arg ,shape)
-						       :nth-argument ,nth-arg
-						       :target-shape ,shape)
+						      (build-subscript-note ,i ',var ,var (nth ,nth-arg ,shape) ',subscript)
 						      ,all-conditions))
 						   (num-major-setq ,var (nth ,nth-arg ,shape)))
 						  ((> (- (length ,shape) ,nth-arg) ,pos1)
@@ -608,19 +564,11 @@ Accordingly, the argument must satisfy: dimensions = ~a
 								(not
 								 (equal ,var (nth ,pos ,shape))))
 						       (push
-							(build-subscript-error-note
-							 :all-subscript ',subscripts
-							 :determined-shape (list ,@(map 'list #'(lambda (x) `(list ,@x)) first-state))
-							 :determined-out (list ,@(map 'list #'(lambda (x) `(list ,@x)) out-state))
-							 :symbol ',var
-							 :excepted ,var
-							 :but-got (nth ,nth-arg ,shape)
-							 :nth-argument ,nth-arg
-							 :target-shape ,shape)
+							(build-subscript-note ,i ',var ,var (nth ,nth-arg ,shape) ',subscript)
 							,all-conditions))
 						     (num-major-setq ,var (nth ,pos ,shape)))))
 				     else
-				       collect
+				       collect ;; Batch-Size ...
 				     `(loop for ,pos fixnum
 					    upfrom ,pos1
 					      below (- (length ,shape) ,pos2)
@@ -632,20 +580,21 @@ Accordingly, the argument must satisfy: dimensions = ~a
 						   ;; mismatch axes-originated.
 						   (if (= (length ,undetermined-shape-tmp) (length ,shape))
 						       (push
-							(format
-							 nil
-							 "Couldn't idenfity ~~: ~~ is determined as ~a ~% butgot: ~a.~% Excepted ~~ = ~a, butgot: ~a"
-							 (nth ,pos ,undetermined-shape-tmp) (nth ,pos ,shape)
-							 (replace-nil ,undetermined-shape-tmp)
-							 ,shape)
+							(make-shape-error-message
+							 :position ,i
+							 :in-short "Inconsistent use of batch: ~~."
+							 :content  (format nil "~~ is already determined as ~a but the tensor attempted to make it ~a."
+									   (nth ,pos ,undetermined-shape-tmp)
+									   (nth ,pos ,shape))
+							 :suggestion (format nil "the shape should be: ~a or broadcasted." (nth ,pos ,undetermined-shape-tmp)))
 							,all-conditions)
 						       ;; the mismatch of dimehsions originated error.
 						       (push
-							(format
-							 nil
-							 "The length of ~~ do not match.~%Excepted ~~ = ~a, butgot: ~a"
-							 (replace-nil ,undetermined-shape-tmp)
-							 ,shape)
+							(make-shape-error-message
+							 :position ,i
+							 :in-short "The length of ~~ do not match."
+							 :content (format nil "is ~a but it violates ~~ = ~a" ,shape (replace-nil ,undetermined-shape-tmp))
+							 :suggestion "")
 							,all-conditions)))
 						 (num-major-setf (nth ,pos ,undetermined-shape-tmp) (nth ,pos ,shape)))))))
 		  
@@ -666,9 +615,10 @@ Accordingly, the argument must satisfy: dimensions = ~a
 					   (and
 					    (unless ,allow-symbol
 					      (push
-					       (format
-						nil
-						"Failed to determine this symbol: ~a" name)
+					       (make-shape-error-message
+						:position 0
+						:place-me-last T
+						:content (format nil "Failed to determine this symbol: ~a" name))
 					       ,all-conditions)
 					      t)
 					    '~)))
@@ -691,12 +641,14 @@ Accordingly, the argument must satisfy: dimensions = ~a
 						      ,tmp
 						      (progn
 							(push
-							 (format
-							  nil
-							  "~a is declared as ~a, but determined as ~a"
+							 (make-shape-error-message
+							  :place-me-last t
+							  :content
+							  (format nil
+							  "~a should be ~a, but determined as: ~a"
 							  ',(car let)
 							  ,tmp
-							  ,(car let))
+							  ,(car let)))
 							 ,all-conditions)
 							,tmp))))))
 		      (let ((,~symbol (remove '~ ,undetermined-shape-tmp :test #'symbol-eq)))
@@ -731,325 +683,5 @@ Accordingly, the argument must satisfy: dimensions = ~a
 		       (symbol-eq (car s) '~))
 		   first-state)
 	      (list first-state out-state)))))
-
-
-
-
-
-
-
-;; ↓ Ituka yarou...
-
-;; Refactor Version...
-(defun expand-rank-check-forms (input-names first-states prev-subscripts detected-errors rank-err)
-  "Comparing all ranks between first-state and prev-subscripts.
-If any, appends Rank-Error to detected-errors"
-  `(progn
-     ;; Iterate by args (e.g.: A B C...)
-     ,@(loop for name  in input-names
-	     for state in first-states
-	     for nth fixnum upfrom 0
-	     collect `(when (= ,(length state) (nth ,nth ,prev-subscripts))
-			(setq ,rank-err t)
-			(push
-			 (make-rank-error
-			  :position      ,nth
-			  :excepted-rank ,(length state)
-			  :butgot        (length (nth ,nth ,prev-subscripts)))
-			 ,detected-errors)))))
-
-(defun expand-least-rank-check-forms (input-names first-states prev-subscripts detected-errors rank-err)
-  `(progn
-     ,@(loop for name in input-names
-	     for state in first-states
-	     for nth fixnum upfrom 0
-	     collect
-	     (let ((least-dim (- (length state) (count '~ state :test #'symbol-eq))))
-	       `(when (< (length (nth ,nth ,prev-subscripts)) ,least-dim)
-		  (setq ,rank-err t)
-		  (push
-		   (make-rank-atleast-error
-		    :position ,nth
-		    :first-state ',state
-		    :butgot (length (nth ,nth ,prev-subscripts)))
-		   ,detected-errors))))))
-
-(defun expand-number-of-args-check-forms (previous-subscripts input-states out-state detected-errors)
-  `(unless (= (length ,previous-subscripts) ,(length input-states))
-     (push
-      (make-number-of-args
-       :first-state ',input-states
-       :out-state ',out-state
-       :previous-subscripts ,previous-subscripts)
-      ,detected-errors)))
-
-(defun expand-flex-dim-ident-form (nth-argument
-				   pos1 pos2
-				   symbol shape
-				   out-omit-p detected-errors
-				   ~
-				   &aux (pos (gensym)))
-  (declare (ignore symbol))
-  ;; out-omit-p == '~
-  `(loop for ,pos upfrom ,pos1 below (- (length ,shape) ,pos2)
-	 do ,(when out-omit-p
-	       `(when (and (not (null (nth ,pos ,~)))
-			   (not (shape-equal-1 ,pos ,~ ,shape)))
-		  (push
-		   (make-flex-mismatch-error
-		    :position ,nth-argument
-		    :excepted (nth ,pos ,~)
-		    :butgot   (nth ,pos ,shape))
-		   ,detected-errors)))
-	    (num-major-setf (nth ,pos ,~) (nth ,pos ,shape))))
-
-(defun expand-dim-ident-form (nth-arg pos1 pos2
-			      symbol shape detected-errors
-			      &aux (pos (gensym)))
-  `(cond
-     ((< ,nth-arg ,pos1)
-      (when (and (not (null ,symbol))
-		 (or
-		  ;; ('a 'a) or (10 10), not ('a 1) (1 'a)
-		  (and (symbolp ,symbol)
-		       (symbolp (nth ,nth-arg ,shape)))
-		  (and (numberp ,symbol)
-		       (numberp (nth ,nth-arg ,shape))))
-		 (not
-		  (equal ,symbol (nth ,nth-arg ,shape))))
-	(push
-	 (make-shape-mismatch-error
-	  :position ,nth-arg
-	  :excepted ,symbol
-	  :butgot   (nth ,nth-arg ,shape))
-	 ,detected-errors))
-      (num-major-setq ,symbol (nth ,nth-arg ,shape)))
-     ((> (- (length ,shape) ,nth-arg) ,pos1)
-      (let ((,pos (- (1- (length ,shape)) (- ,pos2 ,nth-arg))))
-	(when (and (not (null ,symbol))
-		   (or
-		    ;; ('a 'a) or (10 10), not ('a 1) (1 'a)
-		    (and (symbolp ,symbol)
-			 (symbolp (nth ,nth-arg ,shape)))
-		    (and (numberp ,symbol)
-			 (numberp (nth ,nth-arg ,shape))))
-		   (not
-		    (equal ,symbol (nth ,pos ,shape))))
-	  (push
-	   (make-shape-mismatch-error
-	    :position ,nth-arg
-	    :excepted ,symbol
-	    :butgot   (nth ,nth-arg ,shape))
-	   ,detected-errors))
-	(num-major-setq ,symbol (nth ,pos ,shape))))))
-
-;; Refactoring isn't done yet.
-(defun create-subscript-p1 (subscripts
-			    &key
-			      (allow-symbol nil)
-			      (macroexpand nil)
-			      (fixed nil)
-			      (return-body nil)
-			      (local-variables nil)
-			    &aux
-			      (rank-error-p (gensym "rank-err-p"))
-			      (previous-subscripts (gensym "PreviousShape"))
-			      (known-symbols (gensym))
-			      (detected-errors     (gensym "err")))
-  "Returns a inlined version of subscript checker
-
-Inputs:
-    allow-symbol - If t, never produce error even when the predicted output includes symbols
-    fixed        - If t, ~ is ignored.
-
-Return: (values body output-names first-state (list first-state out-state))
-"
-  (declare (type list local-variables))
-  (multiple-value-bind (input-names
-			output-names
-			first-state
-			out-state
-			let-binding)
-      (parse-subscript subscripts :fixed fixed)
-    (declare (optimize (speed 3))
-	     (type list input-names output-names first-state out-state let-binding))
-
-    ;; input-names  ... (A B)
-    ;; output-names ... (C D)
-    ;; first-state  ... ((~ x y z) (i j))
-    ;; output-state ... ((~ x y z) (i j))
-
-    (print input-names)
-    (print output-names)
-    (print first-state)
-    (print out-state)
-    (print let-binding)
-
-    (let ((out-omit-p (find '~ (the list (flatten out-state)) :test #'symbol-eq))
-	  (initial-symbols))
-
-      ;; Register all symbols to be determined to initial-tables
-      (mapc #'(lambda (name)
-		(unless (find name initial-symbols :test #'symbol-eq)
-		  (push name initial-symbols)))
-	    (flatten first-state))
-
-      (mapc #'(lambda (name)
-		(unless (find name initial-symbols :test #'symbol-eq)
-		  (push name initial-symbols)))
-	    (flatten out-state))
-
-      ;; ~ can be used at once and is a special symbol!
-      ;; initial-symbols = (~ i j k ...)
-
-      
-      (let* ((~ (find '~ initial-symbols :test #'symbol-eq))
-	     (flexdim-n (loop for input in first-state ;; the list of arguments which includes ~
-			      for k fixnum upfrom 0
-			      if (find '~ (the list (flatten input)) :test #'symbol-eq)
-				collect k))
-	     (body `(lambda (,previous-subscripts
-			     &aux
-			       (,known-symbols (find-symbols (flatten ,previous-subscripts)))
-			       (,rank-error-p)
-			       (,detected-errors))
-
-		      ;; In the context, ~ must be used as the same rank
-		      ,(when (and flexdim-n (not fixed))
-			 `(let ((dim)
-				(accd))
-			    (loop for k in ',flexdim-n
-				  if (null dim)
-				    do (setq dim (length (nth k ,previous-subscripts)))
-				       (setq accd k)
-				  unless (= dim (length (nth k ,previous-subscripts)))
-				    do (push
-					(make-rank-mismatch-error
-					 :position k
-					 :excepted (length accd)
-					 :butgot   (length (nth k ,previous-subscripts)))
-					,detected-errors))))
-		      
-		      ;; Binding where a = 1 / a = (shape x) ...
-		      ;; Place undetermined symbols (as long as they wasn't initialized by where)
-		      (let* (,@let-binding
-			     ,@(loop for symbol in initial-symbols
-				     unless (or
-					     (symbol-eq symbol '~)
-					     (find symbol let-binding :key #'car :test #'symbol-eq))
-				       collect (if (find (the symbol symbol) (the list local-variables))
-						   `(,symbol ,symbol)
-						   `(,symbol)))
-			     ;; ~ = (nil nil nil) of max dim
-			     ,@(when ~ ;; ~ was once used?
-				 `((,~ (loop for s upfrom 0 below (loop for p in ,previous-subscripts maximize (length p))
-					     collect nil)))))
-			(declare (ignorable ,@initial-symbols))
-			
-
-
-			,(if fixed
-			     ;; If ~ weren't used, do a rank check
-			     ;; symbols could be also a list: A[after] where after = (shape ...)
-			     ;; So do it after placing let-binding
-			     
-			     (expand-rank-check-forms
-			      input-names
-			      first-state
-			      previous-subscripts
-			      detected-errors
-			      rank-error-p)
-
-			     ;; even if ~ were used in subscript
-			     ;; (1) for [~ i j] is still invaild.
-			     (expand-least-rank-check-forms
-			      input-names
-			      first-state
-			      previous-subscripts
-			      detected-errors
-			      rank-error-p))
-
-			;; checking number of arguments
-			;; ((1 2)) with A[i j] -> B[i j] is invaild for example.
-
-			,(expand-number-of-args-check-forms
-			  previous-subscripts
-			  first-state
-			  out-state
-			  detected-errors)
-
-			;; Starting Predicting Output Shapes
-			;; Create and fullfil table			
-
-			,@(loop for subscript in first-state
-				for i fixnum upfrom 0
-				collect
-				;; Iterate by Arguments
-				;; input = (~ i j) (~ j i) ...
-				;; nth   = 0 1 2...
-
-				;; ~ is flexible
-				;; 0 1 ... ~
-				;; ~ 0 1 ...
-				`(progn
-				   ,@(loop
-				       with pos1 = (or (position '~ (the list subscript) :test #'symbol-eq) (length subscript))
-				       with pos2 = (or (position '~ (reverse subscript) :test #'symbol-eq) 0)
-				       with shape = `(nth ,i ,previous-subscripts)
-				       for nth fixnum upfrom 0
-				       for symbol in subscript
-
-				       if (symbol-eq symbol '~)
-					 collect (expand-flex-dim-ident-form
-						  nth
-						  pos1 pos2
-						  symbol shape
-						  out-omit-p detected-errors ~)
-				       else
-					 collect (expand-dim-ident-form
-						  nth pos1 pos1 symbol shape detected-errors))))
-
-			
-			;; At last, we can inference out-state from the table
-
-			;; Lambda Must Return:
-			;; (value (list out-shape1 out-shape2 ...) all-errors rank-error-p
-
-			(values
-			 (flet ((merge-and-inf (shapes symbols)
-				  (map 'list #'(lambda (s name position)
-						 (or (when (or (not (symbolp s)) ;; S = 1 2 3...?
-							       (find s ,known-symbols :test #'symbol-eq))
-						       s)
-						     ,(if allow-symbol ;; allow-symbols=t -> returns known symbol
-							  ~
-							  `(make-shape-mismatch-error
-							    :position position
-							    :excepted nil
-							    :butgot   name))))
-				       shapes symbols (range 0 (length symbols)))))
-			   (list ,@(map 'list #'(lambda (state) `(flatten (merge-and-inf (list ,@state) ',state))) out-state)))
-			 (reverse ,detected-errors)
-			 ,rank-error-p
-			 (list ,@(map 'list #'(lambda (arg)
-						`(flatten (list ,@arg)))
-				      first-state)))))))
-
-	(when macroexpand
-	  (print body))
-
-	(values (if return-body
-		    body
-		    (compile nil body))
-		(map 'list
-		     #'(lambda (sym)
-			 (position sym (the list input-names) :test #'symbol-eq))
-		     output-names)
-		(map 'list
-		     #'(lambda (s)
-			 ;; The first rank is broadcastable?
-			 (symbol-eq (car s) '~))
-		     first-state)
-		(list first-state out-state))))))
 
 

--- a/source/vm/nodes/utils.lisp
+++ b/source/vm/nodes/utils.lisp
@@ -203,6 +203,8 @@ Return:
 			       s))))
     (map 'list #'apply-refine shapes)))
 
+;; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 (defnode (System-Lazy-Cons (self a b)
 	  :where (A[a-size] B[b-size] -> A[a-size] B[a-size] where a-size = (shape a) b-size = (shape b)))
   (setf (ignore-shape-error self) t))
@@ -215,3 +217,6 @@ Return:
 (defun !system-lazy-values (&rest args)
   (reduce #'!system-lazy-cons args))
 
+;; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+(defun range (start end) (loop for i upfrom start below end collect i))

--- a/source/vm/nodes/utils.lisp
+++ b/source/vm/nodes/utils.lisp
@@ -220,3 +220,50 @@ Return:
 ;; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 (defun range (start end) (loop for i upfrom start below end collect i))
+
+
+(defmacro define-and-impl-node ((abstract-name
+				 (self &rest constructor-arguments)
+				 &key
+				   (device t)
+				   (cache-when-compiled t)
+				   (reject-p nil)
+				   (where t)
+				   (out-scalar-p nil)
+				   (slots nil)
+				   (save-for-backward nil)
+				   (forward nil)
+				   (backward nil)
+				   (documentation ""))
+				&body constructor-body)
+  "
+```lisp
+(define-and-impl-node (abstract-name
+				 (self &rest constructor-arguments)
+				 &key
+				   (device t)
+				   (cache-when-compiled t)
+				   (reject-p nil)
+				   (where t)
+				   (out-scalar-p nil)
+				   (slots nil)
+				   (save-for-backward nil)
+				   (forward nil)
+				   (backward nil)
+				   (documentation \"\")))
+```
+
+Expands `defnode` and `define-impl` at the same time.
+"
+  `(eval-when (:compile-toplevel :load-toplevel :execute)
+     (defnode (,abstract-name (,self ,@constructor-arguments)
+	       :where ,where
+	       :out-scalar-p ,out-scalar-p
+	       :slots ,slots
+	       :save-for-backward ,save-for-backward
+	       :backward ,backward
+	       :documentation ,documentation)
+       ,@constructor-body)
+     (define-impl (,abstract-name :device ,device :cache-when-compiled ,cache-when-compiled :reject-p ,reject-p)
+		  :save-for-backward ,save-for-backward
+		  :forward ,forward)))


### PR DESCRIPTION
### Changes

- Eliminate a ton of style-warning
- Improved the quality of shape-error
- Composites with :where decl is now able to inspect the shapes
- `defmodel-as` where form requires names