### PR TITLE
[Optim] Turn on In-place mutation everywhere

### DIFF
--- a/source/optimizers/defoptimizer.lisp
+++ b/source/optimizers/defoptimizer.lisp
@@ -6,11 +6,18 @@
   (:documentation "
 ## [class] AbstractOptimizer
 
-`AbstractOptimizer` is an Abstract class of all optimizing functions in cl-waffe2.
+AbstractTensors with `:requires-grad=t` can find their gradients with the `(backward (build toplevel))` function. `AbstractOptimizer` is a class which minimizes the value of `toplevel` subject to `(grad tensor)`. In cl-waffe2, we initialize one `AbstractOptimizer` for one `AbstractTensor`. Specifically, one is able to create a new AbstractOptimizer with the function `(name tensor &rest constructor-args)`, for example, `(adam (parameter (randn `(3 3))) :lr 1e-3)` to create a new Adam Optimizer, and can be tied to the tensor like: `(hook-optimizer! tensor abstract-optimizer)`. Users can define any optimizer algorithms with the `defoptimizer` macro. Optimizing tied tensors is performed by calling a `(step-optimize optimizer)` method. The parameter to be optimized can be accessed by a `read-parameter` method.
 
-The optimizing operation is performed by calling a `(step-optimize optimizer)` method. The parameter to be optimized can be accessed by a `read-parameter` method. The new optimizer function can be defined via `defoptimizer` macro.
+### Example: Hooks and calls the optimizer tied to the tensor.
 
-See also: `defoptimizer` `read-parameter` `step-optimize`"))
+```lisp
+(let ((a (parameter (randn `(3 3)))))
+    (hook-optimizer! a (Adam a))
+    (call-optimizer! a))
+```
+
+See also: `defoptimizer` `read-parameter` `step-optimize`.
+"))
 
 (defgeneric step-optimize (optimizer))
 
@@ -24,9 +31,7 @@ See also: `defoptimizer` `read-parameter` `step-optimize`"))
   "
 ## [macro] defoptimizer
 
-The macro `defoptimizer` defines a user-defined optimizer class which is a subclass of `AbstractOptimizer`
-
-The class is dispatched one per parameter to be optimized and the method `step-optimize` is called each time an optimizing is performed.
+The macro `defoptimizer` defines a user-defined optimizer class which is a subclass of `AbstractOptimizer`. And the class is dispatched one per parameter to be optimized and the method `step-optimize` is called each time an optimizing is performed.
 
 ### Input
 
@@ -45,7 +50,7 @@ The class is dispatched one per parameter to be optimized and the method `step-o
 		       (declare (ignore self))
 		       (A-=B param (!mul lr grad)))))
 
-(define-composite-function (SGD-Compute-Form) step-sgd)
+(defmodel-as (SGD-Compute-Form) :named step-sgd)
 
 (defmethod step-optimize ((optimizer SGD))
   (let* ((lr    (make-tensor (sgd-lr optimizer)))
@@ -97,4 +102,13 @@ The class is dispatched one per parameter to be optimized and the method `step-o
 					       collect (car slot)))))
 	   ,@constructor-body
 	   ,self)))))
+
+(defmethod print-object ((opt AbstractOptimizer) stream)
+  (format stream "<AbstractOptimizer: ~a(
+    minimize   : toplevel
+    subject to : <~a>~a
+)>"
+	  (class-name (class-of opt))
+	  (tensor-id (read-parameter opt))
+	  (cl-waffe2/vm.nodes::describe-tensor (read-parameter opt))))
 

--- a/source/optimizers/defoptimizer.lisp
+++ b/source/optimizers/defoptimizer.lisp
@@ -6,7 +6,7 @@
   (:documentation "
 ## [class] AbstractOptimizer
 
-AbstractTensors with `:requires-grad=t` can find their gradients with the `(backward (build toplevel))` function. `AbstractOptimizer` is a class which minimizes the value of `toplevel` subject to `(grad tensor)`. In cl-waffe2, we initialize one `AbstractOptimizer` for one `AbstractTensor`. Specifically, one is able to create a new AbstractOptimizer with the function `(name tensor &rest constructor-args)`, for example, `(adam (parameter (randn `(3 3))) :lr 1e-3)` to create a new Adam Optimizer, and can be tied to the tensor like: `(hook-optimizer! tensor abstract-optimizer)`. Users can define any optimizer algorithms with the `defoptimizer` macro. Optimizing tied tensors is performed by calling a `(step-optimize optimizer)` method. The parameter to be optimized can be accessed by a `read-parameter` method.
+AbstractTensors with `:requires-grad=t` can find their gradients with the `(backward (build toplevel))` function. AbstractOptimizer is a class which minimizes the value of `toplevel` subject to `(grad tensor)`. In cl-waffe2, we initialize one AbstractOptimizer for one AbstractTensor. Specifically, one is able to create a new AbstractOptimizer with the function `(name tensor &rest constructor-args)`, for example, `(adam (parameter (randn `(3 3))) :lr 1e-3)` to create a new Adam Optimizer, and can be tied to the tensor like: `(hook-optimizer! tensor abstract-optimizer)`. Users can define any optimizer algorithms with the `defoptimizer` macro. Optimizing tied tensors is performed by calling a `(step-optimize optimizer)` method. The parameter to be optimized can be accessed by a `read-parameter` method.
 
 ### Example: Hooks and calls the optimizer tied to the tensor.
 

--- a/source/optimizers/impls/adam.lisp
+++ b/source/optimizers/impls/adam.lisp
@@ -108,34 +108,3 @@ See the [original paper](https://arxiv.org/abs/1412.6980) for detailed algorithm
        (make-tensor lr-t) ;; Runtime creation of ScalarTensor ... takes a little overhead (approx: 0.00013 sec * N_parameters)
        (make-tensor (eps-of optimizer))))))
 
-#|
-[TODO] Include this to the tests.
-
-(adam-test 1)
-(adam-test 2)
-(adam-test 3)
-(adam-test 4)
- ...
-(defun adam-test (N)
-  (let ((m (cl-waffe2/distributions:ax+b `(,n ,n) 0 0.00))
-	(v (cl-waffe2/distributions:ax+b `(,n ,n) 0 0.00))
-	(p (cl-waffe2/distributions:ax+b `(,n ,n) 0 0.0001))
-	(grad (cl-waffe2/distributions:ax+b `(,n ,n) 0 0.01))
-	(lr (make-tensor 0.01))
-	(beta1 (make-tensor 0.99))
-	(beta2 (make-tensor 0.9))
-	(eps (make-tensor 0.0001)))
-    (with-no-grad
-      (dotimes (i 1)
-	(apply-adam-step-m m grad beta1)
-	;;(print m)	      
-	(apply-adam-step-v v grad beta2)
-	;;(print v)  
-	
-	(apply-adam-step-param
-	 m v p lr eps)
-	)
-      p)))
-
-|#
-

--- a/source/vm/compile.lisp
+++ b/source/vm/compile.lisp
@@ -197,13 +197,8 @@ Tips: `disassemble-waffe2-ir` to display compiled Instruction Sequence.
       ;; Set grad-count=0 if any
       (map 'list #'(lambda (tensor) (setf (tensor-grad-count tensor) 0)) leaves)
 
-      ;; [FixME] In the training mode, apply-in-place-mutation! will produce the destruction of gradients...
-      ;; Analyze and pursuit for the reason and update the algorithm.
+      (apply-in-place-mutation! iseq-forward leaves)
 
-      (when (or (null (ancestor-param-p toplevel))
-		*no-grad*
-		(not need-backward))
-	(apply-in-place-mutation! iseq-forward leaves))
 
       (let* ((out-symbol-p (some #'symbolp (shape toplevel)))
 	     (dout (when need-backward

--- a/source/vm/nodes/model-compiler.lisp
+++ b/source/vm/nodes/model-compiler.lisp
@@ -317,7 +317,7 @@ Redefines a Composite as a new function or AbstractNode specified in the `:asif`
 ─────────────────────────────────────────────────────────────────────────────────────
 :function | Defines a function to be executed immediately that does not create a node.
 ─────────────────────────────────────────────────────────────────────────────────────
-:node     | Defines a AbstractNode which needs to be compiler later
+:node     | Defines a AbstractNode which needs to be compiled later
 ─────────────────────────────────────────────────────────────────────────────────────
 ```
 
@@ -342,7 +342,7 @@ Choose :asif option from:
 ─────────────────────────────────────────────────────────────────────────────────────
 :function | Defines a function to be executed immediately that does not create a node.
 ─────────────────────────────────────────────────────────────────────────────────────
-:node     | Defines a AbstractNode which needs to be compiler later
+:node     | Defines a AbstractNode which needs to be compiled later
 ─────────────────────────────────────────────────────────────────────────────────────
 "
 	   asif))


### PR DESCRIPTION
The problem where in-place mutation with training mode will produce the wrong result, was related to how the `MoveTensorNode` was cached when building. Now it is fixed and in-place mutation works everywhere.