### PR TITLE
[Refactor] Memory-Pool and Locality Optimization

### DIFF
--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -58,6 +58,7 @@
 	       (:file "base-impl/package")
 
 	       (:file "vm/package")
+	       (:file "vm/allocation")
 	       
 	       (:file "vm/generic-tensor/cache")
 	       (:file "vm/generic-tensor/utils")
@@ -95,14 +96,13 @@
 	       (:file "base-impl/ir")
 	       (:file "base-impl/reshapers")
 	       (:file "base-impl/unfold")
-
 	       
 	       (:file "vm/ir")
 	       (:file "vm/utils")
 	       (:file "vm/vm")
 	       (:file "vm/optimize-ir")
 	       (:file "vm/compile")
-	       (:file "vm/allocation")
+	       
 
 	       (:file "backends/lisp/package")
 	       (:file "backends/lisp/tensor")

--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -68,7 +68,7 @@
 	       
 	       (:file "optimizers/package")
 	       
-	       (:file "vm/generic-tensor/acceptor")
+	       (:file "vm/generic-tensor/acceptor" :depends-on ("vm/allocation"))
 	       (:file "vm/generic-tensor/tensor")
 	       (:file "vm/generic-tensor/lut")
 	       

--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -101,7 +101,8 @@
 	       (:file "vm/utils")
 	       (:file "vm/vm")
 	       (:file "vm/optimize-ir")
-	       (:file "vm/compile")	       
+	       (:file "vm/compile")
+	       (:file "vm/allocation")
 
 	       (:file "backends/lisp/package")
 	       (:file "backends/lisp/tensor")

--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -38,7 +38,6 @@
 	       :lparallel
 	       :bordeaux-threads
 	       :closer-mop
-	       :optima
 	       :trivial-garbage
 	       :cl-waffe2/simd-extension)
   ;; TODO: Use components and split dependencies.

--- a/source/backends/cpu/arithmetic.lisp
+++ b/source/backends/cpu/arithmetic.lisp
@@ -179,7 +179,7 @@
 			     (scal  (gensym "SCAL")))
 			 `(with-tensor-ptrs ((,x-ptr ,x))
 			    (locally (declare (optimize (speed 1)))
-			      (let ((,scal (tensor-vec ,scalar)))
+			      (let ((,scal (coerce (tensor-vec ,scalar) (dtype->lisp-type ,(dtype x)))))
 				,(expand-arithmetic-scalar-form x x-ptr scal :fname "add")
 				,x))))))
 
@@ -190,7 +190,7 @@
 			     (scal  (gensym "SCAL")))
 			 `(with-tensor-ptrs ((,x-ptr ,x))
 			    (locally (declare (optimize (speed 1)))
-			      (let ((,scal (tensor-vec ,scalar)))
+			      (let ((,scal (coerce (tensor-vec ,scalar) (dtype->lisp-type ,(dtype x)))))
 				,(expand-arithmetic-scalar-form x x-ptr scal :fname "sub")
 				,x))))))
 
@@ -201,7 +201,7 @@
 			     (scal  (gensym "SCAL")))
 			 `(with-tensor-ptrs ((,x-ptr ,x))
 			    (locally (declare (optimize (speed 1)))
-			      (let ((,scal (tensor-vec ,scalar)))
+			      (let ((,scal (coerce (tensor-vec ,scalar) (dtype->lisp-type ,(dtype x)))))
 				,(expand-arithmetic-scalar-form x x-ptr scal :fname "mul")
 				,x))))))
 
@@ -212,7 +212,7 @@
 			     (scal  (gensym "SCAL")))
 			 `(with-tensor-ptrs ((,x-ptr ,x))
 			    (locally (declare (optimize (speed 1)))
-			      (let ((,scal (tensor-vec ,scalar)))
+			      (let ((,scal (coerce (tensor-vec ,scalar) (dtype->lisp-type ,(dtype x)))))
 				,(expand-arithmetic-scalar-form x x-ptr scal :fname "div")
 				,x))))))
 

--- a/source/base-impl/arithmetic.lisp
+++ b/source/base-impl/arithmetic.lisp
@@ -75,13 +75,13 @@ X\\gets{X ~a Y}
      (values
       (!div dout dy)
       (!div (!mul dx (!mul -1 dout))
-	    (!square dy))))))
+	    (!mul dy dy))))))
 
 (defnode (InverseTensorNode (myself dtype)
 	  :where (A[~] -> A[~])
 	  :save-for-backward (t)
 	  :backward ((self dout dx)
-		     (values (!div (!mul -1 dout) (!square dx))))
+		     (values (!div (!mul -1 dout) (!mul dx dx))))
 	  :documentation "InverseTensorNode is a node which computes following operation element-wise
 
 ```math
@@ -171,7 +171,7 @@ X\\gets{X ~a scalar}
      ;; out = 1/dx * dy
      (values
       (!div dout dy)
-      (->scal (!mean (!div (!mul dx (!mul -1 dout)) (!square dy))))))))
+      (->scal (!mean (!div (!mul dx (!mul -1 dout)) (!mul dy dy))))))))
 
 ;; ===============================================================
 ;; Defun Parts
@@ -340,7 +340,7 @@ The function ~a computes following operation with calling `~a`, returning a new 
      (values (!sas-div dout dy)
 	     (!sas-div
 	      (!sas-mul dx (!sas-mul -1 dout))
-	      (!square dy))))))
+	      (!mul dy dy))))))
 
 (define-impl (ScalarAndScalarAdd :device ScalarTensor)
 	     :forward ((self x y)

--- a/source/base-impl/fundamental.lisp
+++ b/source/base-impl/fundamental.lisp
@@ -197,7 +197,6 @@ This function is also used to adjust memory alignment of tensor."
 (define-impl (ViewTensorNode)
 	     :forward
 	     ((self viewed-tensor old)
-	      (setf (tensor-id viewed-tensor) (tensor-id old))
 	      `(progn
 		 (setf (tensor-vec ,viewed-tensor) (tensor-vec ,old))
 		 ,viewed-tensor))
@@ -213,7 +212,6 @@ This function is also used to adjust memory alignment of tensor."
 		     (inp-sub (slot-value self 'subscripts))
 		     (res (!move dx (apply #'!view dout inp-sub))))		
 		(values nil (->contiguous (apply #'!view res out-sub))))))
-
 
 (defun !view (tensor &rest subscripts)
   "

--- a/source/base-impl/fundamental.lisp
+++ b/source/base-impl/fundamental.lisp
@@ -698,23 +698,25 @@ CL-WAFFE2-REPL> (proceed-bench (!sum (randn `(3 3))))
   (multiple-value-bind (fw-iseq bw-iseq leaves dout allocation)
       (cl-waffe2/vm:compile-forward-and-backward tensor :compile-mode compile-mode :fuse-p fuse-p)
     (declare (ignore leaves dout))
-    (cl-waffe2/vm::with-static-allocation (allocation)
-      (let ((result))
-	(setq result
-	      (cl-waffe2/vm:benchmark-accept-instructions fw-iseq
+    (let ((cl-waffe2/vm.generic-tensor::*runtime-mode-p* t))
+      (cl-waffe2/vm.generic-tensor::with-adjustable-symbol-scope
+	(cl-waffe2/vm::with-static-allocation (allocation)
+	  (let ((result))
+	    (setq result
+		  (cl-waffe2/vm:benchmark-accept-instructions fw-iseq
+							      :n-sample n-sample
+							      :ignore-first-call ignore-first-call
+							      :stream stream
+							      :top-k top-k))
+
+	    (when backward
+	      (format stream "[Benchmarking backward] ... ~%")
+	      (cl-waffe2/vm:benchmark-accept-instructions bw-iseq
 							  :n-sample n-sample
 							  :ignore-first-call ignore-first-call
 							  :stream stream
 							  :top-k top-k))
-
-	(when backward
-	  (format stream "[Benchmarking backward] ... ~%")
-	  (cl-waffe2/vm:benchmark-accept-instructions bw-iseq
-						      :n-sample n-sample
-						      :ignore-first-call ignore-first-call
-						      :stream stream
-						      :top-k top-k))
-	result))))
+	    result))))))
 
 ;; ===============================================================
 ;; Broadcast APIs

--- a/source/base-impl/fundamental.lisp
+++ b/source/base-impl/fundamental.lisp
@@ -197,6 +197,7 @@ This function is also used to adjust memory alignment of tensor."
 (define-impl (ViewTensorNode)
 	     :forward
 	     ((self viewed-tensor old)
+	      (setf (tensor-id viewed-tensor) (tensor-id old))
 	      `(progn
 		 (setf (tensor-vec ,viewed-tensor) (tensor-vec ,old))
 		 ,viewed-tensor))

--- a/source/base-impl/fundamental.lisp
+++ b/source/base-impl/fundamental.lisp
@@ -695,26 +695,27 @@ CL-WAFFE2-REPL> (proceed-bench (!sum (randn `(3 3))))
 ```
 "
 
-  (multiple-value-bind (fw-iseq bw-iseq leaves)
+  (multiple-value-bind (fw-iseq bw-iseq leaves dout allocation)
       (cl-waffe2/vm:compile-forward-and-backward tensor :compile-mode compile-mode :fuse-p fuse-p)
-    (declare (ignore leaves))
-    (let ((result))
+    (declare (ignore leaves dout))
+    (cl-waffe2/vm::with-static-allocation (allocation)
+      (let ((result))
 
-      (setq result
-	    (cl-waffe2/vm:benchmark-accept-instructions fw-iseq
-							:n-sample n-sample
-							:ignore-first-call ignore-first-call
-							:stream stream
-							:top-k top-k))
+	(setq result
+	      (cl-waffe2/vm:benchmark-accept-instructions fw-iseq
+							  :n-sample n-sample
+							  :ignore-first-call ignore-first-call
+							  :stream stream
+							  :top-k top-k))
 
-      (when backward
-	(format stream "[Benchmarking backward] ... ~%")
-	(cl-waffe2/vm:benchmark-accept-instructions bw-iseq
-						    :n-sample n-sample
-						    :ignore-first-call ignore-first-call
-						    :stream stream
-						    :top-k top-k))
-      result)))
+	(when backward
+	  (format stream "[Benchmarking backward] ... ~%")
+	  (cl-waffe2/vm:benchmark-accept-instructions bw-iseq
+						      :n-sample n-sample
+						      :ignore-first-call ignore-first-call
+						      :stream stream
+						      :top-k top-k))
+	result))))
 
 ;; ===============================================================
 ;; Broadcast APIs

--- a/source/base-impl/fundamental.lisp
+++ b/source/base-impl/fundamental.lisp
@@ -532,35 +532,39 @@ The function ->mat receives `ScalarTensor`, returning a matrix with the number o
 
 ;; We can also add: Proceed-Auto
 
-(defnode (ProceedNode (myself &key (measure-time nil) (compile-mode :default))
+(defnode (ProceedNode (myself toplevel &key (measure-time nil) (compile-mode :default))
 	  :where (A[~] -> A[~])
 	  :slots ((measure-time   :initarg :measure-time :reader measure-time-p)
 		  (compiled-model :initform nil :accessor proceed-compiled-model)
 		  (compile-mode   :initarg :compile-mode :reader compile-mode)
 		  (result         :accessor proceed-result))
-	  :documentation "ProceedNode is a special node which takes all the previous computation node before tensor."))
+	  :documentation "ProceedNode is a special node which takes all the previous computation node before tensor.")
+
+  (let ((compiled-model (if measure-time
+			    (progn
+			      (format t "[proceed-time] build ->~%")
+			      (time (build toplevel :compile-mode compile-mode)))
+			    (build toplevel :compile-mode compile-mode))))
+    ;; Detaching the tensor
+    (setf (detach-p toplevel) T
+	  (proceed-compiled-model myself) compiled-model)))
+		
 
 (define-impl (ProceedNode :device t)
 	     :save-for-backward (nil)
 	     :forward ((self x)
-		       (let ((compiled-model (or
-					      (proceed-compiled-model self)
-					      (build x :compile-mode (compile-mode self)))))
-			 ;; Compiled-Composite
-			 (setf (proceed-compiled-model self) compiled-model)
-			 
+		       (let ((compiled-model (proceed-compiled-model self)))			 
 			 (if (measure-time-p self)
 			     (progn
-			       ;; TODO
-			       ;; Display Both: First-Time-Call/Second-Time-Call
-			       (format t "Proceed-Time: With allocation time:~%")
+			       (format t "[proceed-time] With allocation time:~%")
 			       (time (forward compiled-model))
-			       (format t "Proceed-Time: Without allocation time:~%")
+			       (format t "[proceed-time] Without allocation time:~%")
 			       (setf (proceed-result self) (time (forward compiled-model))))
 			     (setf (proceed-result self) (forward compiled-model)))
+			 
 			 ;; Tell cl-waffe2 VM the returned value's type
 			 (setf (out-scalar-p self) (scalar-p (proceed-result self)))
-
+			 
 			 ;; The result is returned.
 			 `(progn
 			    ;; Tell top compiling funtion what composite to use for the compiled-function			    
@@ -573,7 +577,7 @@ The function ->mat receives `ScalarTensor`, returning a matrix with the number o
 			     `(and
 			       ,(if (measure-time-p self)
 				    `(progn
-				       (format t "Proceed-Time: Backward Time")
+				       (format t "[proceed-time] Reverse Mode~%")
 				       (time (backward ,compiled-model)))
 				    `(backward ,compiled-model))
 			       ;; Delete Gradients.
@@ -601,14 +605,10 @@ If `measure-time`=t, ProceedNode wraps with time macro when calling **COMPILED**
 
 `compile-mode` is a keyword, type of `compile-mode-t`.
 "
-  (let* ((node (ProceedNode :measure-time measure-time :compile-mode compile-mode))
+  (let* ((node (ProceedNode tensor :measure-time measure-time :compile-mode compile-mode))
 	 ;; Previous Node is already compiled, so detach tensor from nodes.
 	 (out  (forward node tensor)))
     
-    ;; Cut off previous backwards
-    (setf (tensor-backward tensor) nil)
-    (setf (cl-waffe2/vm.generic-tensor::detach-p tensor) t)
-
     ;; Out is still unallocated, so set the result.
     (if (scalar-p out)
 	(setf (tensor-vec out) (tensor-vec (proceed-result node)))
@@ -700,7 +700,6 @@ CL-WAFFE2-REPL> (proceed-bench (!sum (randn `(3 3))))
     (declare (ignore leaves dout))
     (cl-waffe2/vm::with-static-allocation (allocation)
       (let ((result))
-
 	(setq result
 	      (cl-waffe2/vm:benchmark-accept-instructions fw-iseq
 							  :n-sample n-sample

--- a/source/base-impl/t/apis.lisp
+++ b/source/base-impl/t/apis.lisp
@@ -192,6 +192,14 @@
   (is (proceed-continue-test 1)) ;; 
   (is (proceed-continue-test 2)))
 
+(test proceed-composed-test
+  (is (<
+       (abs
+	(-
+	 (tensor-vec (Proceed (->scal (!Sum (Proceed (cl-waffe2/nn::!Softmax (randn `(3 3))))))))
+	 3.0))
+       0.000001)))
+
 
 (test reshape-permute-test
   (is (equal `(5 1 5) (shape (proceed (!t (!reshape (ax+b `(5 5) 1 0) 5 5 1))))))

--- a/source/base-impl/t/package.lisp
+++ b/source/base-impl/t/package.lisp
@@ -41,7 +41,7 @@
 	  ,@(map 'list #'(lambda (dtype)
 			   `(test ,(symb ', name '- dtype '- (car backend))
 			      (is (with-dtype ,dtype
-				    (with-memory-pool
+				    (progn;with-memory-pool
 				      (let ((result (progn ,,@body)))
 					(if (eql result t)
 					    t

--- a/source/distributions/weights.lisp
+++ b/source/distributions/weights.lisp
@@ -10,7 +10,7 @@
 					    initializer-lambda
 					    document
 					    &key (keep-order? nil))
-  `(progn
+  `(eval-when (:compile-toplevel :load-toplevel :execute)
      (export ',function-name)
      (define-tensor-initializer ,function-name (,@args) ,initializer-lambda ,document :keep-order? ,keep-order?)))
   

--- a/source/nn/criterion.lisp
+++ b/source/nn/criterion.lisp
@@ -107,7 +107,7 @@ In addition, reading the value of a `:reduction` keyword (one of `:mean` `:sum` 
 			  dout
 			  x
 			  labels
-			  (make-tensor (car (last (shape x) 2)) :dtype (dtype x)))))))
+			  (make-tensor (car (last (shape x) 2)) :dtype (dtype x) :order (order x)))))))
 
 
 (defun cross-entropy-loss (x labels &key (delta 1e-7) (reduction :mean))

--- a/source/nn/t/conv.lisp
+++ b/source/nn/t/conv.lisp
@@ -103,7 +103,11 @@
 
 (test 2d-pool-test
   (is (2d-pool-test nil))
-  (is (2d-pool-test t)))
+  (is (2d-pool-test t))
+
+  ;; Do they work even when cached?
+  (is (2d-pool-test t))
+  (is (2d-pool-test nil)))
 
 ;; Add: CNN/MLP Train tests
 

--- a/source/nn/t/conv.lisp
+++ b/source/nn/t/conv.lisp
@@ -95,7 +95,6 @@
 	      (setq f (and f
 			   (let ((grad-n (count-if #'non-zerop (tensor-vec window)))
 				 (grad-item (find-if #'non-zerop (tensor-vec window))))
-			     ;; randnで奇跡的に衝突する確率=0で計算??
 			     (and
 			      (= grad-n 16)
 			      (= grad-item 0.020833334)))))))))

--- a/source/nn/t/regression.lisp
+++ b/source/nn/t/regression.lisp
@@ -408,3 +408,59 @@
   )
 
 
+;; Gradients are decayed well?
+
+
+(defsequence Simple-MLP (in-features hidden-dim)
+	     (LinearLayer in-features hidden-dim t)
+	     (asnode #'!sigmoid)
+	     (LinearLayer hidden-dim 1 t))
+
+;; Naming:... set-input VS set-inputs
+;; allow: (forward self)
+;; make trainer forwardable
+
+(deftrainer (MLPTrainer (self in-features hidden-dim &key (lr 1e-1))
+	     :model (Simple-MLP in-features hidden-dim)
+	     :optimizer (cl-waffe2/optimizers:SGD :lr lr)
+	     :compile-mode :fastest
+	     :build ((self)
+		     (MSE
+		      (make-input `(batch-size 1) :TrainY)
+		      (call (model self) (make-input `(batch-size ,in-features) :TrainX))))
+	     
+	     :set-inputs ((self x y)
+			  (set-input (compiled-model self) :TrainX x)
+			  (set-input (compiled-model self) :TrainY y))
+	     :minimize! ((self)
+			 (zero-grads! (compiled-model self))
+			 (let ((loss (forward (compiled-model self))))
+			   (backward  (compiled-model self))
+			   (optimize! (compiled-model self))
+			   (vref loss 0)))			 
+	     :predict ((self x)
+		       (call (model self) x))))
+
+
+(defun grad-decay-test (&key
+			  (batch-size 100)
+			  (iter-num 3000))
+  (let* ((X (proceed (!sin (ax+b `(,batch-size 100) 0.01 0.1))))
+ 	 (Y (proceed (!cos (ax+b `(,batch-size 1)   0.01 0.1))))
+	 (trainer (MLPTrainer 100 10 :lr 1e-3))
+	 (first)
+	 (end))
+    
+    (set-inputs trainer X Y)
+    (loop for nth-epoch fixnum upfrom 0 below iter-num
+	  do (let ((out (minimize! trainer)))
+	       (if (null first) (setq first out))
+	       (setq end out)))
+    (> first end)))
+
+(test grad-decay-test
+  (is (grad-decay-test)))
+
+(test grad-decay-cached-test
+  (is (grad-decay-test)))
+

--- a/source/nn/t/regression.lisp
+++ b/source/nn/t/regression.lisp
@@ -275,6 +275,8 @@
       (every #'not-zero-p params))))
 
 (test linearlayer-backward-with-criterlion
+  (is (linearlayer-backward-test-with-criterion))
+  ;; Is the cached function, works well?
   (is (linearlayer-backward-test-with-criterion)))
 	     
 
@@ -389,7 +391,7 @@
 
     (with-model-parameters (param model)
       (loop for p in param
-	    do (print (grad p))))
+	    do (grad p)))
 
     ;; Segfault here.
     (forward model)
@@ -397,13 +399,12 @@
 
     (with-model-parameters (param model)
       (loop for p in param
-	    do (print (grad p))))
-    
-    ))
+	    do  (grad p)))
+    T))
 
 (test multiple-time-call-of-compiled-model
   (is (fw-and-bw-test))
-  ;(is (fw-and-bw-test-criterion))
+  (is (fw-and-bw-test-criterion))
   )
 
 

--- a/source/nn/t/regression.lisp
+++ b/source/nn/t/regression.lisp
@@ -236,7 +236,7 @@
 ;; Only using pure features in cl-waffe2
 ;; OK
 (defun linearlayer-backward-test ()
-  (with-memory-pool
+  (progn;with-memory-pool
     (let* ((model (LinearLayer-Sequence 100 50 10))
 	   (model (build (call model (uniform-random `(10 100) -0.01 0.01))
 			 :compile-mode :default)))

--- a/source/optimizers/defoptimizer.lisp
+++ b/source/optimizers/defoptimizer.lisp
@@ -6,11 +6,18 @@
   (:documentation "
 ## [class] AbstractOptimizer
 
-`AbstractOptimizer` is an Abstract class of all optimizing functions in cl-waffe2.
+AbstractTensors with `:requires-grad=t` can find their gradients with the `(backward (build toplevel))` function. `AbstractOptimizer` is a class which minimizes the value of `toplevel` subject to `(grad tensor)`. In cl-waffe2, we initialize one `AbstractOptimizer` for one `AbstractTensor`. Specifically, one is able to create a new AbstractOptimizer with the function `(name tensor &rest constructor-args)`, for example, `(adam (parameter (randn `(3 3))) :lr 1e-3)` to create a new Adam Optimizer, and can be tied to the tensor like: `(hook-optimizer! tensor abstract-optimizer)`. Users can define any optimizer algorithms with the `defoptimizer` macro. Optimizing tied tensors is performed by calling a `(step-optimize optimizer)` method. The parameter to be optimized can be accessed by a `read-parameter` method.
 
-The optimizing operation is performed by calling a `(step-optimize optimizer)` method. The parameter to be optimized can be accessed by a `read-parameter` method. The new optimizer function can be defined via `defoptimizer` macro.
+### Example: Hooks and calls the optimizer tied to the tensor.
 
-See also: `defoptimizer` `read-parameter` `step-optimize`"))
+```lisp
+(let ((a (parameter (randn `(3 3)))))
+    (hook-optimizer! a (Adam a))
+    (call-optimizer! a))
+```
+
+See also: `defoptimizer` `read-parameter` `step-optimize`.
+"))
 
 (defgeneric step-optimize (optimizer))
 
@@ -24,9 +31,7 @@ See also: `defoptimizer` `read-parameter` `step-optimize`"))
   "
 ## [macro] defoptimizer
 
-The macro `defoptimizer` defines a user-defined optimizer class which is a subclass of `AbstractOptimizer`
-
-The class is dispatched one per parameter to be optimized and the method `step-optimize` is called each time an optimizing is performed.
+The macro `defoptimizer` defines a user-defined optimizer class which is a subclass of `AbstractOptimizer`. And the class is dispatched one per parameter to be optimized and the method `step-optimize` is called each time an optimizing is performed.
 
 ### Input
 
@@ -45,7 +50,7 @@ The class is dispatched one per parameter to be optimized and the method `step-o
 		       (declare (ignore self))
 		       (A-=B param (!mul lr grad)))))
 
-(define-composite-function (SGD-Compute-Form) step-sgd)
+(defmodel-as (SGD-Compute-Form) :named step-sgd)
 
 (defmethod step-optimize ((optimizer SGD))
   (let* ((lr    (make-tensor (sgd-lr optimizer)))
@@ -97,4 +102,13 @@ The class is dispatched one per parameter to be optimized and the method `step-o
 					       collect (car slot)))))
 	   ,@constructor-body
 	   ,self)))))
+
+(defmethod print-object ((opt AbstractOptimizer) stream)
+  (format stream "<AbstractOptimizer: ~a(
+    minimize   : toplevel
+    subject to : <~a>~a
+)>"
+	  (class-name (class-of opt))
+	  (tensor-id (read-parameter opt))
+	  (cl-waffe2/vm.nodes::describe-tensor (read-parameter opt))))
 

--- a/source/optimizers/defoptimizer.lisp
+++ b/source/optimizers/defoptimizer.lisp
@@ -6,7 +6,7 @@
   (:documentation "
 ## [class] AbstractOptimizer
 
-AbstractTensors with `:requires-grad=t` can find their gradients with the `(backward (build toplevel))` function. `AbstractOptimizer` is a class which minimizes the value of `toplevel` subject to `(grad tensor)`. In cl-waffe2, we initialize one `AbstractOptimizer` for one `AbstractTensor`. Specifically, one is able to create a new AbstractOptimizer with the function `(name tensor &rest constructor-args)`, for example, `(adam (parameter (randn `(3 3))) :lr 1e-3)` to create a new Adam Optimizer, and can be tied to the tensor like: `(hook-optimizer! tensor abstract-optimizer)`. Users can define any optimizer algorithms with the `defoptimizer` macro. Optimizing tied tensors is performed by calling a `(step-optimize optimizer)` method. The parameter to be optimized can be accessed by a `read-parameter` method.
+AbstractTensors with `:requires-grad=t` can find their gradients with the `(backward (build toplevel))` function. AbstractOptimizer is a class which minimizes the value of `toplevel` subject to `(grad tensor)`. In cl-waffe2, we initialize one AbstractOptimizer for one AbstractTensor. Specifically, one is able to create a new AbstractOptimizer with the function `(name tensor &rest constructor-args)`, for example, `(adam (parameter (randn `(3 3))) :lr 1e-3)` to create a new Adam Optimizer, and can be tied to the tensor like: `(hook-optimizer! tensor abstract-optimizer)`. Users can define any optimizer algorithms with the `defoptimizer` macro. Optimizing tied tensors is performed by calling a `(step-optimize optimizer)` method. The parameter to be optimized can be accessed by a `read-parameter` method.
 
 ### Example: Hooks and calls the optimizer tied to the tensor.
 

--- a/source/optimizers/impls/adam.lisp
+++ b/source/optimizers/impls/adam.lisp
@@ -108,34 +108,3 @@ See the [original paper](https://arxiv.org/abs/1412.6980) for detailed algorithm
        (make-tensor lr-t) ;; Runtime creation of ScalarTensor ... takes a little overhead (approx: 0.00013 sec * N_parameters)
        (make-tensor (eps-of optimizer))))))
 
-#|
-[TODO] Include this to the tests.
-
-(adam-test 1)
-(adam-test 2)
-(adam-test 3)
-(adam-test 4)
- ...
-(defun adam-test (N)
-  (let ((m (cl-waffe2/distributions:ax+b `(,n ,n) 0 0.00))
-	(v (cl-waffe2/distributions:ax+b `(,n ,n) 0 0.00))
-	(p (cl-waffe2/distributions:ax+b `(,n ,n) 0 0.0001))
-	(grad (cl-waffe2/distributions:ax+b `(,n ,n) 0 0.01))
-	(lr (make-tensor 0.01))
-	(beta1 (make-tensor 0.99))
-	(beta2 (make-tensor 0.9))
-	(eps (make-tensor 0.0001)))
-    (with-no-grad
-      (dotimes (i 1)
-	(apply-adam-step-m m grad beta1)
-	;;(print m)	      
-	(apply-adam-step-v v grad beta2)
-	;;(print v)  
-	
-	(apply-adam-step-param
-	 m v p lr eps)
-	)
-      p)))
-
-|#
-

--- a/source/vm/allocation.lisp
+++ b/source/vm/allocation.lisp
@@ -240,24 +240,18 @@ Declares the static allocation state to use.
 
     (when iseq-bw-flat
       (apply-in-place-mutation! iseq-bw-flat (alexandria:hash-table-values cache-tensor-table))
-      (setq iseq-bw-flat (eliminate-setq-node iseq-bw-flat))
-      )
+      (setq iseq-bw-flat (reverse (eliminate-setq-node iseq-bw-flat))))
 
     (setq iseq `(,@iseq ,@(reverse iseq-bw-flat)))
 
-    ;; Iseqを正しい順番にSort
-    ;; :FREEと:USINGをリアルタイムで管理
-    ;; BACKWARD時はgngn
-    ;; 検索はapply '#'* original-shapeベースで
-    ;; SV4BWは逆伝播で一回用いられたらその場で破棄する
     ;; define-opのsave-for-backwardの扱い？
     ;; defmodel-asでwith-static-allocationがネストしたときの扱い・・・
     ;; 最初のallocateはrouteから参照しないと・・・MoveでPruneされた後のTensorもallocしちゃう
     (simulate-memory-pool! iseq)
 
-    
     ;; [TODO] 前後でメモリ使用量計算して性能を評価する
     ;; [TODO] mempool-idxを入れ替えて最適化する
+    ;; [TODO] memory-poolの更新して動くように
     
     (loop for tensor being the hash-values in cache-tensor-table do
       (setf (gethash (tensor-id tensor) alloc-route-table) (tensor-id tensor))

--- a/source/vm/allocation.lisp
+++ b/source/vm/allocation.lisp
@@ -1,0 +1,6 @@
+
+(in-package :cl-waffe2/vm)
+
+(defun schedule (iseq))
+
+;;(tensor-mempool-idx tensor) を更新する・・・

--- a/source/vm/allocation.lisp
+++ b/source/vm/allocation.lisp
@@ -28,6 +28,7 @@
 ;; AbstractNode: f(lambda_fw, lambda_bw, tensors) -> g(tensors) where g is a thread-safe compiled program.
 ;; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+;; (Proceed (!Sum (Proceed (!Softmax (randn `(3 3))))))
 ;; ScalarTensorとMemory_pool, defmodel-asを修正 -> It should work
 
 ;; deftrainerをはいし
@@ -72,20 +73,12 @@
 ;; [TODO] DtypeとかDeviceが違うTensorは同じにしたらダメ
 
 
-;; [TODO] 抜ける時にGlobalのMemory-Poolに移動しないと
 ;; with-static-allocationの外でProceedで繋げることができない。
 ;; defparameterでglobalなallocationを宣言しておく？
 ;; vecに格納しておく
 ;; (grad tensor) <- 読み込める？
 
-;; [TODO] AdjustableSymbolの管理 ... VMAllocationに任せる？
-;; Adjustable-Shape VMAllocationがないとできない <-
-;; Locality 
-;; Eliminate-Undetermined-XXX <- osoi
-;; [BugFix] (!relu (!softmax a)))) backward
-;; コンパイル時と実行時のTensorIDは一致していないかも・・・
-;; allocationだけ新しくすればToplevelでAbstractNodeのコンパイルできる
-;; -> (defun copy-allocation, delete-allocation
+
 
 (defun tensor-tmp-p (tensor &optional (include-scalar nil))
   "Returns T if the given tensor is subject to be optimized locality"

--- a/source/vm/allocation.lisp
+++ b/source/vm/allocation.lisp
@@ -35,6 +35,8 @@
 ;; Eliminate-Undetermined-XXX <- osoi
 ;; [BugFix] (!relu (!softmax a)))) backward
 ;; コンパイル時と実行時のTensorIDは一致していないかも・・・
+;; allocationだけ新しくすればToplevelでAbstractNodeのコンパイルできる
+;; -> (defun copy-allocation, delete-allocation
 
 (defun tensor-tmp-p (tensor)
   "Returns T if the given tensor is subject to be optimized locality"
@@ -247,9 +249,9 @@ Declares the static allocation state to use.
 	     (setf (gethash (tensor-id tensor) id2pool-table) tensor)))
        (wfop-sv4bw inst)))
 
-    (maphash #'(lambda (x y)
-		 (format t "~a->~a~%" x y))
-	     id2pool-table)
+;;    (maphash #'(lambda (x y)
+;;		 (format t "~a->~a~%" x y))
+;;	     id2pool-table)
 
     (values
      iseq-bw-flat

--- a/source/vm/allocation.lisp
+++ b/source/vm/allocation.lisp
@@ -1,6 +1,164 @@
 
 (in-package :cl-waffe2/vm)
 
-(defun schedule (iseq))
+;; [TODO] memory-pool.lispを削除
+;; [TODO] Dynamically-Shapingを安定化する
+;; [TODO] Stride ... In-placeの保証のもとに数値を優先
+
+;; [TODO] モデルをコンパイルするとToplevelではallocation-state構造が帰ってくる
+;; [TODO] 上をグローバル変数にセットしてその下で計算をしないといけない
+
+;; [TODO] REPL上ではどうする？今までののこす？
+;; [TODO] 局所性の最適化 -> 後で
+;; [TODO] DtypeとかDeviceが違うTensorは同じにしたらダメ
+
+(defun tensor-tmp-p (tensor)
+  "Returns T if the given tensor is subject to be optimized locality"
+  (declare (type AbstractTensor tensor))
+  (and (eql     (tensor-facet tensor) :input)
+       (not     (scalar-p tensor))
+       (stringp (tensor-name tensor))))
+
+(defstruct (VMAllocation
+	    (:conc-name vmalloc-))
+  "
+## [struct] VMAllocation
+
+Records the statue and result of localized allocation state by cl-waffe2 VM.
+"
+  (allocated-p nil :type boolean)
+  (id->tensor (make-hash-table) :type hash-table)
+  (reduce-rate 0.0 :type single-float))
+
+(defmethod print-object ((model VMAllocation) stream)
+  (format stream "{VMAllocation:
+    memory-pool=~a,
+    reduce-rate=~a
+}"
+	  (vmalloc-id->tensor model)
+	  (vmalloc-reduce-rate model)))
+
+;; [TODO] Memory-Poolのごにゃごにゃと合わせて
+;; [TODO] Toplevelの引数になるTensorはset-inputしないといけない e.g.: (make-input ... :X)
+(defun adjust-allocation! (allocation shape-table)
+  "
+## [function] adjust-allocation!
+
+Dynamically Shaped Tensors registered in the `allocation`, is able to form their own shapes by calling this function.
+Reading the value of shape-table: (e.g.: A->1, B->2 ...), adjusts the size of storage vector allocated in the allocation.
+If the re-allocation is performed, frees the old one.
+"
+  (declare (type VMAllocation allocation)
+	   (type hash-table shape-table)
+	   (optimize (speed 3)))
+
+  (flet ((->num (val) (the number (if (numberp val) val (gethash val shape-table)))))
+    (loop for tensor being the hash-values in (vmalloc-id->tensor allocation)
+	  ;; If the tensor is DYNAMYCALLY SHAPED:
+	  if (some #'symbolp (cl-waffe2/vm.generic-tensor::tensor-input-shape tensor))
+	    do (if (>= (the fixnum (apply #'* (map 'list #'->num (cl-waffe2/vm.generic-tensor::original-shape tensor))))
+		       (apply #'* (map 'list #'->num (cl-waffe2/vm.generic-tensor::tensor-input-shape tensor))))
+		   ;; Keep Using a old one
+		   (setf (slot-value tensor 'cl-waffe2/vm.generic-tensor::orig-shape)
+			 (map 'list #'->num (cl-waffe2/vm.generic-tensor::tensor-input-shape tensor)))
+		   (when (not (scalar-p tensor))
+		     ;; Update
+		     (funcall (the function (tensor-finalizer tensor)))
+		     (setf (tensor-vec tensor) nil)
+		     
+		     (setf (slot-value tensor 'cl-waffe2/vm.generic-tensor::orig-shape)
+			   (map 'list #'->num (cl-waffe2/vm.generic-tensor::tensor-input-shape tensor)))
+		     (setf (tensor-vec tensor) (make-tensor
+						(cl-waffe2/vm.generic-tensor::original-shape tensor)
+						:dtype (dtype tensor)
+						:order (order tensor)
+						:device (class-of tensor))))))))
+
+(defun maybe-allocate! (allocation)
+  (declare (type VMAllocation allocation))
+  (when (not (vmalloc-allocated-p allocation))
+    (loop for tensor being the hash-values in (vmalloc-id->tensor allocation) do
+      ;; Reading the orig-shape
+      (setf (slot-value tensor 'cl-waffe2/vm.generic-tensor::orig-shape)
+	    (map 'list #'cl-waffe2/vm.generic-tensor::read-symbol
+		 (cl-waffe2/vm.generic-tensor::original-shape tensor)))
+      (let ((use
+	      (if (scalar-p tensor)
+		  (make-tensor 0 :dtype (dtype tensor) :device (class-of tensor) :order (order tensor))
+		  (make-tensor
+		   (cl-waffe2/vm.generic-tensor::original-shape tensor)		       
+		   :dtype (dtype tensor)
+		   :order (order tensor)
+		   :device (class-of tensor)))))
+	(setf (tensor-vec tensor) (cl-waffe2/vm.generic-tensor::vec use))))	
+    (setf (vmalloc-allocated-p allocation) T)))
+	     
+(defun storage-vec-from-memory-pool (allocation tensor)
+  "Reading the allocated state, `allocation`, the function returns a storage vec of tensor."
+  (declare (type VMAllocation allocation)
+	   (type AbstractTensor tensor))
+  (when (null (tensor-mempool-idx tensor))
+    (error "SystemError: Attempted to read the storage vec of ~a but failed because the tensor wasn't tracked when compiling." tensor))
+  
+  (let ((result (gethash (tensor-mempool-idx tensor) (vmalloc-id->tensor allocation))))
+    (when (null result)
+      (error "tensor-vec: The tensor ~a isn't registered to the memory-pool.
+To use InputTensor as a cache, envolve the tensor into your node by any means, as an argument." tensor))
+    (setf (tensor-vec tensor) (cl-waffe2/vm.generic-tensor::vec result))
+    
+    (cl-waffe2/vm.generic-tensor::vec result)))
+
+(defmacro with-static-allocation ((allocation) &body body)
+  "
+## [macro] with-static-allocation
+
+Declares the static allocation state to use.
+"
+  `(let ((*static-alloc-state* ,allocation))
+     (maybe-allocate! ,allocation)
+     ,@body))
+
+;; [TODO] Memory_Pool ... Tensor_IDベースでIndexを振り分ける
+;; [TODO] Optimize Backward...
+;; tensor-protect-dout <- これ最後の参照のdoutは破壊してもOK
+;; InstructionSeqを一直線に並べてからApply-In-Place-Mutation!したい
+
+(defun optimize-memory-locality! (iseq-fw iseq-bw)
+  (declare (type list iseq-fw)
+	   (type (or null list) iseq-bw))
+
+  ;; iseq-fw ... NIL is NG
+  ;; iseq-bw ... NIL is ok
+
+  (let* ((cache-tensor-table (make-hash-table))
+	 (alloc-route-table  (make-hash-table))
+	 (iseq `(,@(loop for inst in iseq-bw
+			 if (null (wfop-block-iseq inst))
+			   append (list inst)
+			 else
+			   append (wfop-block-iseq inst))
+		 ,@(loop for inst in iseq-fw
+			 if (null (wfop-block-iseq inst))
+			   append (list inst)
+			 else
+			   append (wfop-block-iseq inst)))))
+
+    ;; Counting up all tensors (TMP Tensor) used in the node.
+    (loop for inst in iseq do
+      (when (tensor-tmp-p (wfop-self inst))
+        (setf (gethash (tensor-id (wfop-self inst)) cache-tensor-table) (wfop-self inst)))
+      (mapc
+       #'(lambda (arg)
+	   (when (tensor-tmp-p arg)
+	     (setf (gethash (tensor-id arg) cache-tensor-table) arg)))
+       (wfop-args inst)))
+
+    ;; [TODO] 前後でメモリ使用量計算して性能を評価する
+    ;; [TODO] mempool-idxを入れ替えて最適化する
+    (loop for tensor being the hash-values in cache-tensor-table do
+      (setf (tensor-mempool-idx tensor) (tensor-id tensor))
+      (setf (gethash (tensor-id tensor) alloc-route-table) tensor))
+    
+    (make-vmallocation :id->tensor alloc-route-table)))
 
 ;;(tensor-mempool-idx tensor) を更新する・・・

--- a/source/vm/allocation.lisp
+++ b/source/vm/allocation.lisp
@@ -337,12 +337,10 @@ Please explict the allocation state with: (with-static-allocation (allocation) .
     
     ;; Optimizes the locality of memory
     ;; [TODO] Share memory-pools between forward and backward
-    ;; (setq iseq `(,@iseq ,@(reverse iseq-bw-flat)))
     (simulate-memory-pool! iseq)
-
-    ;; FixME
-    ;;q(simulate-memory-pool! iseq-bw-flat)
-
+    ;;(simulate-memory-pool! iseq-bw-flat)
+    (%in-place-vm-ops! iseq-bw-flat)
+    
     ;; iseq ... flattened list of iseq
     ;; VM executes them in the order of iseq[0] iseq[1] ... iseq[n] where n = program_counter
 
@@ -387,7 +385,7 @@ Please explict the allocation state with: (with-static-allocation (allocation) .
 (defun simulate-memory-pool! (iseq)
   (declare (optimize (speed 3))
 	   (type list iseq))
-
+  
   (%in-place-vm-ops! iseq)
   
   (let ((mempool-using-tensors nil)

--- a/source/vm/allocation.lisp
+++ b/source/vm/allocation.lisp
@@ -10,6 +10,7 @@
 ;; O(N^2)
 ;; Enhancement: IDの番地を人間が読みやすくする
 
+;; Forward 動く？ Backwardが動かん〜
 ;; (!mul a b) AがInputTensorだとMoveTensorNodeを一つ減らせる
 
 ;; TODO Nested with-static-allocation
@@ -141,7 +142,7 @@ Allocation State:
     (when (null (cl-waffe2/vm.generic-tensor::vec result))
       (error "tensor-vec: In memory-pool, the InputTensor ~a isn't registered?" result))
     (setf (tensor-vec tensor) (cl-waffe2/vm.generic-tensor::vec result))
-    (cl-waffe2/vm.generic-tensor::vec result)))
+    (cl-waffe2/vm.generic-tensor::vec tensor)))
 
 (defmacro with-static-allocation ((allocation) &body body)
   "

--- a/source/vm/allocation.lisp
+++ b/source/vm/allocation.lisp
@@ -144,7 +144,7 @@ Allocation State:
 
 Declares the static allocation state to use.
 "
-  `(let ((*static-alloc-state* ,allocation))
+  `(let ((cl-waffe2/vm.generic-tensor:*static-alloc-state* ,allocation))
      (maybe-allocate! ,allocation)
      ,@body))
 

--- a/source/vm/allocation.lisp
+++ b/source/vm/allocation.lisp
@@ -71,6 +71,7 @@
   (declare (type AbstractTensor tensor))
   (and (eql     (tensor-facet tensor) :input)
        (stringp (tensor-name tensor))
+       (tensor-mid tensor)
        (if include-scalar
 	   (and (not (scalar-p tensor))
 		(not (tensor-id-lock-p tensor)))
@@ -179,7 +180,7 @@ If the re-allocation is performed, frees the old one.
 			       (make-clone tensor (tensor-name tensor))))))
 	      (setf (slot-value use 'cl-waffe2/vm.generic-tensor::input-shape)
 		    (cl-waffe2/vm.generic-tensor::tensor-input-shape tensor))
-	      (setf (tensor-id use) (tensor-id tensor))
+	      (setf (tensor-mid use) (tensor-mid tensor))
 	      (setf (gethash key (vmalloc-id2pool allocation)) use)))
     allocation))
 
@@ -197,14 +198,17 @@ If the re-allocation is performed, frees the old one.
   (declare (type VMAllocation allocation)
 	   (type AbstractTensor tensor))
 
-  (when (null (gethash (tensor-id tensor) (vmalloc-id2pool allocation)))
+  (when (null (gethash (tensor-mid tensor) (vmalloc-id2pool allocation)))
     (if (cl-waffe2/vm.generic-tensor::vec tensor)
 	(return-from storage-vec-from-memory-pool (cl-waffe2/vm.generic-tensor::vec tensor))
 	(error "tensor-vec: Attempted to read the storage vec of [~a, ~a, ~a] from memory-pool but failed because the tensor wasn't tracked when compiling.
 Allocation State:
-~a" (tensor-id tensor) (class-of tensor) (shape tensor) allocation)))
+~a" (tensor-mid tensor) (class-of tensor) (shape tensor) allocation)))
+
+  (when (null (tensor-mid tensor))
+    (error "MIT=NIL is invaild."))
   
-  (let ((result (gethash (tensor-id tensor) (vmalloc-id2pool allocation))))
+  (let ((result (gethash (tensor-mid tensor) (vmalloc-id2pool allocation))))
     (when (null (cl-waffe2/vm.generic-tensor::vec result))
       (error "tensor-vec: In memory-pool, the InputTensor ~a isn't registered?" result))
     (setf (tensor-vec tensor) (cl-waffe2/vm.generic-tensor::vec result))
@@ -235,12 +239,12 @@ Please explict the allocation state with: (with-static-allocation (allocation) .
 (defun update-mempool-tensor (tensor value)
   (declare (type AbstractTensor tensor value))
   (assure-vmalloc)
-  (setf (gethash (tensor-id tensor) (vmalloc-id2pool *static-alloc-state*)) value))
+  (setf (gethash (tensor-mid tensor) (vmalloc-id2pool *static-alloc-state*)) value))
 
 (defun read-from-mempool-tensor (tensor)
   (declare (type AbstractTensor tensor))
   (assure-vmalloc)
-  (the AbstractTensor (or (gethash (tensor-id tensor) (vmalloc-id2pool *static-alloc-state*)) tensor)))
+  (the AbstractTensor (or (gethash (tensor-mid tensor) (vmalloc-id2pool *static-alloc-state*)) tensor)))
 
 
 ;; ~~ [Implementation] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -262,33 +266,33 @@ Please explict the allocation state with: (with-static-allocation (allocation) .
     ;; Collecting the direction/from of Setq{Pruned}
     (loop for inst in iseq
 	  if (inst-set-p inst)
-	    do (setf (gethash (tensor-id (wfop-self inst)) setq-table) (tensor-id (second (wfop-args inst)))))
+	    do (setf (gethash (tensor-mid (wfop-self inst)) setq-table) (tensor-mid (second (wfop-args inst)))))
 
     ;; Given setq-table, updates all tensor-id
     (loop for inst in iseq
 	  do (dolist (tensor `(,@(wfop-out-to inst) ,@(wfop-args inst)))
 	       (let ((id (findout-origin setq-table tensor)))
 		 (when (not (tensor-id-lock-p tensor))
-		   (setf (tensor-id tensor) id)))))
+		   (setf (tensor-mid tensor) id)))))
 
     ;; Deletes all unused Setq{Pruned}
     (loop for inst in iseq
 	  if (not (or (inst-set-p inst)
 		      (and (eql (wfop-node inst) #'setq-vm-wrap-f)
-			   (eql (tensor-id (car (wfop-out-to inst)))
-				(tensor-id (car (wfop-args inst)))))))
+			   (eql (tensor-mid (car (wfop-out-to inst)))
+				(tensor-mid (car (wfop-args inst)))))))
 	    collect inst)))
 
 (defun iseq-update-tensor-name! (iseq from to)
   (loop for inst in iseq do
-    (dolist (o (remove-duplicates (wfop-out-to inst) :test #'eql :key #'tensor-id))
-      (when (eql (tensor-id o) from)
+    (dolist (o (remove-duplicates (wfop-out-to inst) :test #'eql :key #'tensor-mid))
+      (when (eql (tensor-mid o) from)
 	(when (not (tensor-id-lock-p o))
-	  (setf (tensor-id o) to))))
-    (dolist (a (remove-duplicates (wfop-args inst) :test #'eql :key #'tensor-id))
-      (when (eql (tensor-id a) from)
+	  (setf (tensor-mid o) to))))
+    (dolist (a (remove-duplicates (wfop-args inst) :test #'eql :key #'tensor-mid))
+      (when (eql (tensor-mid a) from)
 	(when (not (tensor-id-lock-p a))
-	  (setf (tensor-id a) to))))))
+	  (setf (tensor-mid a) to))))))
 	
 (defun optimize-memory-locality! (iseq-fw iseq-bw)
   (declare (type list iseq-fw)
@@ -311,9 +315,10 @@ Please explict the allocation state with: (with-static-allocation (allocation) .
 			       append (reverse (wfop-block-iseq inst)))))
 
     (when iseq-bw
+      ;; Set all MID
       (loop for inst in iseq-bw-flat do
 	(mapc #'(lambda (tensor)
-		  (setf (gethash (tensor-id tensor) bw-leaves) tensor))
+		  (setf (gethash (tensor-mid tensor) bw-leaves) tensor))
 	      `(,@(wfop-out-to inst) ,@(wfop-args inst)))))
         
     (when iseq-bw-flat
@@ -335,24 +340,24 @@ Please explict the allocation state with: (with-static-allocation (allocation) .
 
     ;; Counting up all tensors (TMP Tensor) used in the node.
     ;; All we need is the first appearance in the node. So reverse it
+
+    ;; Tensor-ids are locked (regarded as ExistTensor) when finished the compiling.
+    
     (loop for inst in (reverse `(,@iseq ,@iseq-bw-flat)) do
       (when (tensor-tmp-p (wfop-self inst))
-	(setf (gethash (tensor-id (wfop-self inst)) id2pool-table) (wfop-self inst)))
+	(setf (gethash (tensor-mid (wfop-self inst)) id2pool-table) (wfop-self inst)))
+      
       (mapc
        #'(lambda (arg)
 	   (when (tensor-tmp-p arg)
-	     (setf (gethash (tensor-id arg) id2pool-table) arg)))
+	     (setf (gethash (tensor-mid arg) id2pool-table) arg)))
        (wfop-args inst))
       
       (mapc
        #'(lambda (tensor)
 	   (when tensor
-	     (setf (gethash (tensor-id tensor) id2pool-table) tensor)))
+	     (setf (gethash (tensor-mid tensor) id2pool-table) tensor)))
        (wfop-sv4bw inst)))
-
-;;    (maphash #'(lambda (x y)
-;;		 (format t "~a->~a~%" x y))
-;;	     id2pool-table)
 
     (values
      iseq-bw-flat
@@ -386,9 +391,9 @@ Please explict the allocation state with: (with-static-allocation (allocation) .
 	       ;; Otherwise -> NIL
 	       ;; (cdr (nthcdr ... <- do not include the current position
 	       (loop for inst in (cdr (nthcdr pc iseq)) do
-		 (if (find (the symbol (tensor-id target-tensor)) (wfop-args inst) :key #'tensor-id :test #'eql)
+		 (if (find (the symbol (tensor-mid target-tensor)) (wfop-args inst) :key #'tensor-mid :test #'eql)
 		     (return-from args-last-ref-p nil)
-		     (if (find (the symbol (tensor-id target-tensor)) (wfop-out-to inst) :key #'tensor-id :test #'eql)
+		     (if (find (the symbol (tensor-mid target-tensor)) (wfop-out-to inst) :key #'tensor-mid :test #'eql)
 			 (return-from args-last-ref-p t)
 			 nil))) ;; Keep exploring
 	       ;; Reached the last -> T
@@ -401,16 +406,16 @@ Please explict the allocation state with: (with-static-allocation (allocation) .
 			     pools
 			     :test #'memory-pool-p<))))
 	     (read-from-pool (tensor)
-	       (when (find (the symbol (tensor-id tensor)) mempool-using-tensors)
+	       (when (find (the symbol (tensor-mid tensor)) mempool-using-tensors)
 		 (return-from read-from-pool tensor))
 	       
 	       (if (tensor-tmp-p tensor T)
 		   (let ((out (find-from-pool tensor)))
 		     ;; Delete from pool
 		     (when (null out)
-		       (push (tensor-id tensor) mempool-using-tensors)
+		       (push (tensor-mid tensor) mempool-using-tensors)
 		       (return-from read-from-pool tensor))
-		     (push (tensor-id out) mempool-using-tensors)
+		     (push (tensor-mid out) mempool-using-tensors)
 		     (if (some #'symbolp (shape tensor))
 			 (setq pools-adj (remove out pools-adj :test #'memory-pool-p :count 1))
 			 (setq pools
@@ -420,9 +425,9 @@ Please explict the allocation state with: (with-static-allocation (allocation) .
 	     (set-as-free (tensor)
 	       (when (and (tensor-tmp-p tensor T)
 			  ;; The tensor is from memory-pool?
-			  (find (the symbol (tensor-id tensor)) mempool-using-tensors)
+			  (find (the symbol (tensor-mid tensor)) mempool-using-tensors)
 			  )
-		 (setq mempool-using-tensors (delete (tensor-id tensor) mempool-using-tensors :test #'eql))
+		 (setq mempool-using-tensors (delete (tensor-mid tensor) mempool-using-tensors :test #'eql))
 		 (if (some #'symbolp (original-shape tensor))
 		     (push tensor pools-adj)
 		     (push tensor pools)))))
@@ -430,7 +435,7 @@ Please explict the allocation state with: (with-static-allocation (allocation) .
       (loop for inst in iseq for pc fixnum upfrom 0 do
 	(let* ((args (if (inst-set-p inst)
 			 (cdr (wfop-args inst))
-			 (remove-duplicates (wfop-args inst) :test #'eql :key #'tensor-id)))
+			 (remove-duplicates (wfop-args inst) :test #'eql :key #'tensor-mid)))
 	       (args-last-p (map 'list #'(lambda (x) (args-last-ref-p x pc)) args))
 	       (out-to      (wfop-out-to inst)))
 
@@ -441,10 +446,10 @@ Please explict the allocation state with: (with-static-allocation (allocation) .
 	  ;;   args-last-p=T (Moved to the memory-pool)
 	  
 	  ;; WfInstruction: out-to[0], ... <- f(args[0], args[1], ...)
-	  (dolist (out (remove-duplicates out-to :test #'eql :key #'tensor-id))
+	  (dolist (out (remove-duplicates out-to :test #'eql :key #'tensor-mid))
 	    (let ((result (read-from-pool out)))
-	      (when (not (eql (the symbol (tensor-id result)) (tensor-id out)))
-		(iseq-update-tensor-name! (nthcdr pc iseq) (tensor-id out) (tensor-id result)))))
+	      (when (not (eql (the symbol (tensor-mid result)) (tensor-mid out)))
+		(iseq-update-tensor-name! (nthcdr pc iseq) (tensor-mid out) (tensor-mid result)))))
 	  
 	  (mapc #'(lambda (tensor state)
 		    (when state

--- a/source/vm/allocation.lisp
+++ b/source/vm/allocation.lisp
@@ -31,6 +31,9 @@
 ;; [TODO] defmodel-as ...  無駄なインライン化をして実装方式を増やさない
 ;;  -> Compiled-Composite自体をCacheする
 
+;; [FIX] gradient-adderが増えてる
+;; copy/delete-alloc テスト
+
 ;; [TODO] 上の表を実装してThread-safeにする
 ;; [TODO] %vm-moveをthread-safeに動かす defmodel-as ... thread-safe optionを追加
 ;; [TODO] gradient-adder naosu

--- a/source/vm/allocation.lisp
+++ b/source/vm/allocation.lisp
@@ -239,7 +239,11 @@ Declares the static allocation state to use.
        (wfop-sv4bw inst)))
 
     (when iseq-bw-flat
-      (apply-in-place-mutation! iseq-bw-flat (alexandria:hash-table-values cache-tensor-table)))
+      (apply-in-place-mutation! iseq-bw-flat (alexandria:hash-table-values cache-tensor-table))
+      (setq iseq-bw-flat (eliminate-setq-node iseq-bw-flat))
+      )
+
+    (setq iseq `(,@iseq ,@(reverse iseq-bw-flat)))
 
     ;; Iseqを正しい順番にSort
     ;; :FREEと:USINGをリアルタイムで管理
@@ -263,9 +267,11 @@ Declares the static allocation state to use.
       (setf (gethash (tensor-id tensor) alloc-route-table) (tensor-id tensor))
       (setf (gethash (tensor-id tensor) id->tensor-table) tensor))
 
-    (make-vmallocation
-     :id->tensor id->tensor-table
-     :id-routes  alloc-route-table)))
+    (values
+     iseq-bw-flat
+     (make-vmallocation
+      :id->tensor id->tensor-table
+      :id-routes  alloc-route-table))))
 
 
 ;; Blockの形は維持するけど、Node側でIn-place-mutation!をするんじゃなくて

--- a/source/vm/allocation.lisp
+++ b/source/vm/allocation.lisp
@@ -257,6 +257,8 @@ Declares the static allocation state to use.
 (defun simulate-memory-pool! (iseq)
   (declare (optimize (speed 3))
 	   (type list iseq))
+
+  (%in-place-vm-ops! iseq)
   
   (let ((mempool-using-tensors nil)
 	(pools nil)

--- a/source/vm/allocation.lisp
+++ b/source/vm/allocation.lisp
@@ -253,7 +253,7 @@ Please explict the allocation state with: (with-static-allocation (allocation) .
 (defun read-from-mempool-tensor (tensor)
   (declare (type AbstractTensor tensor))
   (assure-vmalloc)
-  (the AbstractTensor (gethash (tensor-id tensor) (vmalloc-id2pool *static-alloc-state*))))
+  (the AbstractTensor (or (gethash (tensor-id tensor) (vmalloc-id2pool *static-alloc-state*)) tensor)))
 
 
 ;; ~~ [Implementation] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/vm/allocation.lisp
+++ b/source/vm/allocation.lisp
@@ -28,7 +28,9 @@
 ;; AbstractNode: f(lambda_fw, lambda_bw, tensors) -> g(tensors) where g is a thread-safe compiled program.
 ;; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-;; dout=0
+;; ScalarTensorとMemory_pool, defmodel-asを修正 -> It should work
+
+;; deftrainerをはいし
 ;; (EXP X) -> A, B <-これ検出できない？
 ;; [TODO] defmodel-as ...  無駄なインライン化をして実装方式を増やさない
 ;;  -> Compiled-Composite自体をCacheする (OK)
@@ -53,9 +55,7 @@
 ;; defmodel-asでwith-static-allocationがネストしたときの扱い・・・
 ;; 最初のallocateはrouteから参照しないと・・・MoveでPruneされた後のTensorもallocしちゃう
 
-;; memory-poolのmemory-poolが欲しい〜
 
-;; Forward 動く？ Backwardが動かん〜
 ;; (!mul a b) AがInputTensorだとMoveTensorNodeを一つ減らせる
 
 ;; TODO Nested with-static-allocation
@@ -93,7 +93,7 @@
   (and (eql     (tensor-facet tensor) :input)
        (stringp (tensor-name tensor))
        (if include-scalar
-	   (scalar-p tensor)
+	   (not (scalar-p tensor))
 	   t)))
 
 (defstruct (VMAllocation
@@ -340,7 +340,8 @@ Please explict the allocation state with: (with-static-allocation (allocation) .
     ;; (setq iseq `(,@iseq ,@(reverse iseq-bw-flat)))
     (simulate-memory-pool! iseq)
 
-    (simulate-memory-pool! iseq-bw-flat)
+    ;; FixME
+    ;;q(simulate-memory-pool! iseq-bw-flat)
 
     ;; iseq ... flattened list of iseq
     ;; VM executes them in the order of iseq[0] iseq[1] ... iseq[n] where n = program_counter

--- a/source/vm/allocation.lisp
+++ b/source/vm/allocation.lisp
@@ -14,6 +14,9 @@
 
 ;; TODO Nested with-static-allocation
 
+;; [TODO] DtypeのCastを計算ノードにする CastTensorNode-XXX
+;; [TODO] ^ forward :aroundでデータ型の不一致を検知したら、outに従って自動でCasting
+
 ;; [TODO] memory-pool.lispを削除 (NO)
 ;; [TODO] Dynamically-Shapingを安定化する
 ;; [TODO] Stride ... In-placeの保証のもとに数値を優先

--- a/source/vm/allocation.lisp
+++ b/source/vm/allocation.lisp
@@ -328,7 +328,7 @@ Please explict the allocation state with: (with-static-allocation (allocation) .
     (simulate-memory-pool! iseq)
 
     (%in-place-vm-ops! iseq-bw-flat)
-    (simulate-memory-pool! iseq-bw-flat)
+    ;;(simulate-memory-pool! iseq-bw-flat)
     
     
     ;; iseq ... flattened list of iseq

--- a/source/vm/allocation.lisp
+++ b/source/vm/allocation.lisp
@@ -328,6 +328,11 @@ Please explict the allocation state with: (with-static-allocation (allocation) .
     (simulate-memory-pool! iseq)
 
     (%in-place-vm-ops! iseq-bw-flat)
+
+    ;; Iseq-bw-flat is well optimized by simulate-memory-pool! iseq
+    ;; So there's no need to call it again (only to result the wrong result)
+    ;; %in-place-vm-ops! is working enough.
+    
     ;;(simulate-memory-pool! iseq-bw-flat)
     
     

--- a/source/vm/allocation.lisp
+++ b/source/vm/allocation.lisp
@@ -28,44 +28,6 @@
 ;; AbstractNode: f(lambda_fw, lambda_bw, tensors) -> g(tensors) where g is a thread-safe compiled program.
 ;; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-;; Deftrainerを廃止
-;; (EXP X) -> A, B <-これ検出できない？
-;; !softmax, exp is duplicated -> delete.
-
-;; define-op の SaveForBackwardの扱いは？テスト増やすべき
-
-;; RNN ... define-impl-opで埋め込む？
-;; SV4BWでAllocしたのは局所性云々とはどうでもいい
-;; O(N^2)
-
-;; define-opのsave-for-backwardの扱い？
-;; defmodel-asでwith-static-allocationがネストしたときの扱い・・・
-;; 最初のallocateはrouteから参照しないと・・・MoveでPruneされた後のTensorもallocしちゃう
-
-
-;; (!mul a b) AがInputTensorだとMoveTensorNodeを一つ減らせる
-
-;; TODO Nested with-static-allocation
-
-;; [TODO] DtypeのCastを計算ノードにする CastTensorNode-XXX
-;; [TODO] ^ forward :aroundでデータ型の不一致を検知したら、outに従って自動でCasting
-
-;; [TODO] memory-pool.lispを削除 (NO)
-;; [TODO] Dynamically-Shapingを安定化する
-;; [TODO] Stride ... In-placeの保証のもとに数値を優先
-
-;; [TODO] REPL上ではどうする？今までののこす？
-;; [TODO] 局所性の最適化 -> 後で
-;; [TODO] DtypeとかDeviceが違うTensorは同じにしたらダメ
-
-
-;; with-static-allocationの外でProceedで繋げることができない。
-;; defparameterでglobalなallocationを宣言しておく？
-;; vecに格納しておく
-;; (grad tensor) <- 読み込める？
-
-
-
 (defun tensor-tmp-p (tensor &optional (include-scalar nil))
   "Returns T if the given tensor is subject to be optimized locality"
   (declare (type AbstractTensor tensor))

--- a/source/vm/compile.lisp
+++ b/source/vm/compile.lisp
@@ -19,7 +19,6 @@
 ;; Z <- Y
 
 
-(defparameter *vm-compile-option* :fastest)
 
 (declaim (ftype (function (AbstractTensor) (or null WFInstruction)) ir->instruction))
 (defun ir->instruction (tensor)
@@ -35,7 +34,7 @@
       (apply
        #'find-cached-function
        (statecontainer-forward-out-form (tensor-state tensor))
-       (cl-waffe2/vm.generic-tensor::compile-option-form *vm-compile-option*)
+       *compile-option*
        (tensor-variables tensor))
       tensor
       (tensor-backward tensor)
@@ -221,7 +220,7 @@ Tips: `disassemble-waffe2-ir` to display compiled Instruction Sequence.
 
 	(when optimize-locality
 	  (setq iseq-forward (eliminate-setq-node iseq-forward)))
-		
+	
 	(let ((forward (reverse iseq-forward))
 	      (backward (if (and need-backward out-symbol-p (not (scalar-p toplevel)))
 			    (append

--- a/source/vm/compile.lisp
+++ b/source/vm/compile.lisp
@@ -220,14 +220,6 @@ Tips: `disassemble-waffe2-ir` to display compiled Instruction Sequence.
 		 (forward->reverse-mode iseq-forward dout))))
 
 	(when optimize-locality
-	  ;; Reset MID
-	  (reset-locality-optimizations! iseq-forward)
-	  (let ((bw-flat (loop for inst in (reverse backward-iseq)
-			       if (null (wfop-block-iseq inst))
-				 append (list inst)
-			       else
-				 append (reverse (wfop-block-iseq inst)))))
-	    (reset-locality-optimizations! bw-flat))
 	  (setq iseq-forward (eliminate-setq-node iseq-forward)))
 	
 	(let ((forward  (reverse iseq-forward))
@@ -245,7 +237,7 @@ Tips: `disassemble-waffe2-ir` to display compiled Instruction Sequence.
 	    (values forward (or bw backward) leaves dout allocation)))))))
 
 (defun findout-origin (table tensor &key (limit 10))
-  (let ((last-ref (tensor-mid tensor)))
+  (let ((last-ref (tensor-id tensor)))
     (loop while t for n upfrom 0 do
       (if (> n limit) (return-from findout-origin last-ref))      
       (if (null (gethash last-ref table))
@@ -275,8 +267,8 @@ Prints out the compiled cl-waffe2 IR from toplevel to each leaf points to `strea
 		   (dolist (i iseq)
 		     (dolist (var (wfop-args i))
 		       (if (scalar-p var)
-			   (push (tensor-mid var) scal-ids)
-			   (push (tensor-mid var) tensor-ids)))
+			   (push (tensor-id var) scal-ids)
+			   (push (tensor-id var) tensor-ids)))
 		     (princ i out)))
 		 (format out "~%~a Instructions | ~a Tensors | ~a Scalars~%"
 			 (length iseq)

--- a/source/vm/compile.lisp
+++ b/source/vm/compile.lisp
@@ -155,15 +155,13 @@
 			     do (set-dout arg o)
 				(init-state-container! o))
 		     ;; MoveTensorBackward is inlined in order to get in-place mutation
-		     (if nil;;(movetensor-p (wfop-node inst))
-			 bw-iseq
-			 (list
-			  (make-wfop bw-function ;; ... dout var1 var2
-				     self
-				     node
-				     `(,(get-dout self) ,@args)
-				     :out-to (loop for o in out-to if o collect o)
-				     :block-iseq bw-iseq))))))
+		     (list
+		      (make-wfop bw-function ;; ... dout var1 var2
+				 self
+				 node
+				 `(,(get-dout self) ,@args)
+				 :out-to (loop for o in out-to if o collect o)
+				 :block-iseq bw-iseq)))))
 	       ;; Expand Gradient Adders
 	       (loop for var in args
 		     if (and (slot-value var 'requires-grad) (get-dout var))

--- a/source/vm/compile.lisp
+++ b/source/vm/compile.lisp
@@ -218,16 +218,6 @@ Tips: `disassemble-waffe2-ir` to display compiled Instruction Sequence.
 	
 	(apply-in-place-mutation! backward-iseq leaves :reverse-iseq t)
 
-	;; Initializes Gradient Resetter
-	(mapc
-	 #'(lambda (tensor)
-	     (when (slot-value tensor 'cl-waffe2/vm.generic-tensor:requires-grad)
-	       (setf (cl-waffe2/vm.generic-tensor::gradient-resetter tensor)
-		     (if (scalar-p tensor)
-			 #'(lambda () (setf (tensor-vec (grad tensor)) (tensor-vec (make-tensor 0 :dtype (dtype tensor) :order (order tensor)))))
-			 #'(lambda () (setf (tensor-grad-count tensor) 0))))))
-	 leaves)
-
 	(values (reverse iseq-forward)
 		(if (and need-backward out-symbol-p (not (scalar-p toplevel)))
 		    (append ;; dout = 0, so add 1

--- a/source/vm/compile.lisp
+++ b/source/vm/compile.lisp
@@ -218,7 +218,7 @@ Tips: `disassemble-waffe2-ir` to display compiled Instruction Sequence.
 			  (ancestor-param-p toplevel))
 		 (forward->reverse-mode iseq-forward dout))))
 
-	(when optimize-locality
+	(when (and dout optimize-locality)
 	  (setf (tensor-protect-me dout) t))
 	
 	;;(apply-in-place-mutation! backward-iseq leaves :reverse-iseq t)
@@ -230,8 +230,8 @@ Tips: `disassemble-waffe2-ir` to display compiled Instruction Sequence.
 			      (node-compile-into-vm dout))
 			     backward-iseq)
 			    backward-iseq)))
-	  (multiple-value-bind (allocation) (when optimize-locality (optimize-memory-locality! forward backward))
-	    (values forward backward leaves dout allocation)))))))
+	  (multiple-value-bind (bw allocation) (when optimize-locality (optimize-memory-locality! forward backward))
+	    (values forward (or bw backward) leaves dout allocation)))))))
 
 (defun findout-origin (table tensor)
   (let ((last-ref (tensor-id tensor)))

--- a/source/vm/compile.lisp
+++ b/source/vm/compile.lisp
@@ -197,13 +197,8 @@ Tips: `disassemble-waffe2-ir` to display compiled Instruction Sequence.
       ;; Set grad-count=0 if any
       (map 'list #'(lambda (tensor) (setf (tensor-grad-count tensor) 0)) leaves)
 
-      ;; [FixME] In the training mode, apply-in-place-mutation! will produce the destruction of gradients...
-      ;; Analyze and pursuit for the reason and update the algorithm.
+      (apply-in-place-mutation! iseq-forward leaves)
 
-      (when (or (null (ancestor-param-p toplevel))
-		*no-grad*
-		(not need-backward))
-	(apply-in-place-mutation! iseq-forward leaves))
 
       (let* ((out-symbol-p (some #'symbolp (shape toplevel)))
 	     (dout (when need-backward

--- a/source/vm/compile.lisp
+++ b/source/vm/compile.lisp
@@ -197,8 +197,7 @@ Tips: `disassemble-waffe2-ir` to display compiled Instruction Sequence.
       (map 'list #'(lambda (tensor) (setf (tensor-grad-count tensor) 0)) leaves)
 
       (when optimize-locality
-	(apply-in-place-mutation! iseq-forward leaves)
-	(setq iseq-forward (eliminate-setq-node iseq-forward)))
+	(apply-in-place-mutation! iseq-forward leaves))
 
       (let* ((out-symbol-p (some #'symbolp (shape toplevel)))
 	     (dout (when need-backward
@@ -216,6 +215,9 @@ Tips: `disassemble-waffe2-ir` to display compiled Instruction Sequence.
 			  (ancestor-param-p toplevel))
 		 (forward->reverse-mode iseq-forward dout))))
 
+	(when optimize-locality
+	  (setq iseq-forward (eliminate-setq-node iseq-forward)))
+	
 	(when (and dout optimize-locality)
 	  (setf (tensor-protect-me dout) t))
 	

--- a/source/vm/compile.lisp
+++ b/source/vm/compile.lisp
@@ -233,9 +233,10 @@ Tips: `disassemble-waffe2-ir` to display compiled Instruction Sequence.
 	  (multiple-value-bind (bw allocation) (when optimize-locality (optimize-memory-locality! forward backward))
 	    (values forward (or bw backward) leaves dout allocation)))))))
 
-(defun findout-origin (table tensor)
+(defun findout-origin (table tensor &key (limit 10))
   (let ((last-ref (tensor-id tensor)))
-    (loop while t do
+    (loop while t for n upfrom 0 do
+      (if (> n limit) (return-from findout-origin last-ref))      
       (if (null (gethash last-ref table))
 	  (return-from findout-origin last-ref)
 	  (setq last-ref (gethash last-ref table))))))

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -418,6 +418,7 @@ Compiles the given computation node starting from `toplevel`. The docstring of `
 
 
 ;; TODO -> (defmethod free-model ((model Compiled-Composite)))
+;; TODO -> (defmethod model-memory-size ((model Compiled-Composite)) )
 
 (defmethod print-object ((model Compiled-Composite) stream)
   (format stream "<Compiled-Composite

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -413,10 +413,20 @@ Compiles the given computation node starting from `toplevel`. The docstring of `
 			 :variables         table)
 	(mapc #'cl-waffe2/vm.nodes:on-finished-compiling *using-backend*)))))
 
+(defmethod copy-compiled-model ((model Compiled-Composite))
+  ;; [検証] NodeVariablesのコピーは取るべき？ (-> Perhaps No, Gradientsは固定？)
+  ;; copy-allocate ... with-static-allocation下にいないけどOK? -> OK
+  (make-instance 'Compiled-Composite
+		 :allocation (cl-waffe2/vm::copy-allocate (compiled-allocation model))
+		 :compiled-forward  (compiled-forward model)
+		 :compiled-backward (compiled-backward model)
+		 :out       (compiled-out model)
+		 :inputs    (compiled-inputs model)
+		 :variables (compiled-variables model)))
+
 
 ;; TODO -> (defmethod free-model ((model Compiled-Composite)))
 ;; TODO -> (defmethod model-memory-size ((model Compiled-Composite)) )
-
 (defmethod print-object ((model Compiled-Composite) stream)
   (format stream "<Compiled-Composite(allocated-p=~a)
     forward     : ~a

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -289,7 +289,6 @@ Before calling the forward method, set any value to these InputTensors first.
 	      (set-input model name val))))
   
   ;; Check if all the inputs are embodied?
-  (all-embodied? model)
   (let ((*runtime-mode-p* t))
     (with-adjustable-symbol-scope
       (set-adjustable-symbols model)
@@ -297,6 +296,7 @@ Before calling the forward method, set any value to these InputTensors first.
 	;;(apply #'values
 	;;       (map 'list #'cl-waffe2/vm.nodes::eliminate-undetermined-size
 	;;	    (multiple-value-list (funcall (compiled-forward model)))))
+	(all-embodied? model)
 	(funcall (compiled-forward model))))))
 
 (defmethod cl-waffe2/vm.nodes:backward ((model Compiled-Composite) &rest inputs)

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -398,9 +398,10 @@ Compiles the given computation node starting from `toplevel`. The docstring of `
 	  (backward-f   (when construct-backward?
 			  #'(lambda (model)
 			      (with-adjustable-symbol-scope
-				(set-adjustable-symbols model)
-				(cl-waffe2/vm::with-static-allocation ((compiled-allocation model))
-				  (cl-waffe2/vm:accept-instructions bw-iseq))))))
+				(let ((alloc-inst (set-adjustable-symbols model)))				  
+				  (cl-waffe2/vm::with-static-allocation ((compiled-allocation model))
+				    (cl-waffe2/vm::adjust-allocation! (compiled-allocation model) alloc-inst)
+				    (cl-waffe2/vm:accept-instructions bw-iseq)))))))
 	  (table        (construct-variables-table variables)))
 
 

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -191,7 +191,7 @@ The operation was: Setting ~a <- ~a
 		(alexandria:copy-hash-table
 		 (nodevariables-variables table)))))
     (flet ((replace-new (tensor)
-	     (or (gethash (tensor-id tensor) (cl-waffe2/vm::vmalloc-id2pool allocation))
+	     (or (gethash (tensor-mid tensor) (cl-waffe2/vm::vmalloc-id2pool allocation))
 		 tensor)))
       (maphash
        #'(lambda (place tensor)
@@ -435,7 +435,7 @@ Or, your network may be disconnected at a certain position."
   (let* ((allocation (cl-waffe2/vm::copy-allocate (compiled-allocation model)))
 	 (table      (cl-waffe2/vm::vmalloc-id2pool allocation)))
     (flet ((replace-new (tensor)
-	     (or (gethash (tensor-id tensor) table)
+	     (or (gethash (tensor-mid tensor) table)
 		 tensor)))
       (let ((dout (replace-new (compiled-dout model)))
 	    (out  (replace-new (compiled-out  model))))

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -294,12 +294,12 @@ Before calling the forward method, set any value to these InputTensors first.
     (with-adjustable-symbol-scope
       (set-adjustable-symbols model)
       (cl-waffe2/vm::with-static-allocation ((compiled-allocation model))
-	(apply #'values
-	       (map 'list #'cl-waffe2/vm.nodes::eliminate-undetermined-size
-		    (multiple-value-list (funcall (compiled-forward model)))))))))
+	;;(apply #'values
+	;;       (map 'list #'cl-waffe2/vm.nodes::eliminate-undetermined-size
+	;;	    (multiple-value-list (funcall (compiled-forward model)))))
+	(funcall (compiled-forward model))))))
 
 (defmethod cl-waffe2/vm.nodes:backward ((model Compiled-Composite) &rest inputs)
-
   (when inputs
     (warn "backward:
     (backward compiled-model inputs)

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -423,6 +423,7 @@ Or, your network may be disconnected at a certain position."
 
 (defmethod copy-compiled-model ((model Compiled-Composite))
   ;; [TODO] NodeVariablesのコピーは取るべき？ (-> Perhaps No, Gradientsは固定？)
+  ;; Make Variables Tableもう一度する？
   ;; copy-allocate ... with-static-allocation下にいないけどOK? -> OK
   (make-instance 'Compiled-Composite
 		 :allocation (cl-waffe2/vm::copy-allocate (compiled-allocation model))

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -397,8 +397,10 @@ Compiles the given computation node starting from `toplevel`. The docstring of `
 				(cl-waffe2/vm:accept-instructions fw-iseq))))))
 	  (backward-f   (when construct-backward?
 			  #'(lambda (model)
-b			      (cl-waffe2/vm::with-static-allocation ((compiled-allocation model))
-				(cl-waffe2/vm:accept-instructions bw-iseq)))))
+			      (with-adjustable-symbol-scope
+				(set-adjustable-symbols model)
+				(cl-waffe2/vm::with-static-allocation ((compiled-allocation model))
+				  (cl-waffe2/vm:accept-instructions bw-iseq))))))
 	  (table        (construct-variables-table variables)))
 
 

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -397,7 +397,7 @@ Compiles the given computation node starting from `toplevel`. The docstring of `
 				(cl-waffe2/vm:accept-instructions fw-iseq))))))
 	  (backward-f   (when construct-backward?
 			  #'(lambda (model)
-			      (cl-waffe2/vm::with-static-allocation ((compiled-allocation model))
+b			      (cl-waffe2/vm::with-static-allocation ((compiled-allocation model))
 				(cl-waffe2/vm:accept-instructions bw-iseq)))))
 	  (table        (construct-variables-table variables)))
 

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -417,6 +417,8 @@ Compiles the given computation node starting from `toplevel`. The docstring of `
 	(mapc #'cl-waffe2/vm.nodes:on-finished-compiling *using-backend*)))))
 
 
+;; TODO -> (defmethod free-model ((model Compiled-Composite)))
+
 (defmethod print-object ((model Compiled-Composite) stream)
   (format stream "<Compiled-Composite
     forward  : ~a

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -287,7 +287,7 @@ Before calling the forward method, set any value to these InputTensors first.
       (loop for val in inputs
 	    for name in input-args do
 	      (set-input model name val))))
-			 
+  
   ;; Check if all the inputs are embodied?
   (all-embodied? model)
   (let ((*runtime-mode-p* t))

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -294,9 +294,6 @@ Before calling the forward method, set any value to these InputTensors first.
     (with-adjustable-symbol-scope
       (set-adjustable-symbols model)
       (cl-waffe2/vm::with-static-allocation ((compiled-allocation model))
-	;; [TODO] 抜ける時にGlobalのMemory-Poolに移動しないと
-	;; with-static-allocationの外でProceedで繋げることができない。
-	;; defparameterでglobalなallocationを宣言しておく？
 	(apply #'values
 	       (map 'list #'cl-waffe2/vm.nodes::eliminate-undetermined-size
 		    (multiple-value-list (funcall (compiled-forward model)))))))))

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -191,7 +191,7 @@ The operation was: Setting ~a <- ~a
 		(alexandria:copy-hash-table
 		 (nodevariables-variables table)))))
     (flet ((replace-new (tensor)
-	     (or (gethash (tensor-mid tensor) (cl-waffe2/vm::vmalloc-id2pool allocation))
+	     (or (gethash (tensor-id tensor) (cl-waffe2/vm::vmalloc-id2pool allocation))
 		 tensor)))
       (maphash
        #'(lambda (place tensor)
@@ -435,7 +435,7 @@ Or, your network may be disconnected at a certain position."
   (let* ((allocation (cl-waffe2/vm::copy-allocate (compiled-allocation model)))
 	 (table      (cl-waffe2/vm::vmalloc-id2pool allocation)))
     (flet ((replace-new (tensor)
-	     (or (gethash (tensor-mid tensor) table)
+	     (or (gethash (tensor-id tensor) table)
 		 tensor)))
       (let ((dout (replace-new (compiled-dout model)))
 	    (out  (replace-new (compiled-out  model))))

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -421,11 +421,13 @@ Compiles the given computation node starting from `toplevel`. The docstring of `
 ;; TODO -> (defmethod model-memory-size ((model Compiled-Composite)) )
 
 (defmethod print-object ((model Compiled-Composite) stream)
-  (format stream "<Compiled-Composite
-    forward  : ~a
-    backward : ~a
+  (format stream "<Compiled-Composite(allocated-p=~a)
+    forward     : ~a
+    backward    : ~a
+    memory-pool : ~a
 ~a>"
 	  ;; Variables
+	  (cl-waffe2/vm::vmalloc-allocated-p (compiled-allocation model))
 	  (if (compiled-inputs model)
 	      (with-output-to-string (out)
 		(format out "forward(model")
@@ -435,6 +437,7 @@ Compiles the given computation node starting from `toplevel`. The docstring of `
 	  (if (compiled-backward model)
 	      "backward(model) -> t"
 	      "nil")
+	  (cl-waffe2/vm::vmalloc-id2pool (compiled-allocation model))
 	  (if (>= (length (alexandria:hash-table-keys (nodevariables-variables (compiled-variables model)))) 1)
 	      (compiled-variables model)
 	      "")))

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -271,10 +271,9 @@ Before calling the forward method, set any value to these InputTensors first.
     (cl-waffe2/vm::adjust-allocation! (compiled-allocation model) allocator)
     nil))
 
-(defmethod cl-waffe2/vm.nodes:forward ((model Compiled-Composite) &rest inputs &key &allow-other-keys)
+(defmethod cl-waffe2/vm.nodes:forward ((model Compiled-Composite) &rest inputs)
   (let ((input-args (compiled-inputs model)))
     (when input-args
-
       (assert (= (length input-args) (length inputs))
 	  nil
 	  "forward: Can't invoke the forward step of given Compiled-Composite because the number of arguments received is invaild.
@@ -379,6 +378,7 @@ Compiles the given computation node starting from `toplevel`. The docstring of `
 						 :compile-mode compile-mode
 						 :fuse-p fuse-ops
 						 :add1 dout-add1)
+    
     (let ((forward-f  #'(lambda (model)
 			  (with-adjustable-symbol-scope
 			    (set-adjustable-symbols model)

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -340,7 +340,8 @@ Reading all variables in the computation node, the method get-input returns an c
 		(construct-backward? (not *no-grad*))
 		(compile-mode :fastest)
 		(fuse-ops t)
-		(defmodel-as-from nil))
+		(defmodel-as-from nil)
+		(dout-add1 t))
   "
 ## [function] build
 
@@ -376,7 +377,8 @@ Compiles the given computation node starting from `toplevel`. The docstring of `
       (cl-waffe2/vm:compile-forward-and-backward toplevel
 						 :need-backward construct-backward?
 						 :compile-mode compile-mode
-						 :fuse-p fuse-ops)
+						 :fuse-p fuse-ops
+						 :add1 dout-add1)
     (let ((forward-f  #'(lambda (model)
 			  (with-adjustable-symbol-scope
 			    (set-adjustable-symbols model)

--- a/source/vm/generic-tensor/cache.lisp
+++ b/source/vm/generic-tensor/cache.lisp
@@ -198,7 +198,7 @@ Reading *kernel-storeroom*, the function expands the form below.
 (defun tensor->id (body args)
   (map-tree
    #'(lambda (obj)
-       (typecase obj
+      (typecase obj
 	 (AbstractTensor
 	  (if (find (tensor-id obj) args :key #'tensor-id)
 	      (tensor-id obj)

--- a/source/vm/generic-tensor/cache.lisp
+++ b/source/vm/generic-tensor/cache.lisp
@@ -78,8 +78,7 @@
   (self nil)) ;; 2D 3D Flatten ...
 
 (defun make-funcallable-kernel (compiled-function compile-option)
-  (declare (type Compiled-Kernel compiled-function)
-	   (ignore compile-option))
+  (declare (type Compiled-Kernel compiled-function))
   ;; If the Compiled-kernel already provides any op as a lambda function, -> use this
   ;; Otherwise -> compile and cache
   (or (compiled-kernel-op compiled-function)
@@ -88,7 +87,11 @@
        ;; [TODO]
        ;; Excepted body: (lambda args body)
        ;;                            ^ Insert Compile-Option
-       (compiled-kernel-body compiled-function))))
+       (let ((body (compiled-kernel-body compiled-function)))
+	 `(,(car body)
+	   ,(second body)
+	   (declare ,compile-option)
+	   ,@(cddr body))))))
 
 (defun funcall-cached-function (kernel-function compile-option &rest args)
   (declare (type Compiled-Kernel kernel-function))

--- a/source/vm/generic-tensor/cache.lisp
+++ b/source/vm/generic-tensor/cache.lisp
@@ -1,6 +1,10 @@
 
 (in-package :cl-waffe2/vm.generic-tensor)
 
+;;
+;; ~~ CALL_WITH_VIEW => FUNCTION ~~
+;;
+
 ;; cache.lisp is used to reuse the result of **call-with-view** in compling time, which consists larger part of generated code, and most reusable part.
 
 ;; =======================================================================

--- a/source/vm/generic-tensor/memory-pool.lisp
+++ b/source/vm/generic-tensor/memory-pool.lisp
@@ -1,6 +1,8 @@
 
 (in-package :cl-waffe2/vm.generic-tensor)
 
+;; [TODO] Delete this
+
 ;; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ;;
 ;;  memory-pool.lisp provides features on MemoryPool, caching tensors, and managing allocation for dynamically shaped tensors.
@@ -65,17 +67,6 @@
 ;;      - When *no-grad*=nil, becomes :input
 ;;      - When *no-grad*=t,   :tmp
 
-;;  いつFreeする
-;; [TODO] メモリプールのrefenreeはTensor-id based
-;; [TODO] メモリプールの検索ってこっちがやるべきこと？ compilersじゃなくて？
-;; [TODO] compile-fw-and-bw ... InputTensorのReferenceも参照する
-;; [TODO] Tensor no Print-objectを更新
-;;
-;; CompilerがVirtualMemPoolみたいなの作ってそれ使うことにする？
-;; Nodeの順番は固定であること必須
-
-;; (defmacro with-set-compiled-mempool ((mempool) ...)
-
 (declaim (inline get-from-memory-pool))
 (defparameter *thread-memory-pool*
   (make-hash-table)
@@ -111,15 +102,6 @@ In order to set the io of each cache-pool as :free, cl-waffe2/vm traces the cl-w
 "
   (temporary-rooms (make-hash-table) :type hash-table) ;; All Tensors allocated here
   (cached-pool     (make-hash-table) :type hash-table) ;; Tensors with :free :using states. (apply #'* (translate-adjustable-shape (slot-value 'orig-shape))) -> ((room TENSOR1) (room TENSOR2) (room TENSOR3) ...)
-  )
-
-;; Dtype, Size is compatible?
-(defun find-cached-tensor (tensor memory-pool)
-  ;; (eq (type-of ...) (type-of ...)
-  )
-
-(defun set-cached-tensor (room memory-pool)
-
   )
 
 (defstruct Adjustable-Shape-State
@@ -353,30 +335,4 @@ InputTensors created inside this macro guarantees for all read information to be
     (when room ;; When room=nil, there's no need to consider whether the tensor will be freed or not.
       (setf (temporary-room-state room) attribute)))
   nil)
-
-;(defun update-mempool-cache-state! (tensor to)
- ; (declare (type read-state-io-t to))
-
-;  )
-
-;; with-memory-pool ... そのスコープ内部のTMPが外に持ち越されないことを保証するマクロ
-;; memory-poolはthreadごとにStaticであるべき。
-
-;;
-;; Known issuses on dynamically shaping:
-;;  Strides   ... Stridesが更新されなくてたまにPrintするとError
-;;  set-input ... viewでオフセットを加算しても, Copyしなくても, incf-offsetしなくても・・・
-;;  Scopingなどの使用が不明
-;;
-;; on memory-pool:
-;;  1. Unstable Ruleを明記
-;;  2. mgl-matでいうwith-cacheみたいなAllocationをしたい。TensorのCopyのStateに:save-for-backwardが付与されていない場合はwith-cacheを持ちいればOK
-;;  3. ^ Therefore, make-inputは0で埋められている保証がない。
-
-;;
-;; Tensorは三つある: Save4Backward, Input, TMP
-;;  Input ... 固定の領域 メモリプールの最上層に位置する
-;;  TMP   ... with-mempoolマクロで新しいスコープを作る+抜けるとき削除
-;;  Save4Backward ... *no-grad*=tの条件のもとならTMP otherwise Input
-;;
 

--- a/source/vm/generic-tensor/memory-pool.lisp
+++ b/source/vm/generic-tensor/memory-pool.lisp
@@ -1,7 +1,7 @@
 
 (in-package :cl-waffe2/vm.generic-tensor)
 
-;; [TODO] Delete this
+;; [TODO] This file provides a global memory-pool
 
 ;; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ;;
@@ -295,6 +295,11 @@ InputTensors created inside this macro guarantees for all read information to be
 (defun get-from-memory-pool (tensor)
   (declare (type AbstractTensor tensor)
 	   (optimize (speed 3)))
+
+  (when (some (the function (compose #'symbolp #'read-symbol)) (shape tensor))
+    (error "tensor-vec: Can't allocate the new space for the given InputTensor:
+~a
+because its shape still includes a symbol." tensor))
   
   (cond
     ((scalar-p tensor) ;; As of ScalarTensor, memory-usage = O(1)

--- a/source/vm/generic-tensor/memory-pool.lisp
+++ b/source/vm/generic-tensor/memory-pool.lisp
@@ -233,7 +233,7 @@ InputTensors created inside this macro guarantees for all read information to be
 ~a
 
 -> Compile the tensor with `build`, and set inputs." tensor))
-  
+
   (cond
     ((scalar-p tensor) ;; As of ScalarTensor, memory-usage = O(1)
      (if (vec tensor)

--- a/source/vm/generic-tensor/package.lisp
+++ b/source/vm/generic-tensor/package.lisp
@@ -21,7 +21,6 @@
 
    #:current-backend-state
 
-   #:tensor-mid
    #:tensor-id-lock-p
    #:tensor-finalizer
    #:tensor-grad-count

--- a/source/vm/generic-tensor/package.lisp
+++ b/source/vm/generic-tensor/package.lisp
@@ -39,6 +39,7 @@
    #:tensor-protect-me
    #:requires-grad
    #:ancestor-param-p
+   #:original-shape
    #:actual-shape
    #:mref
    #:vref

--- a/source/vm/generic-tensor/package.lisp
+++ b/source/vm/generic-tensor/package.lisp
@@ -21,6 +21,7 @@
 
    #:current-backend-state
 
+   #:tensor-id-lock-p
    #:tensor-finalizer
    #:tensor-grad-count
    #:tensor-backward

--- a/source/vm/generic-tensor/package.lisp
+++ b/source/vm/generic-tensor/package.lisp
@@ -21,6 +21,7 @@
 
    #:current-backend-state
 
+   #:tensor-mid
    #:tensor-id-lock-p
    #:tensor-finalizer
    #:tensor-grad-count

--- a/source/vm/generic-tensor/package.lisp
+++ b/source/vm/generic-tensor/package.lisp
@@ -21,6 +21,7 @@
 
    #:current-backend-state
 
+   #:recompute-stride!
    #:tensor-id-lock-p
    #:tensor-finalizer
    #:tensor-grad-count

--- a/source/vm/generic-tensor/package.lisp
+++ b/source/vm/generic-tensor/package.lisp
@@ -142,3 +142,6 @@
    #:*using-backend*))
 
 (in-package :cl-waffe2/vm.generic-tensor)
+
+(defparameter *static-alloc-state* nil)
+

--- a/source/vm/generic-tensor/package.lisp
+++ b/source/vm/generic-tensor/package.lisp
@@ -11,9 +11,9 @@
    #:print-current-memory-pool
    #:free-current-memory-pool
    #:make-compiled-kernel
-   #:compile-forward-kernel
    #:find-cached-function
-   #:*memory-pool*)
+   #:*memory-pool*
+   #:*static-alloc-state*)
   ;; Tensor classes
   (:export
    #:AbstractTensor

--- a/source/vm/generic-tensor/package.lisp
+++ b/source/vm/generic-tensor/package.lisp
@@ -29,6 +29,7 @@
    #:tensor-state
    #:tensor-out-n
    #:tensor-vec
+   #:tensor-mempool-idx
    #:tensor-facet
    #:tensor-stride
    #:tensor-name

--- a/source/vm/generic-tensor/package.lisp
+++ b/source/vm/generic-tensor/package.lisp
@@ -29,7 +29,6 @@
    #:tensor-state
    #:tensor-out-n
    #:tensor-vec
-   #:tensor-mempool-idx
    #:tensor-facet
    #:tensor-stride
    #:tensor-name

--- a/source/vm/generic-tensor/package.lisp
+++ b/source/vm/generic-tensor/package.lisp
@@ -21,7 +21,6 @@
 
    #:current-backend-state
 
-   #:recompute-stride!
    #:tensor-id-lock-p
    #:tensor-finalizer
    #:tensor-grad-count

--- a/source/vm/generic-tensor/package.lisp
+++ b/source/vm/generic-tensor/package.lisp
@@ -20,7 +20,8 @@
    #:ScalarTensor
 
    #:current-backend-state
-
+   #:tensor-compiled-instruction-cache-fw
+   #:tensor-compiled-instruction-cache-bw
    #:tensor-id-lock-p
    #:tensor-finalizer
    #:tensor-grad-count

--- a/source/vm/generic-tensor/t/backward.lisp
+++ b/source/vm/generic-tensor/t/backward.lisp
@@ -113,7 +113,7 @@
   (is (chain-test8))
   (is (chain-test9)))
 
-(test backward-si de-effect-test
+(test backward-side-effect-test
   (is (backward-being-not-destructed)))
   
 ;; save-for-backward test

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -366,11 +366,12 @@ This function is setfable and inlined.
 		  ((and
 		    (not (scalar-p tensor))
 		    (stringp (tensor-name tensor)))
+		   ;; The size of it could be changed depending on dynamically shaping
 		   ;; ChainTMP, made by (make-input shape nil)
 		   ;; using get-form-memory-pool is MUST because shapes are dynamically changing.
 		   (get-from-memory-pool tensor))
 		  (T
-		   ;; ExistTensor
+		   ;; Or: Scalar/ExistTensor
 		   (if (vec tensor)
 		       (vec tensor)
 		       (get-from-memory-pool tensor))))))

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -340,7 +340,6 @@ The generic function current-backend-state is used to rendering (show-backends) 
   (let ((a (copy-list (tensor-permute-order tensor))))
     (not (equal (sort a #'>) (tensor-permute-order tensor)))))
 
-(defparameter *static-alloc-state* nil)
 ;; Inline
 (declaim (inline tensor-vec))
 (defun tensor-vec (tensor)

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -362,15 +362,17 @@ This function is setfable and inlined.
 
   ;; tensor-vec is called under the build execution:
 
-  (cond
-    ;; Adjustable Table is allowed to use:
-    ((and *static-alloc-state* (cl-waffe2/vm::tensor-tmp-p tensor))
-     (cl-waffe2/vm::storage-vec-from-memory-pool *static-alloc-state* tensor))
-    (T (or (vec tensor)
-	   (let ((result (get-from-global-memory-pool tensor)))
-	     (if (lazy-variable-p result)
-		 (read-lazy-var result)
-		 result))))))
+  (let ((out
+	  (cond
+	    ;; Adjustable Table is allowed to use:
+	    ((and *static-alloc-state* (cl-waffe2/vm::tensor-tmp-p tensor))
+	     (cl-waffe2/vm::storage-vec-from-memory-pool *static-alloc-state* tensor))
+	    (T (or (vec tensor) (get-from-global-memory-pool tensor))))))
+    (if (scalar-p tensor)
+	(if (lazy-variable-p out)
+	    (read-lazy-var out)
+	    out)
+	out)))
 
 (defun (setf tensor-vec) (new-value tensor)
   (declare (type AbstractTensor tensor))

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -66,11 +66,20 @@ PriorityN must be a subclass of cl-waffe2/vm.generic-tensor:AbstractTensor")
    (variables :initform nil :accessor tensor-variables)
 
 
+   ;; tensor-mid ... ID in memory-pool, used with build function.
    ;; tensor-id  ... indicates which pointer to use or copied?, plus, the index in the mempool.
    ;; tensor-iid ... used for topological sorting
 
+   ;;
+   ;; NIL NIL            TID1 TID2
+   ;;   \ /  -> build ->    \  /
+   ;;   NIL                 TID3
+   ;; Once the function build is called, the empty slot tensor-mid is intialized with its tensor-id
+   ;; When optimizing networks, tensor-mid is frequently overwritten.
+
    (lock-id-p :initform nil :accessor tensor-id-lock-p)
-   (tensor-id :initform (gensym "TID") :type symbol :accessor tensor-id)         
+   (tensor-mid :initform nil :accessor tensor-mid)
+   (tensor-id :initform (gensym "TID") :type symbol :reader tensor-id)         
    (tensor-ident-id :initform (gensym "TIDi") :accessor tensor-iid)
    
    (nth-value :initform 0 :accessor tensor-out-n :type fixnum)
@@ -1018,7 +1027,9 @@ Creates a new tensor with :requires-grad=t from the given tensor. If the tensor 
 	  (if (eql (tensor-facet tensor) :input)
 	      (if (keywordp (tensor-name tensor))
 		  (format nil ":named :~a" (tensor-name tensor))
-		  (format nil ":id ~a"     (tensor-id tensor)))
+		  (if (tensor-mid tensor)
+		      (format nil ":mid ~a"    (tensor-mid tensor))
+		      (format nil ":id ~a"     (tensor-id tensor))))
 	      "")
 	  (let ((state (tensor-state tensor)))
 	    (if state

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -838,6 +838,12 @@ Note that view is only created for Tensors, not a Scalar.
       (apply-permute (slot-value tensor 'input-shape) tensor))
     nil))
 
+(defun recompute-stride! (tensor)
+  (setf (tensor-stride tensor)
+	(case (order tensor)
+	  (:column (column-major-calc-strides (original-shape tensor)))
+	  (:row    (row-major-calc-strides    (original-shape tensor))))))
+
 (defun permute-computable-p (old-order new-order)
   (equal (sort (copy-list old-order) #'<)
 	 (sort (copy-list new-order) #'<)))

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -360,24 +360,13 @@ This function is setfable and inlined.
   (declare (type AbstractTensor tensor))
 
   ;; TODO: without *static-alloc-state*, puts a error
-  (when (and *static-alloc-state*
-	     (cl-waffe2/vm::tensor-tmp-p tensor))
+  (when (and *static-alloc-state* (cl-waffe2/vm::tensor-tmp-p tensor))
     (return-from tensor-vec (cl-waffe2/vm::storage-vec-from-memory-pool *static-alloc-state* tensor)))
   
   ;; See also: comments on the top of memory-pool.lisp
-  (let ((result (cond
-		  ((and
-		    (not (scalar-p tensor))
-		    (stringp (tensor-name tensor)))
-		   ;; The size of it could be changed depending on dynamically shaping
-		   ;; ChainTMP, made by (make-input shape nil)
-		   ;; using get-form-memory-pool is MUST because shapes are dynamically changing.
-		   (get-from-memory-pool tensor))
-		  (T
-		   ;; Or: Scalar/ExistTensor
-		   (if (vec tensor)
-		       (vec tensor)
-		       (get-from-memory-pool tensor))))))
+  (let ((result (if (vec tensor)
+		    (vec tensor)
+		    (get-from-memory-pool tensor))))
     ;; If returned is lazy-variable?
     ;; Lazy-Variable... (make-tensor 'a)
     (if (lazy-variable-p result)

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -70,7 +70,7 @@ PriorityN must be a subclass of cl-waffe2/vm.generic-tensor:AbstractTensor")
    ;; tensor-iid ... used for topological sorting
 
    (lock-id-p :initform nil :accessor tensor-id-lock-p)
-   (tensor-id :initform (gensym "TID") :accessor tensor-id)         
+   (tensor-id :initform (gensym "TID") :type symbol :accessor tensor-id)         
    (tensor-ident-id :initform (gensym "TIDi") :accessor tensor-iid)
    
    (nth-value :initform 0 :accessor tensor-out-n :type fixnum)
@@ -977,8 +977,9 @@ Creates a new tensor with :requires-grad=t from the given tensor. If the tensor 
   (let ((f-exist-p (statecontainer-forward-result state))
 	(b-exist-p (statecontainer-backward-result state)))
     (cond
-      ((subtypep (class-of (tensor-backward tensor))
-		 'cl-waffe2/base-impl::ProceedNode)
+      ((or (subtypep (class-of (tensor-backward tensor))
+		     'cl-waffe2/base-impl::ProceedNode)
+	   (statecontainer-latest-p state))
        :computed)
       ((and (null f-exist-p)
 	    (null b-exist-p))

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -69,7 +69,7 @@ PriorityN must be a subclass of cl-waffe2/vm.generic-tensor:AbstractTensor")
    ;; tensor-id  ... indicates which pointer to use or copied?, plus, the index in the mempool.
    ;; tensor-iid ... used for topological sorting
 
-   (id-lock-p :initform nil :accessor tensor-id-lock-p)
+   (lock-id-p :initform nil :accessor tensor-id-lock-p)
    (tensor-id :initform (gensym "TID") :accessor tensor-id)         
    (tensor-ident-id :initform (gensym "TIDi") :accessor tensor-iid)
    
@@ -1039,6 +1039,7 @@ Creates a new tensor with :requires-grad=t from the given tensor. If the tensor 
   (if (save-for-backward-space tensor)
       nil
       (let ((tensor-clone (make-clone tensor nil)))
+	(setf (tensor-id-lock-p tensor-clone) t)
 	(setf (save-for-backward-space tensor) tensor-clone)
 	tensor)))
 

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -44,6 +44,9 @@ PriorityN must be a subclass of cl-waffe2/vm.generic-tensor:AbstractTensor")
    (visible-shape :initform nil :reader shape :accessor tensor-visible-shape :type list)
    (view :initarg :view :initform nil :accessor tensor-view :type list)
 
+   (compiled-instruction-cache-fw :initform nil :accessor tensor-compiled-instruction-cache-fw)
+   (compiled-instruction-cache-bw :initform nil :accessor tensor-compiled-instruction-cache-bw)
+
    ;; Viewed?
    (projected-p :initarg :projected-p :initform nil :type boolean :reader tensor-projected-p)
 

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -68,8 +68,6 @@ PriorityN must be a subclass of cl-waffe2/vm.generic-tensor:AbstractTensor")
 
    ;; tensor-id  ... indicates which pointer to use or copied?, plus, the index in the mempool.
    ;; tensor-iid ... used for topological sorting
-   ;; mempool-idx ... In default nil, if set to symbol, the memory-pool refers this index instead.
-   (mempool-idx :initform nil :accessor tensor-mempool-idx)
    (tensor-id :initform (gensym "TID") :accessor tensor-id)         
    (tensor-ident-id :initform (gensym "TIDi") :accessor tensor-iid)
    

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -496,7 +496,8 @@ This function is setfable and inlined.
 		      (view nil)
 		      (order *default-order*) ;; TODO (retain-grads nil)
 		      (initial-element)
-		      (device nil))
+		      (device nil)
+		      (create-from nil))
   "
 ## [function] make-tensor
 
@@ -532,6 +533,7 @@ Created a new ExistTensor of a device of `(car *using-backend*)`.
       (make-instance (or device (car *using-backend*))
 		     :dtype dtype
 		     :order order
+		     :create-from create-from
 		     :requires-grad requires-grad
 		     :shape (copy-list shape-or-scalar)
 		     :projected-p nil
@@ -543,6 +545,7 @@ Created a new ExistTensor of a device of `(car *using-backend*)`.
 		     :vec (coerce-lazy shape-or-scalar (dtype->lisp-type dtype))
 		     :shape nil
 		     :dtype dtype
+		     :create-from create-from
 		     :requires-grad requires-grad
 		     :projected-p nil
 		     :facet :exist

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -715,9 +715,14 @@ If you added a new backend with having different ptr-type (can't be accessed by 
 	  nil
 	  "Assertion Failed because the given actual-tensor doesn't have a existing vec.")
 
+  (when (or (scalar-p input-tensor)
+	    (scalar-p actual-tensor))
+    (setf (tensor-vec input-tensor) (vec actual-tensor))
+    (return-from embody-tensor-vec t))
+
   (when (or (numberp (vec input-tensor))
 	    (numberp (vec actual-tensor)))
-    (setf (tensor-vec input-tensor) (tensor-vec actual-tensor))
+    (setf (tensor-vec input-tensor) (vec actual-tensor))
     (return-from embody-tensor-vec t))
 
   ;; Offsets?

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -838,12 +838,6 @@ Note that view is only created for Tensors, not a Scalar.
       (apply-permute (slot-value tensor 'input-shape) tensor))
     nil))
 
-(defun recompute-stride! (tensor)
-  (setf (tensor-stride tensor)
-	(case (order tensor)
-	  (:column (column-major-calc-strides (original-shape tensor)))
-	  (:row    (row-major-calc-strides    (original-shape tensor))))))
-
 (defun permute-computable-p (old-order new-order)
   (equal (sort (copy-list old-order) #'<)
 	 (sort (copy-list new-order) #'<)))

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -69,6 +69,7 @@ PriorityN must be a subclass of cl-waffe2/vm.generic-tensor:AbstractTensor")
    ;; tensor-id  ... indicates which pointer to use or copied?, plus, the index in the mempool.
    ;; tensor-iid ... used for topological sorting
 
+   (id-lock-p :initform nil :accessor tensor-id-lock-p)
    (tensor-id :initform (gensym "TID") :accessor tensor-id)         
    (tensor-ident-id :initform (gensym "TIDi") :accessor tensor-iid)
    

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -1018,7 +1018,9 @@ Creates a new tensor with :requires-grad=t from the given tensor. If the tensor 
 			 (slot-value tensor 'view)
 			 (render-shape tensor)))))
 	  (if (eql (tensor-facet tensor) :input)
-	      (format nil ":named ~a" (tensor-name tensor))
+	      (if (keywordp (tensor-name tensor))
+		  (format nil ":named :~a" (tensor-name tensor))
+		  (format nil ":id ~a"     (tensor-id tensor)))
 	      "")
 	  (let ((state (tensor-state tensor)))
 	    (if state
@@ -1027,10 +1029,13 @@ Creates a new tensor with :requires-grad=t from the given tensor. If the tensor 
 		""))
 	  (if (and (eql (tensor-facet tensor) :input)
 		   (null (vec tensor)))
-	      (format nil "<<Not-Embodied ~a Tensor>>" (shape tensor))
+	      (format nil "  <<Not allocated: size=~a>>" (shape tensor))
 	      ;; TODO: View -> View for printing 3d, 4d... tensor.
 	      (render-tensor tensor :indent 2))
-	  (tensor-facet tensor)
+	  (if (and (eql (tensor-facet tensor) :input)
+		   (not (keywordp (tensor-name tensor))))
+	      (format nil "input~%  :belongs-to :memory-pool")
+	      (tensor-facet tensor))
 	  (slot-value tensor 'requires-grad)
 	  (tensor-backward tensor)))
 

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -66,20 +66,11 @@ PriorityN must be a subclass of cl-waffe2/vm.generic-tensor:AbstractTensor")
    (variables :initform nil :accessor tensor-variables)
 
 
-   ;; tensor-mid ... ID in memory-pool, used with build function.
    ;; tensor-id  ... indicates which pointer to use or copied?, plus, the index in the mempool.
    ;; tensor-iid ... used for topological sorting
 
-   ;;
-   ;; NIL NIL            TID1 TID2
-   ;;   \ /  -> build ->    \  /
-   ;;   NIL                 TID3
-   ;; Once the function build is called, the empty slot tensor-mid is intialized with its tensor-id
-   ;; When optimizing networks, tensor-mid is frequently overwritten.
-
    (lock-id-p :initform nil :accessor tensor-id-lock-p)
-   (tensor-mid :initform nil :accessor tensor-mid)
-   (tensor-id :initform (gensym "TID") :type symbol :reader tensor-id)         
+   (tensor-id :initform (gensym "TID") :type symbol :accessor tensor-id)         
    (tensor-ident-id :initform (gensym "TIDi") :accessor tensor-iid)
    
    (nth-value :initform 0 :accessor tensor-out-n :type fixnum)
@@ -1027,9 +1018,7 @@ Creates a new tensor with :requires-grad=t from the given tensor. If the tensor 
 	  (if (eql (tensor-facet tensor) :input)
 	      (if (keywordp (tensor-name tensor))
 		  (format nil ":named :~a" (tensor-name tensor))
-		  (if (tensor-mid tensor)
-		      (format nil ":mid ~a"    (tensor-mid tensor))
-		      (format nil ":id ~a"     (tensor-id tensor))))
+		  (format nil ":id ~a"     (tensor-id tensor)))
 	      "")
 	  (let ((state (tensor-state tensor)))
 	    (if state

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -378,7 +378,11 @@ This function is setfable and inlined.
 	out)))
 
 (defun (setf tensor-vec) (new-value tensor)
-  (declare (type AbstractTensor tensor))
+  ;;  (declare (type AbstractTensor tensor))
+
+  ;;(when (and (vec tensor)
+;;	     (not (typep new-value (type-of (vec tensor)))))
+  ;;  (error "(setf tensor-vec) Can't set the ="))
   (write-vec new-value tensor))
 
 ;; Initializes generic uis of tensors.

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -68,6 +68,7 @@ PriorityN must be a subclass of cl-waffe2/vm.generic-tensor:AbstractTensor")
 
    ;; tensor-id  ... indicates which pointer to use or copied?, plus, the index in the mempool.
    ;; tensor-iid ... used for topological sorting
+
    (tensor-id :initform (gensym "TID") :accessor tensor-id)         
    (tensor-ident-id :initform (gensym "TIDi") :accessor tensor-iid)
    
@@ -721,6 +722,7 @@ If you added a new backend with having different ptr-type (can't be accessed by 
 
   ;; Offsets?
   (let ((actual-tensor
+	  ;; V delete?
 	  (if (and (= (the fixnum (dims actual-tensor)) (the fixnum (dims input-tensor)))
 		   (permuted-p input-tensor))
 	      (apply #'permute* actual-tensor (tensor-permute-order input-tensor))

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -713,7 +713,7 @@ If you added a new backend with having different ptr-type (can't be accessed by 
 
   (assert (vec actual-tensor)
 	  nil
-	  "Assertion Failed because the given actual-tensor doesn't have a existing vec.")
+	  "embody-tensor-vec: Assertion Failed because the given actual-tensor doesn't have an existing vec.")
 
   (when (or (scalar-p input-tensor)
 	    (scalar-p actual-tensor))

--- a/source/vm/generic-tensor/utils.lisp
+++ b/source/vm/generic-tensor/utils.lisp
@@ -85,7 +85,8 @@
        (eql (tensor-attribute tensor) :input)))
 
 
-(defun make-clone (tensor &optional name ignore-create-from)
+;; [TODO] Extend devices
+(defun make-clone (tensor &optional name ignore-create-from) 
   (let* ((shape (actual-shape tensor))
 	 (out (make-input shape (or name nil)
 			  :create-from (if ignore-create-from

--- a/source/vm/generic-tensor/utils.lisp
+++ b/source/vm/generic-tensor/utils.lisp
@@ -128,3 +128,100 @@
     (:debug ;; Compiling would be suuuuuper slow
      `(optimize (safety 3) (debug 3)))))
 
+
+
+
+(defun translate-adjustable-shape (shape) ;; tensor-input-shape
+  "
+## [function] translate-adjustable-shape
+
+Reading the *adjustable-shape-table*, the function returns an list consisted of fixnum.
+
+If there's any undetermined one, returns an error (TODO: Add Conditions)"
+  (declare (type list shape)
+	   (optimize (speed 3)))
+  (map 'list #'read-symbol shape))
+
+(declaim (ftype (function ((or fixnum symbol)) fixnum) read-adjustable-symbol))
+(defun read-adjustable-symbol (s)
+  (typecase s
+    (fixnum s)
+    (symbol
+     (or (read-symbol s) (error "translate-adjustable-shape: encountered unknown symbol: ~a" s)))))
+
+(defmacro with-adjustable-symbol ((symbol-name symbol-value) &body body)
+  "Adding an element: symbol-name -> symbol-value to *adjustable-shape-table*, which can be read by translate-adjustable-shape function.
+
+Usage:
+
+(with-adjustable-symbols (('a 1) ('b 1))
+    (with-let-adjustable-symbols (a b)
+        (print a)   ;; = 1
+        (print b))) ;; = 1
+
+"
+
+  `(let* ((*adjustable-shape-table* (or *adjustable-shape-table* (make-hash-table)))
+	  (*current-shape-state*    (make-adjustable-shape-state)))
+
+     (setf (gethash ,symbol-name *adjustable-shape-table*) ,symbol-value)
+	 
+     ,@body))
+
+(defmacro with-adjustable-symbol-scope (&body body)
+  `(let* ((*adjustable-shape-table* (alexandria:copy-hash-table (or *adjustable-shape-table* (make-hash-table))))
+	  (*current-shape-state*    (make-adjustable-shape-state)))
+     ,@body))
+
+(defun register-adjustable-shape (symbol value)
+  (setf (gethash symbol *adjustable-shape-table*) value))
+
+(defmacro with-adjustable-symbols ((&rest forms) &body body)
+  (labels ((expand-form (rest-forms)
+	     (if (null rest-forms)
+		 `(progn ,@body)
+		 `(with-adjustable-symbol (,@(car rest-forms))
+		    ,(expand-form (cdr rest-forms))))))
+    (expand-form forms)))
+
+
+(defmacro with-let-adjustable-symbol (symbol-name &body body)
+  ;; TO DELETE: Binding with symbol-name
+  `(let ((,symbol-name (gethash ',symbol-name *adjustable-shape-table*)))
+     (declare (type fixnum ,symbol-name)
+	      (ignorable ,symbol-name))
+     
+     (declare (ignore symbol-name))
+     ,@body))
+
+;; Fix: symbol conflicts??
+(defmacro with-let-adjustable-symbols ((&rest symbol-names) &body body)
+  (labels ((expand (rest-forms)
+	     (if (null rest-forms)
+		 `(progn ,@body)
+		 `(with-let-adjustable-symbol ,(car rest-forms)
+		    ,(expand (cdr rest-forms))))))
+    (expand symbol-names)))
+
+(defun read-symbol (symbol)
+  (declare (optimize (speed 3) (safety 0)))
+  (if *adjustable-shape-table*
+      (typecase symbol
+	(symbol
+	 ;; out <- table[symbol]
+	 (let ((out (gethash symbol *adjustable-shape-table*)))
+	   (if (null out)
+	       symbol ;; No result?
+	       (if (and (symbolp out)
+			(not (eq symbol out))) ;; A -> A ...
+		   ;; A = BATCH_SIZE = 10
+		   (read-symbol out)
+		   out))))
+	;; Return fixnum
+	(T symbol))
+      symbol))
+
+(defun no-need-update-p (tensor)
+  (declare (type AbstractTensor tensor))
+  (adjustable-shape-compatible (tensor-alloc-state tensor)))
+

--- a/source/vm/generic-tensor/utils.lisp
+++ b/source/vm/generic-tensor/utils.lisp
@@ -161,16 +161,14 @@ Usage:
 
 "
 
-  `(let* ((*adjustable-shape-table* (or *adjustable-shape-table* (make-hash-table)))
-	  (*current-shape-state*    (make-adjustable-shape-state)))
+  `(let* ((*adjustable-shape-table* (or *adjustable-shape-table* (make-hash-table))))
 
      (setf (gethash ,symbol-name *adjustable-shape-table*) ,symbol-value)
 	 
      ,@body))
 
 (defmacro with-adjustable-symbol-scope (&body body)
-  `(let* ((*adjustable-shape-table* (alexandria:copy-hash-table (or *adjustable-shape-table* (make-hash-table))))
-	  (*current-shape-state*    (make-adjustable-shape-state)))
+  `(let* ((*adjustable-shape-table* (alexandria:copy-hash-table (or *adjustable-shape-table* (make-hash-table)))))
      ,@body))
 
 (defun register-adjustable-shape (symbol value)

--- a/source/vm/ir.lisp
+++ b/source/vm/ir.lisp
@@ -61,11 +61,11 @@ out_to[0], out_to[1], ... <- λ(Args1 Args2 Args3, ...)
 		    (princ "<Param>" out)
 		    (when (not (eql (cl-waffe2/vm.generic-tensor:tensor-attribute o) :chain))
 		      (princ "<Input>" out)))		      
-		(princ (tensor-mid o) out)
+		(princ (tensor-id o) out)
 		(princ " " out)))
 	    (if ignored-p
 		(with-output-to-string (out)
-		  (format out "~a{~(~a~), ~a}" (tensor-mid (second (wfop-args inst))) (dtype (second (wfop-args inst))) (shape (second (wfop-args inst)))))
+		  (format out "~a{~(~a~), ~a}" (tensor-id (second (wfop-args inst))) (dtype (second (wfop-args inst))) (shape (second (wfop-args inst)))))
 		(if (>= (length (wfop-args inst)) *omit-args-n*)
 		    (format nil "..., x~a,..." (length (wfop-args inst)))
 		    (with-output-to-string (out)
@@ -81,7 +81,7 @@ out_to[0], out_to[1], ... <- λ(Args1 Args2 Args3, ...)
 				  (if sv4
 				      "SV4BW("
 				      "")
-				  (tensor-mid var)
+				  (tensor-id var)
 				  (dtype var)
 				  (shape var)
 				  (if sv4
@@ -279,16 +279,16 @@ out_to[0], out_to[1], ... <- λ(Args1 Args2 Args3, ...)
     ;; Set Result.id <- Base.id
     (when (or (typep (wfop-node inst) 'cl-waffe2/base-impl::ViewTensorNode))
       (iseq-update-tensor-name! iseq
-				(tensor-mid (second (wfop-args inst)))
-				(tensor-mid (car    (wfop-args inst)))))
+				(tensor-id (second (wfop-args inst)))
+				(tensor-id (car    (wfop-args inst)))))
 
     ;; Reshape, Permute: Result Base -> Base
     ;; Base.id <- Result.id
     (when (or (typep (wfop-node inst) 'cl-waffe2/base-impl::ReshapeTensorNode)
 	      (typep (wfop-node inst) 'cl-waffe2/base-impl::Permute-Node))
       (iseq-update-tensor-name! iseq
-				(tensor-mid (car    (wfop-args inst)))
-				(tensor-mid (second (wfop-args inst)))))))
+				(tensor-id (car    (wfop-args inst)))
+				(tensor-id (second (wfop-args inst)))))))
 
 
 

--- a/source/vm/ir.lisp
+++ b/source/vm/ir.lisp
@@ -7,7 +7,7 @@
 
 (defstruct (WfInstruction
 	    (:conc-name wfop-)
-	    (:constructor make-wfop (op self node args &key (sv4bw nil) (out-to nil) (fuse-prev nil) (fused-body-cache nil) (call-with-view nil))))
+	    (:constructor make-wfop (op self node args &key (sv4bw nil) (out-to nil) (fuse-prev nil) (block-iseq nil) (fused-body-cache nil) (call-with-view nil))))
   "
 ## [struct] WFInstruction
 
@@ -33,6 +33,7 @@ out_to[0], out_to[1], ... <- λ(Args1 Args2 Args3, ...)
   (node node :type (or function string null AbstractNode))
   (out-to    out-to :type list)
   (self self :type AbstractTensor)
+  (block-iseq nil :type list)
   (args args :type list)
   (sv4bw sv4bw :type list)
   (bw-is-leaf-p nil :type boolean)
@@ -168,6 +169,7 @@ out_to[0], out_to[1], ... <- λ(Args1 Args2 Args3, ...)
 ;; The algorithm that detects such a node is simple:
 ;;
 
+;; reverse-iseq .. Set T if the node is compiled as a toplevel of reverse mode
 (defun apply-in-place-mutation! (iseq leaves &key (reverse-iseq nil))
   (declare (type list iseq leaves)
 	   (type boolean reverse-iseq)

--- a/source/vm/ir.lisp
+++ b/source/vm/ir.lisp
@@ -174,9 +174,8 @@ out_to[0], out_to[1], ... <- λ(Args1 Args2 Args3, ...)
   (declare (type list iseq leaves)
 	   (type boolean reverse-iseq)
 	   (optimize (speed 3)))
-   
-  (let ((ref-table (make-hash-table)))
 
+  (let ((ref-table (make-hash-table)))
     ;; First, Register all tensors appeared in the computation node
     (mapc
      #'(lambda (variable)
@@ -224,7 +223,7 @@ out_to[0], out_to[1], ... <- λ(Args1 Args2 Args3, ...)
 		;; Before counting up the reference, we judge whether MoveTensor is needed.
 
 		(let (;;(place  (car (wfop-args instruction)))
-		      (target (second (wfop-args instruction))))
+		      (target (second (wfop-args instruction)))) ;; <- もしかしたらcarかも〜〜〜
 		  ;; MoveTensorNode: out <- out, tensor_to_be_copied
 		  ;; But with ignored:
 		  ;; [Deleted] : out <- _, tensor_to_be_copied ;; <- _ is never allocated
@@ -256,7 +255,9 @@ out_to[0], out_to[1], ... <- λ(Args1 Args2 Args3, ...)
 	      ;; arg1 arg2 arg3 ... set +=1 as long as registered in the table.
 	      
 	      (mapc #'(lambda (arg)
-			(when (numberp (gethash (tensor-id arg) ref-table))
+			(when (and
+			       move-p
+			       (numberp (gethash (tensor-id arg) ref-table)))
 			  (incf (the fixnum (gethash (tensor-id arg) ref-table)))))
 		    (if (and reverse-iseq move-p (= (length (wfop-args instruction)) 3))
 			(cdr (wfop-args instruction))

--- a/source/vm/ir.lisp
+++ b/source/vm/ir.lisp
@@ -280,5 +280,16 @@ out_to[0], out_to[1], ... <- λ(Args1 Args2 Args3, ...)
 	  (when (or (typep (wfop-node inst) 'cl-waffe2/base-impl::ViewTensorNode))
 	    (iseq-update-tensor-name! iseq
 				      (tensor-id (second (wfop-args inst)))
-				      (tensor-id (car (wfop-args inst)))))))
+				      (tensor-id (car (wfop-args inst)))))
+
+	  ;; Reshape, Permute: Result Base -> Base
+	  ;; Base.id <- Result.id
+	  (when (or (typep (wfop-node inst) 'cl-waffe2/base-impl::ReshapeTensorNode)
+		    (typep (wfop-node inst) 'cl-waffe2/base-impl::Permute-Node))
+	    (iseq-update-tensor-name! iseq
+				      (tensor-id (car (wfop-args inst)))
+				      (tensor-id (second (wfop-args inst)))))))
+
+
+
 	    

--- a/source/vm/ir.lisp
+++ b/source/vm/ir.lisp
@@ -273,7 +273,7 @@ out_to[0], out_to[1], ... <- λ(Args1 Args2 Args3, ...)
   ;; Make ViewTensorNode/ReshapeNode/PermuteNode In-place
   ;; Iseq ... Follows the execution order
   (declare (type list iseq))
-  
+    
   (loop for inst of-type WfInstruction in iseq do
     ;; ViewTensorNode: Result Base -> Result
     ;; Set Result.id <- Base.id

--- a/source/vm/ir.lisp
+++ b/source/vm/ir.lisp
@@ -223,7 +223,7 @@ out_to[0], out_to[1], ... <- λ(Args1 Args2 Args3, ...)
 		;; Before counting up the reference, we judge whether MoveTensor is needed.
 
 		(let (;;(place  (car (wfop-args instruction)))
-		      (target (second (wfop-args instruction)))) ;; <- もしかしたらcarかも〜〜〜
+		      (target (second (wfop-args instruction))))
 		  ;; MoveTensorNode: out <- out, tensor_to_be_copied
 		  ;; But with ignored:
 		  ;; [Deleted] : out <- _, tensor_to_be_copied ;; <- _ is never allocated

--- a/source/vm/ir.lisp
+++ b/source/vm/ir.lisp
@@ -61,11 +61,11 @@ out_to[0], out_to[1], ... <- λ(Args1 Args2 Args3, ...)
 		    (princ "<Param>" out)
 		    (when (not (eql (cl-waffe2/vm.generic-tensor:tensor-attribute o) :chain))
 		      (princ "<Input>" out)))		      
-		(princ (tensor-id o) out)
+		(princ (tensor-mid o) out)
 		(princ " " out)))
 	    (if ignored-p
 		(with-output-to-string (out)
-		  (format out "~a{~(~a~), ~a}" (tensor-id (second (wfop-args inst))) (dtype (second (wfop-args inst))) (shape (second (wfop-args inst)))))
+		  (format out "~a{~(~a~), ~a}" (tensor-mid (second (wfop-args inst))) (dtype (second (wfop-args inst))) (shape (second (wfop-args inst)))))
 		(if (>= (length (wfop-args inst)) *omit-args-n*)
 		    (format nil "..., x~a,..." (length (wfop-args inst)))
 		    (with-output-to-string (out)
@@ -81,7 +81,7 @@ out_to[0], out_to[1], ... <- λ(Args1 Args2 Args3, ...)
 				  (if sv4
 				      "SV4BW("
 				      "")
-				  (tensor-id var)
+				  (tensor-mid var)
 				  (dtype var)
 				  (shape var)
 				  (if sv4
@@ -275,21 +275,21 @@ out_to[0], out_to[1], ... <- λ(Args1 Args2 Args3, ...)
   (declare (type list iseq))
   
   (loop for inst of-type WfInstruction in iseq do
-	  ;; ViewTensorNode: Result Base -> Result
-	  ;; Set Result.id <- Base.id
-	  (when (or (typep (wfop-node inst) 'cl-waffe2/base-impl::ViewTensorNode))
-	    (iseq-update-tensor-name! iseq
-				      (tensor-id (second (wfop-args inst)))
-				      (tensor-id (car (wfop-args inst)))))
+    ;; ViewTensorNode: Result Base -> Result
+    ;; Set Result.id <- Base.id
+    (when (or (typep (wfop-node inst) 'cl-waffe2/base-impl::ViewTensorNode))
+      (iseq-update-tensor-name! iseq
+				(tensor-mid (second (wfop-args inst)))
+				(tensor-mid (car    (wfop-args inst)))))
 
-	  ;; Reshape, Permute: Result Base -> Base
-	  ;; Base.id <- Result.id
-	  (when (or (typep (wfop-node inst) 'cl-waffe2/base-impl::ReshapeTensorNode)
-		    (typep (wfop-node inst) 'cl-waffe2/base-impl::Permute-Node))
-	    (iseq-update-tensor-name! iseq
-				      (tensor-id (car (wfop-args inst)))
-				      (tensor-id (second (wfop-args inst)))))))
+    ;; Reshape, Permute: Result Base -> Base
+    ;; Base.id <- Result.id
+    (when (or (typep (wfop-node inst) 'cl-waffe2/base-impl::ReshapeTensorNode)
+	      (typep (wfop-node inst) 'cl-waffe2/base-impl::Permute-Node))
+      (iseq-update-tensor-name! iseq
+				(tensor-mid (car    (wfop-args inst)))
+				(tensor-mid (second (wfop-args inst)))))))
 
 
 
-	    
+

--- a/source/vm/nodes/defnode.lisp
+++ b/source/vm/nodes/defnode.lisp
@@ -149,7 +149,7 @@ reject-when=nil, or (apply reject-when inputs)=t"
   ;; [TODO]
   ;; (call node TID1 TID1)
   ;;   ^ should return error
-
+  
   (make-compiled-kernel
    :name name
    :body (replace-tensor->id body args)
@@ -157,7 +157,7 @@ reject-when=nil, or (apply reject-when inputs)=t"
    :self self
    :call-with-view *ranked-loop-result-cacher*
    :cache-when-compiled (if cl-waffe2/vm.generic-tensor::*freeze-call-with-view*
-			    nil
+			    T
 			    traceable?)
    :cache-p (when (and traceable? *call-with-view-route*) t)
    :view-route (if (and traceable? *call-with-view-route*)

--- a/source/vm/nodes/defnode.lisp
+++ b/source/vm/nodes/defnode.lisp
@@ -157,7 +157,7 @@ reject-when=nil, or (apply reject-when inputs)=t"
    :self self
    :call-with-view *ranked-loop-result-cacher*
    :cache-when-compiled (if cl-waffe2/vm.generic-tensor::*freeze-call-with-view*
-			    T
+			    NIL ;; This function should not be used as a cache.
 			    traceable?)
    :cache-p (when (and traceable? *call-with-view-route*) t)
    :view-route (if (and traceable? *call-with-view-route*)

--- a/source/vm/nodes/defnode.lisp
+++ b/source/vm/nodes/defnode.lisp
@@ -146,6 +146,9 @@ reject-when=nil, or (apply reject-when inputs)=t"
    body))
 
 (defun vm-kernel-lambda (traceable? name args self body)
+  ;; [TODO]
+  ;; (call node TID1 TID1)
+  ;;   ^ should return error
   (make-compiled-kernel
    :name name
    :body (replace-tensor->id body args)

--- a/source/vm/nodes/defnode.lisp
+++ b/source/vm/nodes/defnode.lisp
@@ -149,6 +149,7 @@ reject-when=nil, or (apply reject-when inputs)=t"
   ;; [TODO]
   ;; (call node TID1 TID1)
   ;;   ^ should return error
+
   (make-compiled-kernel
    :name name
    :body (replace-tensor->id body args)

--- a/source/vm/nodes/function.lisp
+++ b/source/vm/nodes/function.lisp
@@ -15,14 +15,26 @@
 ;; In order to implemenet "GENERIC" behaviour, we need to wrap composite->defun by higher-order function.
 
 (defun eliminate-undetermined-size (tensor)
-  (let ((place (make-input
-		(cl-waffe2/vm.generic-tensor::translate-adjustable-shape (shape tensor))
-		nil
-		:create-from tensor
-		:dtype (dtype tensor)
-		:order (order tensor)
-		:scalar-p (scalar-p tensor))))
-    (cl-waffe2/vm.generic-tensor::embody-tensor-vec place tensor)
-    ;; set facet = :exist?
-    place))
+  (let* ((shape (cl-waffe2/vm.generic-tensor::translate-adjustable-shape (actual-shape tensor)))
+	 (out (make-input  shape nil
+			   :create-from tensor
+			   :dtype (dtype tensor)
+			   :order (order tensor)
+			   :scalar-p (scalar-p tensor)))
+	 (broadcasted-p)
+	 (broadcasts (loop for size in (cl-waffe2/vm.generic-tensor::translate-adjustable-shape (shape tensor))
+			   for view in (tensor-view tensor)
+			   if (eql :broadcast (cl-waffe2/vm.generic-tensor::viewtype (cl-waffe2/vm.generic-tensor::force-list view)))
+			     collect (and
+				      (setq broadcasted-p t)
+				      `(:broadcast ,size))
+			   else
+			     collect t))
+	 (out (if broadcasted-p
+		  (apply #'cl-waffe2/vm.generic-tensor::view out broadcasts)
+		  out)))
+    
+    (setf (cl-waffe2/vm.generic-tensor::tensor-initial-offset out) (cl-waffe2/vm.generic-tensor::tensor-initial-offset tensor)
+	  (tensor-vec out) (cl-waffe2/vm.generic-tensor::vec tensor))
+    out))
 

--- a/source/vm/nodes/model-compiler.lisp
+++ b/source/vm/nodes/model-compiler.lisp
@@ -6,23 +6,6 @@
 ;; Compiler from Composite (i.e.: CLOS classes defined by defmodel) into another forms (e.g.: function defnode)
 ;;
 
-
-;; [TODO]
-;;- retain_graph option
-;;- Theano likeな動作を目指したい
-;;-  defmodel-as, AbstractNodeのcache
-;;-  Dynamically ShapeとControl Flowでもいいけど、コンパイル速度をもっと高速化してPyTorch-likeに動かす方針も可能っぽい
-;;     -> キャッシュできないdefine-implをdefine-impl-opで全て置き換えることでcompile nilのオーバーヘッドが0になる
-;;     -> call-with-viewのFunction Version apply-rank-iterみたいなのでランクつき演算
-;;     -> defpathでFusionOpをすればSoTAに近い性能目指せるか？
-;;     -> AD: (log 1 + x)とかのFusionで数値的安定性の保証
-;;     -> define-by-run modeでRNN
-;;  memory-pool
-;;   IR: Block内部でAllocateしたTensorはmemory-poolを出たときにFreeする
-
-;; TODO: defmodel-as ... :whereにoutのシンボル名指定しないとError
-;; (make-input `(A)) A=list Tensorにrankを記録させないとAから以降のShapeを推論できなくない？
-
 (defvar *thread-pool-lock* (make-lock "thread cache lock"))
 (defparameter *model-function-cache-form* (make-hash-table))
 (declaim (type hash-table *model-function-cache-form*))
@@ -225,6 +208,7 @@ And manages its allocation not to cause conflicts in the threads."))
 => (defmodel-as (...) :differentiable t)
                               └── Set :differentiable=t or the forward wasn't called."
 					   ',node-name))
+
 				  (let ((dout (read-dout ,self)))
 				    (if (scalar-p dout)
 					(setf (tensor-vec dout)

--- a/source/vm/nodes/model-compiler.lisp
+++ b/source/vm/nodes/model-compiler.lisp
@@ -146,7 +146,8 @@ excepted: AbstractTensor"
 								:construct-backward? need-backward
 								:compile-mode :fastest
 								:fuse-ops t
-								:defmodel-as-from named)))
+								:defmodel-as-from named
+								:dout-add1 nil))) ;; <- Embodied by AbstractNode
 	(values compiled-model trace-tensors)))))
 
 (defun expand-define->function-form (composite where defun-p named

--- a/source/vm/nodes/model-compiler.lisp
+++ b/source/vm/nodes/model-compiler.lisp
@@ -112,9 +112,6 @@ Note that this function isn't subject to lazy-evaluation, and all arguments need
 				else
 				  collect tensor))
 	   (toplevel (apply #'call composite trace-tensors)))
-
-      ;; [FixME] !matmul with transpsosed could be compiled as well?
-      ;; [TODO]  -> Envolve transpose-p option into lazy-evaluation
       
       (unless (typep toplevel 'AbstractTensor)
 	(error "defmodel-as: Attempted to compile the function ~(~a~) but failed because the composite didn't return any AbstractTensor. butgot: ~a
@@ -148,6 +145,8 @@ excepted: AbstractTensor"
 			  (map 'list #'(lambda (tensor)
 					 (list (dtype tensor)
 					       (class-of tensor)
+					       ;;[FIXME] Reusing compiled composite could be the main reason for SegFault!!
+					       (random 1.0)
 					       (length (shape tensor))
 					       (cl-waffe2/vm.generic-tensor:ancestor-param-p tensor)))
 			       (list ,@arguments)))

--- a/source/vm/nodes/model-compiler.lisp
+++ b/source/vm/nodes/model-compiler.lisp
@@ -160,6 +160,8 @@ excepted: AbstractTensor"
 	   (body
 	     (progn
 	       `((declare (type AbstractTensor ,@arguments))
+		 ;; tensor-vec=Eliminate InputTensor with no existing vec.
+		 (mapc #'tensor-vec (list ,@arguments))
 		 (let* ((,dispatching-keys
 			  ;; Dispatching compiled methods by, :DTYPE, DEVICE, RANK, REQUIRES_GRAD_P
 			  (map 'list #'(lambda (tensor)
@@ -258,6 +260,8 @@ And manages its allocation not to cause conflicts in the threads."))
 	   (defun ,named (,@in-names)
 	     (declare (type AbstractTensor ,@in-names))
 	     ;; in-names=number -> make-tensor auto?
+	     ;; tensor-vec=Eliminate InputTensor with no existing vec.
+	     (mapc #'tensor-vec (list ,@in-names))
 	     (call (,node-name ,@in-names) ,@in-names)))))))
 	       
 ;; [Exported]

--- a/source/vm/nodes/model-compiler.lisp
+++ b/source/vm/nodes/model-compiler.lisp
@@ -19,7 +19,7 @@
 
 (defun thread-cache-table (&optional (idx nil))
   (with-lock-held (*thread-pool-lock*)
-    (let ((memory-pool	   
+    (let ((memory-pool
 	    (gethash (or idx (current-thread)) *model-function-cache-form*)))
       (if memory-pool
 	  memory-pool
@@ -41,9 +41,7 @@
 (defun read-from-cache (key)
   (let ((table (thread-cache-table)))
     (or (gethash key table)
-	(progn
-	  (setf (gethash key table) (make-hash-table :test #'equal))
-	  (gethash key table)))))
+	(setf (gethash key table) (make-hash-table :test #'equal)))))
 	  
 	       
 (defun read-where-args (where)
@@ -157,7 +155,7 @@ excepted: AbstractTensor"
 		   (if ,found-function
 		       ;; [TODO] Shape Inspection
 		       ,(if get-model
-			    found-function			   
+			    found-function
 			     `(forward ,found-function ,@arguments))
 		       (let ((,found-function (trace-and-compile-composite
 						,need-backward

--- a/source/vm/nodes/model-compiler.lisp
+++ b/source/vm/nodes/model-compiler.lisp
@@ -101,13 +101,18 @@ Note that this function isn't subject to lazy-evaluation, and all arguments need
 				if (and need-backward
 					(cl-waffe2/vm.generic-tensor:ancestor-param-p arg))
 				  collect (progn
-					    (setf (slot-value tensor 'requires-grad) t
+					    (setf (slot-value tensor 'requires-grad) t						  
+						  (cl-waffe2/vm.generic-tensor::tensor-id-lock-p tensor) T
 						  (slot-value tensor 'cl-waffe2/vm.generic-tensor::grad)
 						  (make-input (shape tensor) nil
 							      :create-from tensor
 							      :scalar-p (scalar-p tensor)
 							      :dtype    (dtype tensor)
 							      :order    (order tensor)))
+					    ;; Never moved by compiler
+					    (setf (cl-waffe2/vm.generic-tensor::tensor-id-lock-p
+						   (cl-waffe2/vm.generic-tensor::grad tensor))
+						  T)
 					    tensor)
 				else
 				  collect tensor))
@@ -145,7 +150,7 @@ excepted: AbstractTensor"
 			  (map 'list #'(lambda (tensor)
 					 (list (dtype tensor)
 					       (class-of tensor)
-					       ;; [FIXME] Reusing compiled composite could be the main reason for SegFault!!
+					       ;; [FIXME] Reusing gcompiled composite could be the main reason for SegFault!!
 					       ;; [FIXME] The size of something (like gradients) could be FIXED, and IMMUTABLE
 					       ;; Even when the node is cached
 					       ;; It should be dispatched by ranks, but helplessly uses shape

--- a/source/vm/nodes/model-compiler.lisp
+++ b/source/vm/nodes/model-compiler.lisp
@@ -172,7 +172,6 @@ excepted: AbstractTensor"
 					       (cl-waffe2/vm.generic-tensor:ancestor-param-p tensor)))
 			       (list ,@arguments)))
 			(,found-function (gethash ,dispatching-keys (read-from-cache ,cache-key))))
-		  
 		   (if ,found-function
 		       ;; [TODO] Shape Inspection
 		       ,(if get-model
@@ -186,7 +185,7 @@ excepted: AbstractTensor"
 						',composite-input-size
 						',arguments
 						,@arguments)))
-			  ;; cache it
+			 ;; cache it
 			 (setf (gethash ,dispatching-keys (read-from-cache ,cache-key)) ,found-function)
 			 ,(if get-model
 			      found-function
@@ -216,7 +215,7 @@ And manages its allocation not to cause conflicts in the threads."))
 		       :where    ,where
 		       :extends 'AbstractCompositeNode
 		       :forward ((,self ,@in-names)
-				 (let ((out (multiple-value-list (forward (read-compiled-model ,self) ,@in-names))))				   
+				 (let ((out (multiple-value-list (forward (read-compiled-model ,self) ,@in-names))))
 				   (when (every #'scalar-p out)
 				     (setf (out-scalar-p ,self) t))
 				   (apply #'values out)))

--- a/source/vm/nodes/model-compiler.lisp
+++ b/source/vm/nodes/model-compiler.lisp
@@ -212,7 +212,7 @@ And manages its allocation not to cause conflicts in the threads."))
 	`(progn
 	   (define-op (,node-name (,self ,@in-names)
 		       :where    ,where
-		       :extends 'AbstractCompositeNode
+		       :extends (AbstractCompositeNode)
 		       :forward ((,self ,@in-names)
 				 (let ((out (multiple-value-list (forward (read-compiled-model ,self) ,@in-names))))
 				   (when (every #'scalar-p out)

--- a/source/vm/nodes/model-compiler.lisp
+++ b/source/vm/nodes/model-compiler.lisp
@@ -145,9 +145,11 @@ excepted: AbstractTensor"
 			  (map 'list #'(lambda (tensor)
 					 (list (dtype tensor)
 					       (class-of tensor)
-					       ;;[FIXME] Reusing compiled composite could be the main reason for SegFault!!
-					       (random 1.0)
-					       (length (shape tensor))
+					       ;; [FIXME] Reusing compiled composite could be the main reason for SegFault!!
+					       ;; [FIXME] The size of something (like gradients) could be FIXED, and IMMUTABLE
+					       ;; Even when the node is cached
+					       ;; It should be dispatched by ranks, but helplessly uses shape
+					       (shape tensor)
 					       (cl-waffe2/vm.generic-tensor:ancestor-param-p tensor)))
 			       (list ,@arguments)))
 			(,found-function (gethash ,dispatching-keys (read-from-cache ,cache-key))))

--- a/source/vm/nodes/model-compiler.lisp
+++ b/source/vm/nodes/model-compiler.lisp
@@ -317,7 +317,7 @@ Redefines a Composite as a new function or AbstractNode specified in the `:asif`
 ─────────────────────────────────────────────────────────────────────────────────────
 :function | Defines a function to be executed immediately that does not create a node.
 ─────────────────────────────────────────────────────────────────────────────────────
-:node     | Defines a AbstractNode which needs to be compiler later
+:node     | Defines a AbstractNode which needs to be compiled later
 ─────────────────────────────────────────────────────────────────────────────────────
 ```
 
@@ -342,7 +342,7 @@ Choose :asif option from:
 ─────────────────────────────────────────────────────────────────────────────────────
 :function | Defines a function to be executed immediately that does not create a node.
 ─────────────────────────────────────────────────────────────────────────────────────
-:node     | Defines a AbstractNode which needs to be compiler later
+:node     | Defines a AbstractNode which needs to be compiled later
 ─────────────────────────────────────────────────────────────────────────────────────
 "
 	   asif))

--- a/source/vm/nodes/model-compiler.lisp
+++ b/source/vm/nodes/model-compiler.lisp
@@ -159,6 +159,8 @@ This is because the argument ~a wasn't appeared in leaves, that is, your network
 	      (declare (optimize (speed 3)))
 	      (cl-waffe2/vm.generic-tensor::with-adjustable-symbol-scope
 		(apply #'shape-compatible? composite received-arguments)
+		;; Allocate arguments outside the function's scope
+		(mapc #'tensor-vec received-arguments)
 		
 		(loop for arg of-type AbstractTensor in received-arguments
 		      for place                      in input-tensors do
@@ -231,6 +233,7 @@ This is because the argument ~a wasn't appeared in leaves, that is, your network
 			       (allocation   :initform nil))
 		       :forward ((,self ,@in-names)
 				 (cl-waffe2/vm.generic-tensor::with-adjustable-symbol-scope
+				   (mapc #'tensor-vec (list ,@in-names))
 				   (cl-waffe2/vm::with-static-allocation ((slot-value ,self 'allocation))
 				     (let ((out (cl-waffe2/vm:accept-instructions (slot-value ,self 'fw-iseq))))				   
 				       (when (scalar-p out)

--- a/source/vm/nodes/model-compiler.lisp
+++ b/source/vm/nodes/model-compiler.lisp
@@ -144,7 +144,6 @@ excepted: AbstractTensor"
       (let ((compiled-model (cl-waffe2/vm.generic-tensor::build toplevel
 								:inputs (map 'list #'tensor-name trace-tensors)
 								:construct-backward? need-backward
-								:compile-mode :fastest
 								:fuse-ops t
 								:defmodel-as-from named
 								:dout-add1 nil))) ;; <- Embodied by AbstractNode

--- a/source/vm/nodes/model-compiler.lisp
+++ b/source/vm/nodes/model-compiler.lisp
@@ -210,7 +210,7 @@ And manages its allocation not to cause conflicts in the threads."))
       (with-gensyms (self dy)
 	`(progn
 	   (define-op (,node-name (,self ,@in-names)
-		       :where      ,where
+		       :where    ,where
 		       :extends 'AbstractCompositeNode
 		       :forward ((,self ,@in-names)
 				 (let ((out (multiple-value-list (forward (read-compiled-model ,self) ,@in-names))))				   
@@ -240,8 +240,8 @@ And manages its allocation not to cause conflicts in the threads."))
 						 if (cl-waffe2/vm.generic-tensor:grad argument)
 						   collect (cl-waffe2/vm.generic-tensor:grad argument)
 						 else
-						   collect nil)))))	     
-	     (setf (read-compiled-model ,self) (,(symb named '-model) ,@in-names)
+						   collect nil)))))
+	     (setf (read-compiled-model ,self) (cl-waffe2/vm.generic-tensor::copy-compiled-model (,(symb named '-model) ,@in-names))
 		   (read-dout ,self) (cl-waffe2/vm.generic-tensor::compiled-dout (read-compiled-model ,self))))
 
 	   (defun ,(symb named '-model) (,@in-names)

--- a/source/vm/nodes/node.lisp
+++ b/source/vm/nodes/node.lisp
@@ -218,9 +218,9 @@ butgot: ~a"
 					 
 					 (tensor-view next-tensor)
 					 (tensor-view input)
+					 
+					 (slot-value next-tensor 'cl-waffe2/vm.generic-tensor::tensor-id) (tensor-id input)
 
-					 ;; Memo: extending tensor-id is added later...
-					 (tensor-id next-tensor) (tensor-id input)
 					 (tensor-name next-tensor) (tensor-name input)
 					 (slot-value next-tensor 'cl-waffe2/vm.generic-tensor::projected-p)
 					 (slot-value input 'cl-waffe2/vm.generic-tensor::projected-p)

--- a/source/vm/nodes/node.lisp
+++ b/source/vm/nodes/node.lisp
@@ -284,7 +284,7 @@ forward: Couldn't step forward step of ~a because it is undefined.
 					(cl-waffe2/vm.generic-tensor:make-clone var nil nil))))
 	  (dout (cl-waffe2/vm.generic-tensor::make-clone dout)))
 
-      (setf (tensor-protect-me dout) t)
+      ;;(setf (tensor-protect-me dout) t)
       (let* ((out-toplevels (multiple-value-list (apply #'backward node dout in-tensors)))
 	     (out-toplevels (if (every #'null out-toplevels) ;; no gradients?
 				(return-from make-backward)
@@ -307,9 +307,9 @@ forward: Couldn't step forward step of ~a because it is undefined.
 								   :compile-mode :fastest
 								   :optimize-locality nil)))
 	     (fw-iseq (car compiled))
-	     (leaves  (third compiled)))
-	
-	(cl-waffe2/vm::apply-in-place-mutation! fw-iseq leaves)
+	     ;;(leaves  (third compiled))
+	     )
+	;;(cl-waffe2/vm::apply-in-place-mutation! fw-iseq leaves)
 	(values
 	 #'(lambda (dout-runtime &rest inputs-runtime)
 	     (setf (tensor-vec dout) (tensor-vec dout-runtime))

--- a/source/vm/nodes/node.lisp
+++ b/source/vm/nodes/node.lisp
@@ -283,6 +283,7 @@ forward: Couldn't step forward step of ~a because it is undefined.
 			    collect (or (system-lazy-read-save-for-backward var)
 					(cl-waffe2/vm.generic-tensor:make-clone var nil nil))))
 	  (dout (cl-waffe2/vm.generic-tensor::make-clone dout)))
+
       (setf (tensor-protect-me dout) t)
       (let* ((out-toplevels (multiple-value-list (apply #'backward node dout in-tensors)))
 	     (out-toplevels (if (every #'null out-toplevels) ;; no gradients?
@@ -303,12 +304,12 @@ forward: Couldn't step forward step of ~a because it is undefined.
 			(cl-waffe2/vm:compile-forward-and-backward toplevel
 								   :need-backward nil
 								   :fuse-p t
-								   :compile-mode :fastest)))
+								   :compile-mode :fastest
+								   :optimize-locality nil)))
 	     (fw-iseq (car compiled))
 	     (leaves  (third compiled)))
-
-	(cl-waffe2/vm::apply-in-place-mutation! fw-iseq leaves)
 	
+	(cl-waffe2/vm::apply-in-place-mutation! fw-iseq leaves)
 	(values
 	 #'(lambda (dout-runtime &rest inputs-runtime)
 	     (progn;;cl-waffe2/vm.generic-tensor::with-memory-pool

--- a/source/vm/nodes/package.lisp
+++ b/source/vm/nodes/package.lisp
@@ -4,7 +4,7 @@
 (defpackage :cl-waffe2/vm.nodes.facets-tmp (:use :cl))
 
 (defpackage :cl-waffe2/vm.nodes
-  (:use :cl :cl-ppcre :alexandria)
+  (:use :cl :cl-ppcre :alexandria :bordeaux-threads)
   (:import-from :cl-waffe2/vm.generic-tensor
 		#:AbstractTensor
 		#:*using-backend*

--- a/source/vm/nodes/package.lisp
+++ b/source/vm/nodes/package.lisp
@@ -24,6 +24,7 @@
 		#:actual-shape
 		#:set-input
 		#:tensor-stride
+		#:detach-p
 		#:compile-option-t
 		#:movetensor-p
 		#:shaping-error

--- a/source/vm/nodes/static-node.lisp
+++ b/source/vm/nodes/static-node.lisp
@@ -39,6 +39,7 @@
 	;; Make clone and allocate
 	;; [FIXME] Is this tensor creation gc-reachable??
 	(let ((place (cl-waffe2/vm.generic-tensor::make-clone-exist tensor)))
+	  (setf (cl-waffe2/vm.generic-tensor::tensor-id-lock-p place) T)
 	  ;; Do allocation of place
 	  ;; Set it to the slot
 	  (setf (slot-value self name) place)))
@@ -46,7 +47,6 @@
       (cl-waffe2/vm::%vm-move (slot-value self name) tensor)
 
       ;; FixME
-
       (when (and (scalar-p (slot-value self name))
 		 (scalar-p tensor))
 	(setf (tensor-vec (slot-value self name)) (cl-waffe2/vm.generic-tensor::vec tensor)))))

--- a/source/vm/nodes/static-node.lisp
+++ b/source/vm/nodes/static-node.lisp
@@ -45,6 +45,7 @@
 
       ;; Move: Existing Save-For-Backward-Place <- The target tensor.
       ;;(move-and-save-for-backward-static (slot-value self name) tensor)
+      ;; do not proceed, defmodel-as!
       (cl-waffe2/base-impl:proceed (cl-waffe2/base-impl:!move (slot-value self name) tensor :force t))
 
       nil)))

--- a/source/vm/nodes/static-node.lisp
+++ b/source/vm/nodes/static-node.lisp
@@ -43,7 +43,13 @@
 	  ;; Set it to the slot
 	  (setf (slot-value self name) place)))
 
-      (cl-waffe2/vm::%vm-move (slot-value self name) tensor)))
+      (cl-waffe2/vm::%vm-move (slot-value self name) tensor)
+
+      ;; FixME
+
+      (when (and (scalar-p (slot-value self name))
+		 (scalar-p tensor))
+	(setf (tensor-vec (slot-value self name)) (cl-waffe2/vm.generic-tensor::vec tensor)))))
   nil)
 
 (defun apply-read-save-for-backward (self name)

--- a/source/vm/nodes/static-node.lisp
+++ b/source/vm/nodes/static-node.lisp
@@ -37,18 +37,14 @@
       ;; Save For Backward hasn't created yet?
       (when (null past-sv4bw)
 	;; Make clone and allocate
-	(let ((place (cl-waffe2/vm.generic-tensor::make-clone tensor)))
+	;; [FIXME] Is this tensor creation gc-reachable??
+	(let ((place (cl-waffe2/vm.generic-tensor::make-clone-exist tensor)))
 	  ;; Do allocation of place
-	  (tensor-vec place)
 	  ;; Set it to the slot
 	  (setf (slot-value self name) place)))
 
-      ;; Move: Existing Save-For-Backward-Place <- The target tensor.
-      ;;(move-and-save-for-backward-static (slot-value self name) tensor)
-      ;; do not proceed, defmodel-as!
-      (cl-waffe2/base-impl:proceed (cl-waffe2/base-impl:!move (slot-value self name) tensor :force t))
-
-      nil)))
+      (cl-waffe2/vm::%vm-move (slot-value self name) tensor)))
+  nil)
 
 (defun apply-read-save-for-backward (self name)
   (declare (type AbstractNode self)

--- a/source/vm/nodes/static-node.lisp
+++ b/source/vm/nodes/static-node.lisp
@@ -185,8 +185,7 @@ Saves the given tensors to save-place, in the currently working node.
 			(save-for-backward-names nil)
 			(forward nil)
 			(backward nil)
-			(extends-fw nil)
-			(extends-bw nil)
+			(extends nil)
 			(documentation ""))
 		     &body constructor-body)
   "
@@ -197,7 +196,7 @@ Saves the given tensors to save-place, in the currently working node.
 Defines a differentiable AbstractNode which its definition is given by a function.
 
 ```lisp
-(define-op (name (self &rest constructor-args) where slots out-scalar-p save-for-backward-names forward backward documentation extends-fw extends-bw) &body body)
+(define-op (name (self &rest constructor-args) where slots out-scalar-p save-for-backward-names forward backward documentation extends) &body body)
 ```
 
 ### Effects
@@ -268,7 +267,7 @@ butgot -> ~a"
 		     :out-scalar-p ,out-scalar-p
 		     :slots (,@slots
 			     ,@save-for-backward-slots)
-		     :extends ,extends-fw
+		     :extends ,extends
 		     :documentation ,documentation)
 	     ,@constructor-body)
 	   
@@ -294,7 +293,7 @@ butgot -> ~a"
 					   append
 					   `(,(symb 'in-shapes n) = (nth ,n ,in-shape))))
 		     :slots ((fw-self :initform nil))
-		     :extends ,extends-bw)
+		     :extends ,extends)
 	     (setf (slot-value ,self 'fw-self) ,fw-self
 		   (ignore-shape-error ,self) t))
 	   

--- a/source/vm/optimize-ir.lisp
+++ b/source/vm/optimize-ir.lisp
@@ -182,7 +182,8 @@ Not replaced until the `query-list` matches everything, including the order.
     (dolist (arg (wfop-args i))
       (setf (detach-p arg) nil))))
 
-;; Test this:
+
+;; [TODO] Update this algorithm: Since MoveTensorNode(SAVE_FOR_BACKWARD) is eliminated in the InstructionSeq
 (defun apply-path-fusion (iseq &key (limit 3) (count 0))
   "`apply-path-fusions` start searching all replaceable combination of InstructionSeq declared via `defpath`, and replaces the IR.
 The operation will continue until count=limit or there's no changes."

--- a/source/vm/optimize-ir.lisp
+++ b/source/vm/optimize-ir.lisp
@@ -1,10 +1,11 @@
 
 (in-package :cl-waffe2/vm)
 
-;; This file isn't used anymore for a while
 ;; TODO:
 ;;  Add a macro named `defpath`
 ;;  We create a search-based fuse-ops, which is user-extensible
+;;  DO TESTS!!!!!
+;;  diff(exp(log))=1 , log(1+x), etc...
 
 ;; defpath possess these datum:
 ;;  1. Nodes to be replaced

--- a/source/vm/optimize-ir.lisp
+++ b/source/vm/optimize-ir.lisp
@@ -263,12 +263,3 @@ The operation will continue until count=limit or there's no changes."
 	  iseq
 	  (apply-path-fusion iseq :limit limit :count (1+ count))))))
 
-;; [TODO] Static Allocation Scheduling
-
-(defun schedule-static-allocation! (iseq leaves)
-  (declare (type list iseq)
-	   (type list leaves))
-
-  ;; 最後のTensorの使用地点を特定する O(n^2)
-  ;; ^ 下からTraceすればO(n)
-  nil)

--- a/source/vm/package.lisp
+++ b/source/vm/package.lisp
@@ -8,6 +8,10 @@
    :cl-waffe2/vm.nodes
    :cl-waffe2/base-impl)
   (:export
+   #:*safety-mode-p*
+   #:*logging-vm-execution*
+
+   
    #:accept-instructions
    #:compile-forward-and-backward
    #:disassemble-waffe2-ir

--- a/source/vm/utils.lisp
+++ b/source/vm/utils.lisp
@@ -15,7 +15,6 @@
                            :initial-value (apply fn1 args))))
       #'identity))
 
-;; Ref: http://www.utkuevci.com/ml/autograd/
 (defun topological-sort (var)
   (declare (type AbstractTensor var)
 	   (optimize (speed 3)))
@@ -35,7 +34,6 @@
 		     (push v top-sort)))))
       (top-sort-helper var (detach-p var))
       (reverse top-sort))))
-
 
 ;; Autograd:
 (defun make-backward-wfinst (tensor dout-prev)
@@ -249,3 +247,4 @@ op2 ..  E <- F(X, Y, Z)
 		     (grad tensor)
 		     grad)))))))
     (setf (detach-p grad) nil)))
+

--- a/source/vm/utils.lisp
+++ b/source/vm/utils.lisp
@@ -200,12 +200,16 @@ op2 ..  E <- F(X, Y, Z)
     (setf (tensor-state tensor)
 	  (make-statecontainer :forward-out-form (make-compiled-kernel)))))
 
+(defun setq-vm-wrap-f ()
+  "To avoid iseq=null, adds this node"
+  "Setq{%VMWrap}")
+
 (defun %vm-wrap-tensor (tensor)
   (init-state-container! tensor)
   (make-wfop
    #'(lambda (x) (declare (ignore x)) tensor)
    tensor
-   #'(lambda () (format nil "Setq{Internal}"))
+   #'setq-vm-wrap-f
    (list tensor)
    :out-to (list tensor)))
 
@@ -236,8 +240,10 @@ op2 ..  E <- F(X, Y, Z)
 		     (cl-waffe2/base-impl:MoveTensorNode
 		      (dtype tensor)
 		      :save-for-backward
-		      (or (tensor-projected-p grad)
-			  (cl-waffe2/vm.generic-tensor::permuted-p  grad)))
+		      ;;(or (tensor-projected-p grad)
+		      ;;  (cl-waffe2/vm.generic-tensor::permuted-p  grad))
+		      t
+		      )
 		     (grad tensor)
 		     grad)))
 		 (progn

--- a/source/vm/utils.lisp
+++ b/source/vm/utils.lisp
@@ -100,9 +100,9 @@
     `(lambda (&rest ,args)
        (let  (,@(loop for tensor in all-args
 		      for nth upfrom 0
-		      if (not (find (tensor-mid tensor) seen))
-			collect `(,(tensor-mid tensor) (nth ,nth ,args))
-		      do (push (tensor-mid tensor) seen)))
+		      if (not (find (tensor-id tensor) seen))
+			collect `(,(tensor-id tensor) (nth ,nth ,args))
+		      do (push (tensor-id tensor) seen)))
 	 (locally
 	     ,@(cl-waffe2/vm.nodes::replace-tensor->id
 		other-parts
@@ -190,8 +190,8 @@ op2 ..  E <- F(X, Y, Z)
   (let ((fused-p (wfop-fuse-prev fused-iseq)))
     (or (null fused-p)
 	(let* ((inst-list (apply #'collect-fused-ops fused-p))
-	       (prev-vars (map 'list (compose #'tensor-mid #'wfop-self) inst-list)))
-	  (not (find (tensor-mid (wfop-self instruction)) prev-vars))))))
+	       (prev-vars (map 'list (compose #'tensor-id #'wfop-self) inst-list)))
+	  (not (find (tensor-id (wfop-self instruction)) prev-vars))))))
 
 (defun node-out-to (node) (cl-waffe2/vm.nodes::node-out-to node))
 
@@ -250,12 +250,4 @@ op2 ..  E <- F(X, Y, Z)
 		     (grad tensor)
 		     grad)))))))
     (setf (detach-p grad) nil)))
-
-(defun reset-locality-optimizations! (iseq &optional (overwrite t))
-  (loop for inst in iseq do
-    (mapc #'(lambda (tensor)
-	      (when tensor
-		(if (if overwrite T (null (tensor-mid tensor)))
-		    (setf (tensor-mid tensor) (tensor-id tensor)))))
-	  `(,@(wfop-out-to inst) ,@(wfop-args inst) ,@(wfop-sv4bw inst)))))
 

--- a/source/vm/utils.lisp
+++ b/source/vm/utils.lisp
@@ -240,10 +240,7 @@ op2 ..  E <- F(X, Y, Z)
 		     (cl-waffe2/base-impl:MoveTensorNode
 		      (dtype tensor)
 		      :save-for-backward
-		      ;;(or (tensor-projected-p grad)
-		      ;;  (cl-waffe2/vm.generic-tensor::permuted-p  grad))
-		      t
-		      )
+		      t)
 		     (grad tensor)
 		     grad)))
 		 (progn

--- a/source/vm/utils.lisp
+++ b/source/vm/utils.lisp
@@ -100,11 +100,11 @@
     `(lambda (&rest ,args)
        (let  (,@(loop for tensor in all-args
 		      for nth upfrom 0
-		      if (not (find (tensor-id tensor) seen))
-			collect `(,(tensor-id tensor) (nth ,nth ,args))
-		      do (push (tensor-id tensor) seen)))
+		      if (not (find (tensor-mid tensor) seen))
+			collect `(,(tensor-mid tensor) (nth ,nth ,args))
+		      do (push (tensor-mid tensor) seen)))
 	 (locally
-	     ,@(cl-waffe2/vm.generic-tensor::tensor->id
+	     ,@(cl-waffe2/vm.nodes::replace-tensor->id
 		other-parts
 		all-args))))))
 
@@ -190,8 +190,8 @@ op2 ..  E <- F(X, Y, Z)
   (let ((fused-p (wfop-fuse-prev fused-iseq)))
     (or (null fused-p)
 	(let* ((inst-list (apply #'collect-fused-ops fused-p))
-	       (prev-vars (map 'list (compose #'tensor-id #'wfop-self) inst-list)))
-	  (not (find (tensor-id (wfop-self instruction)) prev-vars))))))
+	       (prev-vars (map 'list (compose #'tensor-mid #'wfop-self) inst-list)))
+	  (not (find (tensor-mid (wfop-self instruction)) prev-vars))))))
 
 (defun node-out-to (node) (cl-waffe2/vm.nodes::node-out-to node))
 
@@ -250,4 +250,12 @@ op2 ..  E <- F(X, Y, Z)
 		     (grad tensor)
 		     grad)))))))
     (setf (detach-p grad) nil)))
+
+(defun reset-locality-optimizations! (iseq &optional (overwrite t))
+  (loop for inst in iseq do
+    (mapc #'(lambda (tensor)
+	      (when tensor
+		(if (if overwrite T (null (tensor-mid tensor)))
+		    (setf (tensor-mid tensor) (tensor-id tensor)))))
+	  `(,@(wfop-out-to inst) ,@(wfop-args inst) ,@(wfop-sv4bw inst)))))
 

--- a/source/vm/vm.lisp
+++ b/source/vm/vm.lisp
@@ -39,7 +39,7 @@ If set to T, the result is displayed on the terminal with the arguments used eac
 	      (tensor-vec place)
 	      (tensor-vec var)
 	      (%vm-move place var)
-
+	      
 	      ;; FixME: Delete this line:
 	      (when (scalar-p place)
 		(setf (tensor-vec place) (tensor-vec var))))))
@@ -79,7 +79,8 @@ If set to T, the result is displayed on the terminal with the arguments used eac
 		;;  displayed as [computed] in the terminal.
 		;; ScalarTensors never use Memory-Pool
 		;; Update Memory-Pool
-		(setf (tensor-vec (read-from-mempool-tensor tensor)) (cl-waffe2/vm.generic-tensor::vec result))
+		;;(setf (tensor-vec (read-from-mempool-tensor tensor)) (cl-waffe2/vm.generic-tensor::vec result))
+		(update-alloc-vec! tensor result)
 		;; Tensor is already broadcasted/permuted...
 		;; So sharing vec is enough.
 		(setf (tensor-vec tensor) (cl-waffe2/vm.generic-tensor::vec result))

--- a/source/vm/vm.lisp
+++ b/source/vm/vm.lisp
@@ -46,7 +46,7 @@
 	for result in results
 	if  result do
 	  (if (tensor-tmp-p tensor)
-	      (setf (tensor-vec tensor) (tensor-vec result))
+	      (cl-waffe2/vm.generic-tensor::embody-tensor-vec tensor result)
 	      (let* ((state (tensor-state tensor)))
 		(setf (cl-waffe2/vm.generic-tensor::statecontainer-forward-result state) result)))))
 

--- a/source/vm/vm.lisp
+++ b/source/vm/vm.lisp
@@ -34,9 +34,6 @@ If set to T, the result is displayed on the terminal with the arguments used eac
       (loop for var   in variables
 	    for place in places
 	    if (and place var) do
-	      (print place)
-	      (print var)
-	      ;; Place <- Var
 	      (%vm-move place var))))
   nil)
 
@@ -44,7 +41,10 @@ If set to T, the result is displayed on the terminal with the arguments used eac
 (defun maybe-read-result (tensor)
   (declare (type AbstractTensor tensor))
   (if (tensor-tmp-p tensor)
-      tensor
+      (let ((out (read-from-mempool-tensor tensor)))
+	;; Keep Broadcasting, Permution etc... But storages are shared.
+	(setf (tensor-vec tensor) (cl-waffe2/vm.generic-tensor::vec out))
+	tensor)
       (if (scalar-p tensor)
 	  tensor
 	  (let* ((state (tensor-state tensor))

--- a/source/vm/vm.lisp
+++ b/source/vm/vm.lisp
@@ -67,9 +67,11 @@ If set to T, the result is displayed on the terminal with the arguments used eac
   ;; [TODO] Runtime Shape-Error Detection
   (loop for tensor of-type AbstractTensor in tensors
 	for result in results
-	if  result do
+	if  (and tensor result) do
 	  (if (tensor-tmp-p tensor)
 	      (progn
+		;; tensor ... out-to
+		;; results ... result
 		;; Tensors registerd in the memory-pool,
 		;; doesn't need the support of StateContainer anymore
 		;; Deleting Unused StateContainer will benefit:
@@ -78,7 +80,6 @@ If set to T, the result is displayed on the terminal with the arguments used eac
 		;; ScalarTensors never use Memory-Pool
 		;; Update Memory-Pool
 		(setf (tensor-vec (read-from-mempool-tensor tensor)) (cl-waffe2/vm.generic-tensor::vec result))
-		;;(tensor-vec result)
 		;; Tensor is already broadcasted/permuted...
 		;; So sharing vec is enough.
 		(setf (tensor-vec tensor) (cl-waffe2/vm.generic-tensor::vec result))
@@ -98,13 +99,12 @@ If set to T, the result is displayed on the terminal with the arguments used eac
     (let* ((inst (format nil "~a" instruction))
 	   (cnt  (length inst)))
       (format t "= [*logging-vm-execution*] ~a
-Instruction: ~a
-args:
-~a"
+Instruction: ~a"
 	      (with-output-to-string (out)
 		(dotimes (i cnt) (princ "=" out)))
 	      inst
-	      (map 'list #'maybe-read-result (wfop-args instruction)))))
+	      ;;(map 'list #'maybe-read-result (wfop-args instruction))
+	      )))
 
   
   (let ((outs (multiple-value-list
@@ -166,8 +166,8 @@ Butgot:
     (when *logging-vm-execution*
       (format t "
 outs:
-~a~%"
-	      outs))
+~%"
+	      ))
     outs))
 
 (declaim (ftype (function (list) t) accept-instructions))

--- a/source/vm/vm.lisp
+++ b/source/vm/vm.lisp
@@ -355,7 +355,7 @@ CL-WAFFE2-REPL>
 		   (loop for nth being the hash-keys in profiled-result do
 		     (let ((i (gethash nth inst->node-table)))
 		       (dolist (var (wfop-args i))
-			 (push (tensor-id var) tensor-ids))
+			 (push (tensor-mid var) tensor-ids))
 		       
 		       ;; Put the result of benchmark
 		       (let* ((times (gethash nth profiled-result))

--- a/source/vm/vm.lisp
+++ b/source/vm/vm.lisp
@@ -53,7 +53,6 @@ If set to T, the result is displayed on the terminal with the arguments used eac
   (if (tensor-tmp-p tensor)
       (let ((out (read-from-mempool-tensor tensor)))
 	;; Keep Broadcasting, Permution etc... But storages are shared.
-	(setf (tensor-state tensor) nil)
 	(setf (tensor-vec tensor) (cl-waffe2/vm.generic-tensor::vec out))
 	tensor)
       (if (scalar-p tensor)
@@ -73,8 +72,14 @@ If set to T, the result is displayed on the terminal with the arguments used eac
 	if  result do
 	  (if (tensor-tmp-p tensor)
 	      (progn
+		;; Tensors registerd in the memory-pool,
+		;; doesn't need the support of StateContainer anymore
+		;; Deleting Unused StateContainer will benefit:
+		;;  The returned tensor by the proceed function is
+		;;  displayed as [computed] in the terminal.
+		(setf (tensor-vec tensor) nil)
 		;; ScalarTensors never use Memory-Pool
-		;; Update Memory-Pool		
+		;; Update Memory-Pool
 		(setf (tensor-vec (read-from-mempool-tensor tensor)) (cl-waffe2/vm.generic-tensor::vec result))
 		;;(tensor-vec result)
 		;; Tensor is already broadcasted/permuted...

--- a/source/vm/vm.lisp
+++ b/source/vm/vm.lisp
@@ -34,6 +34,8 @@ If set to T, the result is displayed on the terminal with the arguments used eac
       (loop for var   in variables
 	    for place in places
 	    if (and place var) do
+	      (print place)
+	      (print var)
 	      ;; Place <- Var
 	      (%vm-move place var))))
   nil)

--- a/source/vm/vm.lisp
+++ b/source/vm/vm.lisp
@@ -75,7 +75,6 @@ If set to T, the result is displayed on the terminal with the arguments used eac
 		;; Deleting Unused StateContainer will benefit:
 		;;  The returned tensor by the proceed function is
 		;;  displayed as [computed] in the terminal.
-		;;(setf (tensor-state tensor) nil)
 		;; ScalarTensors never use Memory-Pool
 		;; Update Memory-Pool
 		(setf (tensor-vec (read-from-mempool-tensor tensor)) (cl-waffe2/vm.generic-tensor::vec result))

--- a/source/vm/vm.lisp
+++ b/source/vm/vm.lisp
@@ -11,13 +11,7 @@
 
 (defmodel-as (SV4BW-Copier)
   :where (A[~] B[~] -> OUT[~])
-  :asif :function :named %vm-move1)
-
-(defun %vm-move (a b)
-  ;; A <- B
-  (print a)
-  (print b)
-  (%vm-move1 a b))
+  :asif :function :named %vm-move)
 
 (declaim (ftype (function (WfInstruction) t) apply-inst-sv4bw))
 (defun apply-inst-sv4bw (instruction)

--- a/source/vm/vm.lisp
+++ b/source/vm/vm.lisp
@@ -6,7 +6,7 @@
 
 When set to T, a run-time error is detected and a warning is displayed.")
 
-(defparameter *logging-vm-execution* NIL "
+(defparameter *logging-vm-execution* NIl "
 ## [parameter] *logging-vm-execution*
 
 If set to T, the result is displayed on the terminal with the arguments used each time cl-waffe2 VM executes an instruction. In default, set to nil
@@ -42,8 +42,7 @@ If set to T, the result is displayed on the terminal with the arguments used eac
 (defun maybe-read-result (tensor)
   (declare (type AbstractTensor tensor))
   (if (tensor-tmp-p tensor)
-      (let ((out (read-from-mempool-tensor tensor)))
-	out)
+      tensor
       (if (scalar-p tensor)
 	  tensor
 	  (let* ((state (tensor-state tensor))
@@ -60,7 +59,12 @@ If set to T, the result is displayed on the terminal with the arguments used eac
 	for result in results
 	if  result do
 	  (if (tensor-tmp-p tensor)
-	      (update-mempool-tensor tensor result) ;; Tensor.ID <- Result
+	      (progn
+		;; Update Memory-Pool
+		(setf (tensor-vec (read-from-mempool-tensor tensor)) (cl-waffe2/vm.generic-tensor::vec result))
+		(tensor-vec result)
+		(cl-waffe2/vm.generic-tensor::embody-tensor-vec tensor result)
+		) ;; Tensor.ID <- Result
 	      (if (scalar-p tensor)
 		  (setf (tensor-vec tensor) (tensor-vec result))
 		  (let* ((state (tensor-state tensor)))

--- a/source/vm/vm.lisp
+++ b/source/vm/vm.lisp
@@ -38,7 +38,12 @@ If set to T, the result is displayed on the terminal with the arguments used eac
 		;; Intentionally creates the illusion of VM that misunderstands
 		;; var is [computed] by deleting tensor-state
 		(setf (tensor-state var) nil)
-		(%vm-move place var)
+	        (%vm-move place var)
+
+		;; FixME: Delete this line:
+		(when (scalar-p place)
+		  (setf (tensor-vec place) (tensor-vec var)))
+		
 		(setf (tensor-state var) state)))))
   nil)
 
@@ -68,7 +73,7 @@ If set to T, the result is displayed on the terminal with the arguments used eac
 	  (if (tensor-tmp-p tensor)
 	      (progn
 		;; ScalarTensors never use Memory-Pool
-		;; Update Memory-Pool
+		;; Update Memory-Pool		
 		(setf (tensor-vec (read-from-mempool-tensor tensor)) (cl-waffe2/vm.generic-tensor::vec result))
 		;;(tensor-vec result)
 		;; Tensor is already broadcasted/permuted...

--- a/source/vm/vm.lisp
+++ b/source/vm/vm.lisp
@@ -355,7 +355,7 @@ CL-WAFFE2-REPL>
 		   (loop for nth being the hash-keys in profiled-result do
 		     (let ((i (gethash nth inst->node-table)))
 		       (dolist (var (wfop-args i))
-			 (push (tensor-mid var) tensor-ids))
+			 (push (tensor-id var) tensor-ids))
 		       
 		       ;; Put the result of benchmark
 		       (let* ((times (gethash nth profiled-result))

--- a/source/vm/vm.lisp
+++ b/source/vm/vm.lisp
@@ -6,7 +6,7 @@
 
 When set to T, a run-time error is detected and a warning is displayed.")
 
-(defparameter *logging-vm-execution* T "
+(defparameter *logging-vm-execution* NIL "
 ## [parameter] *logging-vm-execution*
 
 If set to T, the result is displayed on the terminal with the arguments used each time cl-waffe2 VM executes an instruction. In default, set to nil

--- a/source/vm/vm.lisp
+++ b/source/vm/vm.lisp
@@ -34,17 +34,15 @@ If set to T, the result is displayed on the terminal with the arguments used eac
       (loop for var   in variables
 	    for place in places
 	    if (and place var) do
-	      (let ((state (tensor-state var)))
-		;; Intentionally creates the illusion of VM that misunderstands
-		;; var is [computed] by deleting tensor-state
-		(setf (tensor-state var) nil)
-	        (%vm-move place var)
+	      ;; Intentionally creates the illusion of VM that misunderstands
+	      ;; var is [computed] by deleting tensor-state
+	      (tensor-vec place)
+	      (tensor-vec var)
+	      (%vm-move place var)
 
-		;; FixME: Delete this line:
-		(when (scalar-p place)
-		  (setf (tensor-vec place) (tensor-vec var)))
-		
-		(setf (tensor-state var) state)))))
+	      ;; FixME: Delete this line:
+	      (when (scalar-p place)
+		(setf (tensor-vec place) (tensor-vec var))))))
   nil)
 
 (declaim (ftype (function (AbstractTensor) AbstractTensor) maybe-read-result))
@@ -77,7 +75,7 @@ If set to T, the result is displayed on the terminal with the arguments used eac
 		;; Deleting Unused StateContainer will benefit:
 		;;  The returned tensor by the proceed function is
 		;;  displayed as [computed] in the terminal.
-		(setf (tensor-vec tensor) nil)
+		;;(setf (tensor-state tensor) nil)
 		;; ScalarTensors never use Memory-Pool
 		;; Update Memory-Pool
 		(setf (tensor-vec (read-from-mempool-tensor tensor)) (cl-waffe2/vm.generic-tensor::vec result))

--- a/source/vm/vm.lisp
+++ b/source/vm/vm.lisp
@@ -14,9 +14,10 @@
   :asif :function :named %vm-move1)
 
 (defun %vm-move (a b)
-  (let ((out (%vm-move1 a b)))
-    (cl-waffe2/vm.generic-tensor::write-mempool-state out :save-for-backward)
-    out))
+  ;; A <- B
+  (print a)
+  (print b)
+  (%vm-move1 a b))
 
 (declaim (ftype (function (WfInstruction) t) apply-inst-sv4bw))
 (defun apply-inst-sv4bw (instruction)

--- a/source/vm/vm.lisp
+++ b/source/vm/vm.lisp
@@ -53,6 +53,7 @@ If set to T, the result is displayed on the terminal with the arguments used eac
   (if (tensor-tmp-p tensor)
       (let ((out (read-from-mempool-tensor tensor)))
 	;; Keep Broadcasting, Permution etc... But storages are shared.
+	(setf (tensor-state tensor) nil)
 	(setf (tensor-vec tensor) (cl-waffe2/vm.generic-tensor::vec out))
 	tensor)
       (if (scalar-p tensor)
@@ -189,7 +190,13 @@ Evaluates generated cl-waffe2 IR sequence.
 	  do (apply-inst-sv4bw inst)
 	     (write-result (wfop-out-to inst) (apply-instruction inst))
 	  finally
-	     (return-from accept-instructions (apply #'values (map 'list #'maybe-read-result (wfop-out-to inst)))))))
+	     (return-from accept-instructions
+	       (apply #'values
+		      (map 'list
+			   (compose
+			    #'cl-waffe2/vm.nodes::eliminate-undetermined-size
+			    #'maybe-read-result)
+			   (wfop-out-to inst)))))))
 
 (defparameter *under-benchmark-set* nil "(list sorted-node profiled-table) If there's any") 
 

--- a/source/vm/vm.lisp
+++ b/source/vm/vm.lisp
@@ -32,12 +32,14 @@
   (declare (type AbstractTensor tensor))
   (if (tensor-tmp-p tensor)
       tensor
-      (let* ((state (tensor-state tensor))
-	     (res
-	       (or (when state
-		     (cl-waffe2/vm.generic-tensor::statecontainer-forward-result state))
-		   tensor)))
-	(the AbstractTensor res))))
+      (if (scalar-p tensor)
+	  tensor
+	  (let* ((state (tensor-state tensor))
+		 (res
+		   (or (when state
+			 (cl-waffe2/vm.generic-tensor::statecontainer-forward-result state))
+		       tensor)))
+	    (the AbstractTensor res)))))
 
 (declaim (ftype (function (list list) t) write-result))
 (defun write-result (tensors results)
@@ -47,8 +49,10 @@
 	if  result do
 	  (if (tensor-tmp-p tensor)
 	      (cl-waffe2/vm.generic-tensor::embody-tensor-vec tensor result)
-	      (let* ((state (tensor-state tensor)))
-		(setf (cl-waffe2/vm.generic-tensor::statecontainer-forward-result state) result)))))
+	      (if (scalar-p tensor)
+		  (setf (tensor-vec tensor) (tensor-vec result))
+		  (let* ((state (tensor-state tensor)))
+		    (setf (cl-waffe2/vm.generic-tensor::statecontainer-forward-result state) result))))))
 
 (declaim (ftype (function (WFInstruction) list) apply-instruction))
 (defun apply-instruction (instruction)


### PR DESCRIPTION
# Changes

## Memory-Locality Optimizing

As there is an assumption that InputTensor can be filled with non-zero, an optimisation was implemented to reconnect the computation nodes to reduce the extra cache. Now, Composing several `!softmax` function will require one additional space:

```lisp
;; Memory-Size is 2x times smaller!
CL-WAFFE2-REPL> (disassemble-waffe2-ir
		 (!softmax (!softmax (randn `(10 10)))))

disassemble-waffe2-ir:
 [Forward]: 
<WfInst[op=MOVETENSORNODE-CPUTENSOR] : TID6503 <= op(TID6503{float, (10 10)} <Input>TID6415{float, (10 10)})>
<WfInst[op=VIEWTENSORNODE-T]         : TID6497 <= op(TID6455{float, (10 1)} TID6497{float, (10 1)})>
<WfInst[op=SCALARMUL-CPUTENSOR]      : TID6497 <= op(TID6497{float, (10 1)} <Input>TID6424{float, (1)})>
<WfInst[op=VIEWTENSORNODE-T]         : TID6497 <= op(TID6497{float, (10 10)} TID6497{float, (10 1)})>
<WfInst[op=ADDNODE-CPUTENSOR]        : TID6497 <= op(TID6497{float, (10 10)} <Input>TID6415{float, (10 10)})>
<WfInst[op=VIEWTENSORNODE-T]         : TID6497 <= op(TID6497{float, (10 1)} TID6497{float, (10 10)})>
<WfInst[op=SCALARDIV-CPUTENSOR]      : TID6497 <= op(TID6497{float, (10 1)} <Input>TID6419{float, (1)})>
<WfInst[op=VIEWTENSORNODE-T]         : TID6497 <= op(TID6497{float, (10 10)} TID6497{float, (10 1)})>
<WfInst[op=SUBNODE-CPUTENSOR]        : TID6503 <= op(TID6503{float, (10 10)} TID6497{float, (10 10)})>
<WfInst[op=MOVETENSORNODE-CPUTENSOR] : TID6584 <= op(TID6584{float, (10 10)} TID6503{float, (10 10)})>
<WfInst[op=EXPNODE-CPUTENSOR]        : TID6584 <= op(TID6503{float, (10 10)} TID6584{float, (10 10)})>
<WfInst[op=SCALARMUL-CPUTENSOR]      : TID6497 <= op(TID6497{float, (10 1)} <Input>TID6552{float, (1)})>
<WfInst[op=VIEWTENSORNODE-T]         : TID6497 <= op(TID6497{float, (10 10)} TID6497{float, (10 1)})>
<WfInst[op=EXPNODE-CPUTENSOR]        : TID6503 <= op(TID6503{float, (10 10)} TID6503{float, (10 10)})>
<WfInst[op=ADDNODE-CPUTENSOR]        : TID6497 <= op(TID6497{float, (10 10)} TID6503{float, (10 10)})>
<WfInst[op=DIVNODE-CPUTENSOR]        : TID6584 <= op(TID6584{float, (10 10)} TID6497{float, (10 10)})>
<WfInst[op=VIEWTENSORNODE-T]         : TID6497 <= op(TID6668{float, (10 1)} TID6497{float, (10 1)})>
<WfInst[op=SCALARMUL-CPUTENSOR]      : TID6497 <= op(TID6497{float, (10 1)} <Input>TID6637{float, (1)})>
<WfInst[op=VIEWTENSORNODE-T]         : TID6497 <= op(TID6497{float, (10 10)} TID6497{float, (10 1)})>
<WfInst[op=ADDNODE-CPUTENSOR]        : TID6497 <= op(TID6497{float, (10 10)} TID6584{float, (10 10)})>
<WfInst[op=VIEWTENSORNODE-T]         : TID6497 <= op(TID6497{float, (10 1)} TID6497{float, (10 10)})>
<WfInst[op=SCALARDIV-CPUTENSOR]      : TID6497 <= op(TID6497{float, (10 1)} <Input>TID6632{float, (1)})>
<WfInst[op=VIEWTENSORNODE-T]         : TID6497 <= op(TID6497{float, (10 10)} TID6497{float, (10 1)})>
<WfInst[op=SUBNODE-CPUTENSOR]        : TID6584 <= op(TID6584{float, (10 10)} TID6497{float, (10 10)})>
<WfInst[op=MOVETENSORNODE-CPUTENSOR] : TID6503 <= op(TID6503{float, (10 10)} TID6584{float, (10 10)})>
<WfInst[op=EXPNODE-CPUTENSOR]        : TID6503 <= op(TID6584{float, (10 10)} TID6503{float, (10 10)})>
<WfInst[op=SCALARMUL-CPUTENSOR]      : TID6497 <= op(TID6497{float, (10 1)} <Input>TID6765{float, (1)})>
<WfInst[op=VIEWTENSORNODE-T]         : TID6497 <= op(TID6497{float, (10 10)} TID6497{float, (10 1)})>
<WfInst[op=EXPNODE-CPUTENSOR]        : TID6584 <= op(TID6584{float, (10 10)} TID6584{float, (10 10)})>
<WfInst[op=ADDNODE-CPUTENSOR]        : TID6497 <= op(TID6497{float, (10 10)} TID6584{float, (10 10)})>
<WfInst[op=DIVNODE-CPUTENSOR]        : TID6503 <= op(TID6503{float, (10 10)} TID6497{float, (10 10)})>

31 Instructions | 6 Tensors | 6 Scalars

```

## [Update] Static-Allocation

- Add: `VMAllocation`, `with-static-allocation`
- 👍 No memory-leak
- Adjustable Shapes are managed well

## [Update] Thread-Safe defmodel-as

- defmodel-as is now thread-safe
- Setting `:asif=:node` won't produce additional compiling overhead, it is cached!
- Reconnection of compute nodes to be cached; AbstractTensor has a dedicated thread to store WfInstruction

## Minor changes

- When displaying compiled-comosite, the size of memory-pool is also displayed!

```lisp
CL-WAFFE2-REPL> (build (!sin (randn `(3 3))))

<Compiled-Composite(allocated-p=NIL)
    forward     : forward(model) -> CPUTENSOR{FLOAT}(3 3)
    backward    : backward(model) -> t
    memory-pool : one tensor(s)
                   L {3.6e-5}MB
>
```

- Customized Printing of AbstractOptimizer
```lisp
CL-WAFFE2-REPL> (Adam (parameter (randn `(3 3))))
<AbstractOptimizer: ADAM(
    minimize   : toplevel
    subject to : <TID6870>CPUTENSOR{FLOAT}(3 3)
)>
CL-WAFFE2-REPL> 
```
