### PR TITLE
New Features

### DIFF
--- a/docs/apis/nn.lisp
+++ b/docs/apis/nn.lisp
@@ -30,21 +30,44 @@
 
     (insert "## Normalization Layers~%")
 
-    (insert "## Loss Functions~%")
+    (insert "## Loss Functions
+
+### Tips: Utility Function
+
+The `:reduction` keyword for all loss functions is set to T by default. If you want to compose several functions for reduction (e.g. ->scal and !sum), it is recommended to define utilities such as:
+
+```lisp
+(defun criterion (criterion X Y &key (reductions nil))
+  (apply #'call->
+	 (funcall criterion X Y)
+	 (map 'list #'asnode reductions)))
+
+;; Without criterion:
+(->scal (MSE x y :reduction :sum))
+
+;; With criterion for example:
+(criterion #'MSE x y :reductions `(#'->scal #'!sum))
+```
+")
     
     (with-nn-doc 'L1Norm 'function
       (with-example
 	"(proceed (L1Norm (randn `(10 10)) (randn `(10 10))))"))
-    (with-nn-doc 'mse 'function
+    
+    (with-nn-doc 'MSE 'function
       (with-example
 	"(proceed (MSE (randn `(10 10)) (randn `(10 10))))"))
     
     (with-nn-doc 'cross-entropy-loss 'function)
     (with-nn-doc 'softmax-cross-entropy 'function)
 
+    (insert "## Regressions~%")
+    
     (with-nn-doc (find-class 'LinearLayer) 't
       (with-example
 	"(LinearLayer 10 5)"))
+
+    (insert "## Image Processings~%")
 
     (with-nn-doc (find-class 'Conv2D) 't
       (with-example

--- a/docs/apis/nn.lisp
+++ b/docs/apis/nn.lisp
@@ -6,14 +6,32 @@
 	       `(progn
 		  (placedoc ,name ,type)
 		  ,@body)))
+    (insert "## Non Linear Activations~%")
+    
     (with-nn-doc '!relu 'function
       (with-example
 	"(proceed (!relu (randn `(10 10))))"))
-    (with-nn-doc '!gelu 'function)
+
+    (with-nn-doc '!gelu 'function
+      (with-example
+	"(proceed (!relu (randn `(10 10))))"))
+
     (with-nn-doc '!sigmoid 'function
       (with-example
 	"(proceed (!sigmoid (randn `(10 10))))"))
 
+    (with-nn-doc '!leakey-relu 'function
+      (with-example
+	"(proceed (!leakey-relu (randn `(10 10))))"))
+
+    (with-nn-doc '!elu 'function
+      (with-example
+	"(proceed (!leakey-relu (randn `(10 10))))"))
+
+    (insert "## Normalization Layers~%")
+
+    (insert "## Loss Functions~%")
+    
     (with-nn-doc 'L1Norm 'function
       (with-example
 	"(proceed (L1Norm (randn `(10 10)) (randn `(10 10))))"))

--- a/docs/apis/reference.lisp
+++ b/docs/apis/reference.lisp
@@ -244,7 +244,9 @@
       (with-op-doc #'asnode 't)
       (with-op-doc #'call-> 't)
       (with-op-doc (macro-function 'defsequence) 't)
-      (with-op-doc (macro-function 'hooker) 't))
+      (with-op-doc (macro-function 'hooker) 't)
+      (with-op-doc (macro-function 'node->lambda) 't)
+      (with-op-doc (macro-function 'node->defun) 't))
     
     (with-op-doc #'show-backends 'function)
     (with-op-doc #'set-devices-toplevel 'function)))

--- a/docs/apis/reference.lisp
+++ b/docs/apis/reference.lisp
@@ -147,7 +147,6 @@
 
     (caller-doc !move)
     (caller-doc !copy)
-    (caller-doc !copy-force)
 
     (caller-doc !permute)
     (caller-doc !reshape)

--- a/docs/cl-waffe2-docs/docs/base-impl-nodes.md
+++ b/docs/cl-waffe2-docs/docs/base-impl-nodes.md
@@ -162,8 +162,7 @@ A\gets{1 / A}
 (InverseTensorNode dtype)
 ```
 
-`dtype` dtype to use, being used to dispatch backends. (e.g.: `:float` `:uint8`)
-
+`dtype` indicates dtype to use, being used to dispatch backends. (e.g.: `:float` `:uint8`)
 
 
 ### Backward
@@ -1666,7 +1665,7 @@ In order to implement device-specific implementation of `Unfold`, define-impl `I
    (values
     (call
      (col2imnode n c (h-of self) (w-of self) k-h k-w h-out w-out stride-x
-                 stride-y (img-out-of self))
+      stride-y (img-out-of self))
      dout)
     nil)))
 ```

--- a/docs/cl-waffe2-docs/docs/base-impl.md
+++ b/docs/cl-waffe2-docs/docs/base-impl.md
@@ -399,19 +399,8 @@ Note that: the function `!copy` never creates a new tensor larger than (tensor-v
 
 `!copy` is used to make a cache before calling destructive operation to avoid side effects, therefore if the copy is included to be useless by compiler, this operations is being ignored without changing its behaviour. And this is why !copy returns `InputTensor`, not `AbstractTensor`.
 
-See also: `!copy-force` never being ignored by compiler, and broadcasted axes will be padded.
-
 Input:  Tensor[AbstractTensor]
 Output: Tensor[AbstractTensor]
-## [function] !copy-force
-
-```lisp
-(!copy-force (tensor))
-```
-
-The function !copy-force returns a node which copies the given tensor forcibly while the function !copy sometimes ignored.
-
-This function is also used to adjust memory alignment of tensor.
 ## [function] !permute
 
 In cl-waffe2, each tensor has a slot `(tensor-permute-order tensor)`, which indicates the order of the dimensions to be invoked. The function `!permute` returns a view of the original tensor input with its dimensions permuted.

--- a/docs/cl-waffe2-docs/docs/distributions.md
+++ b/docs/cl-waffe2-docs/docs/distributions.md
@@ -16,11 +16,11 @@ That is, arguments passed to the `make-tensor` function can also be passed direc
 (normal `(10 10) 0.0 1.0 :requires-grad t)
 
 {CPUTENSOR[float] :shape (10 10)  
-  ((-1.3054699   0.18602815   -0.3616548   ~ -0.22505726  -0.15569693  0.3095909)                    
-   (0.077898845  -0.44244626  1.0635623    ~ -0.40228054  -0.40816537  1.0006372)   
+  ((-0.68094176  -0.096516706 1.315713     ~ -0.09775145  -0.26254508  0.4150814)                    
+   (0.17923991   -1.8472044   -0.9620114   ~ -1.3274325   1.0314808    -1.2027103)   
                  ...
-   (1.4225258    -0.08328378  -0.77037257  ~ -0.54520386  1.0669057    -0.54442966)
-   (-0.06799416  -0.3919469   0.2048984    ~ 1.1178145    -1.9768039   -0.75663793))
+   (-0.619261    1.5115738    0.9725089    ~ 1.7362964    0.17250857   -1.4037871)
+   (-1.44131     2.1897004    -0.17695138  ~ -1.1236498   -0.1235727   1.0795678))
   :facet :exist
   :requires-grad T
   :backward NIL}
@@ -146,9 +146,9 @@ Note: My implementation is unstable, being occurs floating-overflow constantly..
 (beta `(3 3) 5.0 1.0)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((0.71240944 0.847264   0.69012284)
-   (0.75272816 0.8312693  0.9785166)
-   (0.80858713 0.95975447 0.6866892))
+  ((0.48670492 0.35642892 0.6711993)
+   (0.92313844 0.92171085 0.9534024)
+   (0.8218194  0.6207688  0.74418557))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -170,9 +170,9 @@ p - Takes 1 with probability p and 0 with probalibity (1-p).
 (bernoulli `(3 3) 0.3)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((0.0 0.0 1.0)
-   (1.0 0.0 0.0)
-   (1.0 0.0 0.0))
+  ((0.0 0.0 0.0)
+   (0.0 1.0 0.0)
+   (0.0 0.0 0.0))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -198,9 +198,9 @@ df - degree of freedom.
 (chisquare `(3 3) 1.0)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((1.444597    0.179507    0.2541821)
-   (0.08026809  0.07310683  0.003460823)
-   (0.082672    0.22727925  0.5728937))
+  ((0.0041524577 0.0071927933 0.04589742)
+   (0.15356903   0.12593193   0.017479597)
+   (0.9752275    0.14017592   1.6264822))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -227,9 +227,9 @@ The function expotential is a family of initializer functions, and samples the e
 (expotential `(3 3))
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((0.16602875  0.51840174  0.021845827)
-   (0.6818311   6.2415676   0.29937285)
-   (1.1426421   0.90104485  0.9713096))
+  ((1.3096758  2.781888   1.1931132)
+   (0.4078095  1.6282117  0.95690584)
+   (0.79340816 1.7541006  0.5570962))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -252,9 +252,9 @@ The function gamma is a family of initializer functions, and samples matrices fr
 (gamma `(3 3) 1.0)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((1.3301286   0.9113628   2.2936785)
-   (1.458179    1.1904559   0.022091847)
-   (1.6347893   0.15075241  0.35237762))
+  ((1.554159   0.16423602 0.8228366)
+   (1.2420335  3.7241278  3.6187208)
+   (1.746659   0.8460458  0.3539876))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -309,9 +309,9 @@ Input:
 (uniform-random `(3 3) 2 4)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((2.7340446 3.542842  3.4739382)
-   (3.3757188 2.502474  3.263076)
-   (3.1209097 2.6771405 2.324503))
+  ((3.1986127 3.7427945 3.89206)
+   (3.244409  2.3592925 3.6935184)
+   (2.578202  3.7208295 2.5322545))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -339,9 +339,9 @@ The function randn is a family of initializer functions, and samples the gaussia
 (randn `(3 3))
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((1.1390121   1.9054949   0.40986034)
-   (0.8395159   1.5175884   0.044068847)
-   (-0.7726815  0.5808442   0.561935))
+  ((-0.14792383 0.9427928   1.3183076)
+   (1.5446137   -0.2083845  0.043253314)
+   (1.3484981   -1.1502582  0.11353562))
   :facet :exist
   :requires-grad NIL
   :backward NIL}

--- a/docs/cl-waffe2-docs/docs/generic-tensor.md
+++ b/docs/cl-waffe2-docs/docs/generic-tensor.md
@@ -420,7 +420,7 @@ Compiles the given computation node starting from `toplevel`. The docstring of `
 > (setq out (!add (make-input `(a 10) :X) (make-input `(a 10) :Y)))
 ```
 ```
-{CPUTENSOR[float] :shape (A 10) :id TID1377 
+{CPUTENSOR[float] :shape (A 10) :id TID1422 
   :vec-state [maybe-not-computed]
     <<Not allocated: size=(A 10)>>
   :facet :input

--- a/docs/cl-waffe2-docs/docs/nn.md
+++ b/docs/cl-waffe2-docs/docs/nn.md
@@ -1,25 +1,31 @@
 
 # cl-waffe2/nn
+## Non Linear Activations
 
 ## [function] !relu
 
-Returns a tensor that applied ReLU element-wise.
+```lisp
+(!relu x)
+```
+
+Computes ReLU to the given tensor.
 
 ```math
 ReLU(x) = max(x, 0)
 ```
+
 ### Example
 
 ```lisp
 (proceed (!relu (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (10 10) :id TID1427 
+{CPUTENSOR[float] :shape (10 10) :id TID1512 
   :vec-state [computed]
-  ((-0.0        -0.0        1.4563614   ~ 0.12839013  1.6735466   -0.0)                   
-   (-0.0        0.7021836   -0.0        ~ 0.0920827   1.6974396   -0.0)   
+  ((-0.0        0.06268174  0.38545948  ~ 0.45613456  -0.0        1.2389519)                   
+   (-0.0        0.80596685  -0.0        ~ -0.0        -0.0        2.1135337)   
                 ...
-   (1.0319365   0.09859386  1.2601917   ~ -0.0        0.7230486   -0.0)
-   (-0.0        0.12257845  1.0139741   ~ 0.6677612   -0.0        0.35926917))
+   (-0.0        0.66437244  -0.0        ~ -0.0        0.9794315   -0.0)
+   (-0.0        0.33708817  0.8596226   ~ 0.44115165  -0.0        0.4445048))
   :facet :input
   :belongs-to :memory-pool
   :requires-grad NIL
@@ -28,11 +34,42 @@ ReLU(x) = max(x, 0)
 
 ## [function] !gelu
 
-Approximates GeLU (Not tested yet): `(!* 0.5 x (!+ 1 (!tanh (!* (sqrt (/ 2 pi)) (!+ x (!* 0.044715 (!expt x 3)))))))`
+```lisp
+(!gelu x)
+```
+
+Applies the Gaussian Error Linear Units function approximated with:
+
+```math
+GeLU(x) = 0.5\times{x}\times{(1 + Tanh(\sqrt{\frac{2}{π}}\times{(x + 0.44715\times{x^3})}))}
+```
+
+
+### Example
+
+```lisp
+(proceed (!relu (randn `(10 10))))
+
+{CPUTENSOR[float] :shape (10 10) :id TID1610 
+  :vec-state [computed]
+  ((-0.0         0.89838934   1.0843782    ~ -0.0         -0.0         -0.0)                    
+   (-0.0         0.4584069    -0.0         ~ 0.5861535    0.80540437   -0.0)   
+                 ...
+   (-0.0         2.0839996    -0.0         ~ 1.1435975    -0.0         -0.0)
+   (-0.0         1.3144796    0.04638508   ~ -0.0         -0.0         1.8804568))
+  :facet :input
+  :belongs-to :memory-pool
+  :requires-grad NIL
+  :backward <Node: PROCEEDNODE-T (A[~] -> A[~])>}
+```
 
 ## [function] !sigmoid
 
-Returns a tensor that applied sigmoid function element-wise.
+```lisp
+(!sigmoid x)
+```
+
+Computes sigmoid function to the given tensor.
 
 ```math
 Sigmoid(x) = \frac{1}{1 + exp(-x)}
@@ -43,23 +80,114 @@ Sigmoid(x) = \frac{1}{1 + exp(-x)}
 ```lisp
 (proceed (!sigmoid (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (10 10) :id TID1518 
+{CPUTENSOR[float] :shape (10 10) :id TID1699 
   :vec-state [computed]
-  ((0.92068595  0.38643858  0.59769624  ~ 0.782908    0.7951611   0.3243036)                   
-   (0.45063692  0.8844838   0.7055789   ~ 0.6401052   0.58050334  0.3435368)   
-                ...
-   (0.6815791   0.5202018   0.40984365  ~ 0.5420403   0.29856625  0.30525693)
-   (0.21781419  0.536015    0.8327136   ~ 0.65991646  0.49891552  0.3606924))
+  ((0.728437   0.631219   0.62524664 ~ 0.1444213  0.4615509  0.45974594)                  
+   (0.65860546 0.36433932 0.53884435 ~ 0.56951594 0.4647735  0.4935272)   
+               ...
+   (0.5236434  0.69857574 0.09652317 ~ 0.51632696 0.80563885 0.53765744)
+   (0.77151203 0.5960395  0.6833214  ~ 0.71123135 0.2943471  0.23736556))
   :facet :input
   :belongs-to :memory-pool
   :requires-grad NIL
   :backward <Node: PROCEEDNODE-T (A[~] -> A[~])>}
 ```
 
+## [function] !leakey-relu
+
+```lisp
+(!leakey-relu x &key (negative-slope 0.01))
+```
+
+Applies the element-wise function:
+
+```lisp
+LeakeyReLU(x) = max(x, 0) + negative-slope\times{min(0, x)}
+```
+
+### Inputs
+
+`x[AbstractTensor]`
+
+`negative-slope[single-float]`
+
+### Example
+
+```lisp
+(proceed (!leakey-relu (randn `(10 10))))
+
+{CPUTENSOR[float] :shape (10 10) :id TID1870 
+  :vec-state [computed]
+  ((-0.007370783  -0.0010218715 -0.011959649  ~ -0.012164829  0.43317536    0.95860183)                     
+   (-0.0010178427 0.33624887    -0.010997846  ~ 2.351149      -0.009332305  -0.006312372)   
+                  ...
+   (0.014392254   0.49713793    -0.011500162  ~ 0.9108881     -0.0100887185 0.102592506)
+   (0.44861665    -0.010909835  -0.008496331  ~ -0.014008625  1.3601671     -0.008670153))
+  :facet :input
+  :belongs-to :memory-pool
+  :requires-grad NIL
+  :backward <Node: PROCEEDNODE-T (A[~] -> A[~])>}
+```
+
+## [function] !elu
+
+```lisp
+(!elu x &key (alpha 1.0))
+```
+
+Applies the Expotential Linear Units Function (ELUs) element-wise as described in [this paper](https://arxiv.org/abs/1511.07289)
+
+```math
+\begin{equation}
+  ELU(x)=
+  \begin{cases}
+    \text{x} & if x>0 \\
+    \text{α*(exp(x)-1)} & \text{otherwise}
+  \end{cases}
+\end{equation}
+```
+
+### Example
+
+```lisp
+(proceed (!leakey-relu (randn `(10 10))))
+
+{CPUTENSOR[float] :shape (10 10) :id TID1968 
+  :vec-state [computed]
+  ((-0.013192002  -0.011740226  0.8038811     ~ -0.0074112606 1.3139632     2.1789594)                     
+   (-0.0010714618 0.80368596    -0.0033079023 ~ -5.434935e-4  0.93554825    1.1892815)   
+                  ...
+   (0.30161232    -0.017567515  -0.004835163  ~ -0.006370061  0.47988546    1.4195682)
+   (-0.00520801   -3.4653608e-4 -9.5531833e-4 ~ -0.012002897  -0.0018533143 0.6940714))
+  :facet :input
+  :belongs-to :memory-pool
+  :requires-grad NIL
+  :backward <Node: PROCEEDNODE-T (A[~] -> A[~])>}
+```
+## Normalization Layers
+## Loss Functions
+
+### Tips: Utility Function
+
+The `:reduction` keyword for all loss functions is set to T by default. If you want to compose several functions for reduction (e.g. ->scal and !sum), it is recommended to define utilities such as:
+
+```lisp
+(defun criterion (criterion X Y &key (reductions nil))
+  (apply #'call->
+	 (funcall criterion X Y)
+	 (map 'list #'asnode reductions)))
+
+;; Without criterion:
+(->scal (MSE x y :reduction :sum))
+
+;; With criterion for example:
+(criterion #'MSE x y :reductions `(#'->scal #'!sum))
+```
+
 ## [function] L1Norm
 
 ```
-(L1Norm x p &key (:reduction :mean))
+(L1Norm x p &key (:reduction t))
 ```
 
 Returns a tensor that measures L1 Norm between each element in the input `x` and `y`.
@@ -70,16 +198,20 @@ l(x, y) = L = {l_1, ..., l_n}^\intercal, l_n = abs(x_n - y_n)
 
 where `N` is a batch-size.
 
-In addition, reading the value of a `:reduction` keyword (one of `:mean` `:sum` `nil`), the result of `L` is reducted. (If nil, reduction is ignored.)
+In addition, reading the value of a `:reduction` keyword (one of `:mean` `:sum` `t`), the result of `L` is reducted. (If t, reduction is ignored.)
 
 ### Example
 
 ```lisp
 (proceed (L1Norm (randn `(10 10)) (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (1 1) -> :view (<(BROADCAST 1)> <(BROADCAST 1)>) -> :visible-shape (1 1) :id TID1777 
+{CPUTENSOR[float] :shape (10 10) :id TID2057 
   :vec-state [computed]
-  ((1.1418228))
+  ((0.52083296  0.40177372  2.1186347   ~ 1.3097919   1.4082458   3.0848603)                   
+   (1.2743711   2.3686373   0.20020244  ~ 0.9002279   1.7962848   2.3246503)   
+                ...
+   (0.7444719   1.0475134   0.32404017  ~ 0.43116307  2.3071566   1.7676215)
+   (0.5804124   0.7593653   0.38540208  ~ 1.5800132   0.27997005  0.61595696))
   :facet :input
   :belongs-to :memory-pool
   :requires-grad NIL
@@ -88,9 +220,10 @@ In addition, reading the value of a `:reduction` keyword (one of `:mean` `:sum` 
 
 ## [function] mse
 ```
-(mse x p &key (:reduction :mean))
+(mse x p &key (:reduction T))
 ```
-Returns a tensor that measures the MSE error (L2Norm) between each element in the input `x` and `y`.
+
+Returns a tensor that measures the MSE error (i.e.: L2Norm) between each element in the input `x` and `y`.
 
 ```math
 l(x, y) = L = {l_1, ..., l_n}^\intercal, l_n = (x_n - y_n)^2
@@ -98,16 +231,20 @@ l(x, y) = L = {l_1, ..., l_n}^\intercal, l_n = (x_n - y_n)^2
 
 where `N` is a batch-size.
 
-In addition, reading the value of a `:reduction` keyword (one of `:mean` `:sum` `nil`), the result of `L` is reducted. (If nil, reduction is ignored.)
+In addition, reading the value of a `:reduction` keyword (one of `:mean` `:sum` `t`), the result of `L` is reducted. (If t, this operation is ignored.)
 
 ### Example
 
 ```lisp
 (proceed (MSE (randn `(10 10)) (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (1 1) -> :view (<(BROADCAST 1)> <(BROADCAST 1)>) -> :visible-shape (1 1) :id TID1945 
+{CPUTENSOR[float] :shape (10 10) :id TID2163 
   :vec-state [computed]
-  ((1.814005))
+  ((0.67441535   2.1862133    8.821052     ~ 2.4430165    2.5409465    0.17583068)                    
+   (0.13544491   9.803973     3.0020092    ~ 0.08279413   17.030046    0.15624054)   
+                 ...
+   (2.7255685    0.27481204   2.2419963    ~ 1.431767     0.35703227   3.0560243)
+   (0.42558736   2.4342675    0.00399647   ~ 1.2202001    0.70150405   0.2355568))
   :facet :input
   :belongs-to :memory-pool
   :requires-grad NIL
@@ -117,7 +254,7 @@ In addition, reading the value of a `:reduction` keyword (one of `:mean` `:sum` 
 ## [fucntion] cross-entropy-loss
 
 ```lisp
-(cross-entropy-loss x labels &key (delta 1e-7) (reduction :mean))
+(cross-entropy-loss x labels &key (delta 1e-7) (reduction t))
 ```
 
 Returns a tensor that measures the Cross-Entropy-Error between each element in the x and labels.
@@ -143,10 +280,12 @@ L_i = -p_ilog(x_i + delta)
 
 `labels[AbstractTensor]` one-hot encoding.
 
+`reduction` one of :sum :mean t
+
 ## [function] softmax-cross-entropy
 
 ```lisp
-(softmax-cross-entropy x labels)
+(softmax-cross-entropy x labels &key (axis 1) (delta 1e-7) (avoid-overflow nil) (reduction t))
 ```
 
 Returns a tensor that measures the Softmax-Cross-Entropy-Error between each element in the x and labels.
@@ -157,9 +296,10 @@ out = CrossEntropyLoss(Softmax(x), labels)
 
 ### Inputs
 
-`x[AbstractTensor]`
+`x[AbstractTensor]` distribution to measure
 
-`labels[AbstractTensor]` one-hot encoding.
+`labels[AbstractTensor]` answer labels with one-hot encoding.
+## Regressions
 
 ## [model] LINEARLAYER
 
@@ -200,13 +340,14 @@ y = xA^\intercal + b
 ```lisp
 (LinearLayer 10 5)
 
-<Composite: LINEARLAYER{W2009}(
+<Composite: LINEARLAYER{W2264}(
     <Input : ((~ BATCH-SIZE 10)) -> Output: ((~ BATCH-SIZE 5))>
 
     WEIGHTS -> (5 10)
     BIAS    -> (5)
 )>
 ```
+## Image Processings
 
 ## [model] CONV2D
 
@@ -288,7 +429,7 @@ Note: When `Conv2D` is initialised, the output is displayed as -1. This is becau
 ```lisp
 (Conv2D 3 5 '(3 3))
 
-<Composite: CONV2D{W2019}(
+<Composite: CONV2D{W2274}(
     <Input : ((N 3 H_IN W_IN)) -> Output: ((N 5 -1 -1))>
 
     WEIGHT -> (5 3 3 3)

--- a/docs/cl-waffe2-docs/docs/nodes.md
+++ b/docs/cl-waffe2-docs/docs/nodes.md
@@ -679,8 +679,6 @@ Directly defines a `call` method. Arguments must be: `(self arg1 arg2...)`
 
 Redefines a Composite as a new function or AbstractNode specified in the `:asif` keyword. Further functions or `Differentiable AbstractNode` can be defined based on existing Composites (also called as `model` and defined by `defmodel` macro) which bundles several `AbstractNodes`, as long as `:where` form is fulfilled.
 
-**Note that the expanded form includes eval function! So this macro should be placed in the toplevel!**
-
 ### Example
 
 ```lisp

--- a/docs/cl-waffe2-docs/docs/optimizer.md
+++ b/docs/cl-waffe2-docs/docs/optimizer.md
@@ -3,7 +3,7 @@
 
 ## [class] AbstractOptimizer
 
-AbstractTensors with `:requires-grad=t` can find their gradients with the `(backward (build toplevel))` function. AbstractOptimizer is a class which minimizes the value of `toplevel` subject to `(grad tensor)`. In cl-waffe2, we initialize one AbstractOptimizer for one AbstractTensor. Specifically, one is able to create a new AbstractOptimizer with the function `(name tensor &rest constructor-args)`, for example, `(adam (parameter (randn `(3 3))) :lr 1e-3)` to create a new Adam Optimizer, and can be tied to the tensor like: `(hook-optimizer! tensor abstract-optimizer)`. Users can define any optimizer algorithms with the `defoptimizer` macro. Optimizing tied tensors is performed by calling a `(step-optimize optimizer)` method. The parameter to be optimized can be accessed by a `read-parameter` method.
+AbstractTensors with `:requires-grad=t` can find their gradients with the `(backward (build toplevel))` function. AbstractOptimizer is a class which minimizes the value of `toplevel` subject to `(grad tensor)`. In cl-waffe2, we initialize one AbstractOptimizer for one AbstractTensor. Specifically, one is able to create a new AbstractOptimizer with the function `(name tensor &rest constructor-args)`, for example, `(adam (parameter (randn (list 3 3))) :lr 1e-3)` to create a new Adam Optimizer, and can be tied to the tensor like: `(hook-optimizer! tensor abstract-optimizer)`. Users can define any optimizer algorithms with the `defoptimizer` macro. Optimizing tied tensors is performed by calling a `(step-optimize optimizer)` method. The parameter to be optimized can be accessed by a `read-parameter` method.
 
 ### Example: Hooks and calls the optimizer tied to the tensor.
 

--- a/docs/cl-waffe2-docs/docs/utils.md
+++ b/docs/cl-waffe2-docs/docs/utils.md
@@ -185,6 +185,9 @@ However, due to constrains of `call`, it is not possible to place functions here
 The macro `cl-waffe2/vm.nodes:defmodel-as` is able to define new functions/nodes from existing `Composite`. However, this macro only needs the traced computation nodes information to do this. As the simplest case, compiling the AbstractNode `SinNode` (which is callable as `!sin`) into static function, `matrix-sin`.
 
 ```lisp
+
+;; The number of arguments is anything: (defmodel-as (asnode #'(lambda (x y z) ... is also ok
+
 (defmodel-as (asnode #'!sin) :where (A[~] -> B[~]) :asif :function :named matrix-sin)
 
 (matrix-sin (ax+b `(10 10) 0 1)) ;; <- No compiling overhead. Just works like Numpy
@@ -274,6 +277,67 @@ In cl-waffe2, one independent Optimizer must be initialised per parameter. This 
   (backward model)
 
   (mapc #'call-optimizer! (model-parameters model)))
+```
+
+## [macro] node->lambda
+
+```lisp
+(node->lambda (&rest where) &body body)
+```
+
+Creates a lambda function obtained by tracing and compiling the computation node described in body.
+
+### Inputs
+
+`where` declares the shape transforms. the tensor names used here are the same as those used in body. (i.e.: everything is AbstractTensor)
+
+`body` Describe the construction of the computation node here.
+
+### Example
+
+```lisp
+(node->lambda (A[~] -> B[~])
+    (!sin (!cos a)))
+
+(funcall * (randn `(3 3)))
+```
+
+### Note
+
+⚠️A cache of functions is created for each location where this macro is located. Never place it inside a loop!
+
+
+## [macro] node->defun
+
+```lisp
+(node->defun (name (&rest where) &body body))
+```
+
+Defines a function obtained by tracing and compiling the computation node described in the body.
+
+### Inputs
+
+`name[symbol]` the function is defined after it
+
+`where` declares the shape transforms. the tensor names used here are the same as those used in body.
+
+`body` Describe the construction of the computation node here.
+
+### Example
+
+```lisp
+(node->defun log-softmax (A[~] -> OUT[~])
+    (!softmax (!loge a) :axis 1))
+
+(log-softmax (ax+b `(3 3) 0 1))
+{CPUTENSOR[float] :shape (3 3) :id TID261835 
+  ((0.33333334 0.33333334 0.33333334)
+   (0.33333334 0.33333334 0.33333334)
+   (0.33333334 0.33333334 0.33333334))
+  :facet :input
+  :belongs-to :memory-pool
+  :requires-grad NIL
+  :backward NIL}
 ```
 
 ## [function] show-backends

--- a/examples/mlp_sin_wave.lisp
+++ b/examples/mlp_sin_wave.lisp
@@ -25,7 +25,7 @@
 (defun criterion (criterion X Y &key (reductions nil))
   (apply #'call->
 	 (funcall criterion X Y)
-	 (map 'list #'asnode (reverse reductions))))
+	 (map 'list #'asnode reductions)))
 ;; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ;; Defines a model
@@ -40,7 +40,7 @@
 			       (call (Simple-MLP in-features hidden-dim)
 				     (make-input `(batch-size ,in-features) :TrainX))
 			       (make-input `(batch-size 1) :TrainY)
-			       :reductions (list #'->scal)))
+			       :reductions (list #'!mean #'->scal)))
 	 (model (build lazy-loss :inputs `(:TrainX :TrainY))))
 
     ;; Initializes and hooks AbstractOptimizers

--- a/examples/mnist/cnn.lisp
+++ b/examples/mnist/cnn.lisp
@@ -20,7 +20,7 @@
 	 (lazy-loss (criterion #'softmax-cross-entropy
 			       (call model (make-input `(,N 1 28 28) :X))
 			       (make-input `(,N 10) :Y)
-			       :reductions (list #'->scal #'!sum)))
+			       :reductions (list #'!sum #'->scal)))
 	 (compiled-model (build lazy-loss :inputs `(:X :Y))))
     (mapc (hooker x (Adam x :lr lr)) (model-parameters compiled-model))
     (values compiled-model model)))

--- a/examples/mnist/mlp.lisp
+++ b/examples/mnist/mlp.lisp
@@ -7,7 +7,7 @@
 (defun criterion (criterion X Y &key (reductions nil))
   (apply #'call->
 	 (funcall criterion X Y)
-	 (map 'list #'asnode (reverse reductions))))
+	 (map 'list #'asnode reductions)))
 ;; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 (defsequence MLP-Sequence (in-features hidden-dim out-features
@@ -25,7 +25,7 @@
 			       (call mlp
 				     (make-input `(batch-size ,in-class) :X))
 			       (make-input `(batch-size ,out-class) :Y)
-			       :reductions (list #'->scal #'!sum)))
+			       :reductions (list #'!sum #'->scal)))
 	 (model     (build lazy-loss :inputs `(:X :Y))))
     (mapc (hooker x (Adam x :lr lr)) (model-parameters model))
     (values model mlp)))

--- a/source/base-impl/fundamental.lisp
+++ b/source/base-impl/fundamental.lisp
@@ -517,7 +517,7 @@ The function ->mat receives `ScalarTensor`, returning a matrix with the number o
 			    (progn
 			      (format t "[proceed-time] build ->~%")
 			      (time (build toplevel :compile-mode compile-mode)))
-			    (build toplevel :compile-mode compile-mode))))
+			    (build toplevel :compile-mode compile-mode :construct-backward? (and (not *no-grad*) (ancestor-param-p toplevel))))))
     ;; Detaching the tensor
     (setf (detach-p toplevel) T
 	  (proceed-compiled-model myself) compiled-model)))

--- a/source/base-impl/package.lisp
+++ b/source/base-impl/package.lisp
@@ -38,7 +38,6 @@
    #:!mean
    #:!move
    #:!copy
-   #:!copy-force
    #:!permute
    #:!view
    #:!reshape

--- a/source/network.lisp
+++ b/source/network.lisp
@@ -8,9 +8,10 @@
 (defmodel (Encapsulated-Node (self node-func)
 	   :slots ((node-func :initarg :node-func))
 	   :initargs (:node-func node-func)
-	   :documentation "(asnode ) dedicated Composite. Wraps the given node-func (excepted to construct networks) with no `:where` dependency"
-	   :on-call-> ((self x)
-		       (funcall (slot-value self 'node-func) x))))
+	   :documentation "(asnode ) dedicated Composite. Wraps the given node-func (excepted to construct networks) with no `:where` dependency"))
+
+(defmethod call ((model Encapsulated-Node) &rest inputs)
+  (apply (slot-value model 'node-func) inputs))
 
 (defmethod on-print-object ((model Encapsulated-Node) stream)
   (format stream "
@@ -65,6 +66,9 @@ However, due to constrains of `call`, it is not possible to place functions here
 The macro `cl-waffe2/vm.nodes:defmodel-as` is able to define new functions/nodes from existing `Composite`. However, this macro only needs the traced computation nodes information to do this. As the simplest case, compiling the AbstractNode `SinNode` (which is callable as `!sin`) into static function, `matrix-sin`.
 
 ```lisp
+
+;; The number of arguments is anything: (defmodel-as (asnode #'(lambda (x y z) ... is also ok
+
 (defmodel-as (asnode #'!sin) :where (A[~] -> B[~]) :asif :function :named matrix-sin)
 
 (matrix-sin (ax+b `(10 10) 0 1)) ;; <- No compiling overhead. Just works like Numpy

--- a/source/network.lisp
+++ b/source/network.lisp
@@ -216,7 +216,7 @@ Creates a lambda function obtained by tracing and compiling the computation node
 
 ### Inputs
 
-`where` declares the shape transforms. the tensor names used here are the same as those used in body.
+`where` declares the shape transforms. the tensor names used here are the same as those used in body. (i.e.: everything is AbstractTensor)
 
 `body` Describe the construction of the computation node here.
 

--- a/source/nn/activation.lisp
+++ b/source/nn/activation.lisp
@@ -76,7 +76,7 @@ GeLU(x) = 0.5\\times{x}\\times{(1 + Tanh(\\sqrt{\\frac{2}{π}}\\times{(x + 0.447
 
 Applies the element-wise function:
 
-```lisp
+```math
 LeakeyReLU(x) = max(x, 0) + negative-slope\\times{min(0, x)}
 ```
 

--- a/source/nn/activation.lisp
+++ b/source/nn/activation.lisp
@@ -1,23 +1,12 @@
 
-;; Non Linear Functions
+;; Non Linear Activations
 
 (in-package :cl-waffe2/nn)
-
-;; [TODO] ドキュメント更新 + Examples + Package追加 + Test !mulとかの型宣言
-
-;; Softmax
-;; ReLU
-;; GeLU
-;; Leakey-ReLU
-;; Swish Hardswish Hardtanh
 
 (declaim (ftype (function (AbstractTensor) AbstractTensor)
 		!relu
 		!sigmoid
 		!gelu))
-
-(declaim (ftype (function (AbstractTensor &key (:negative-slope single-float)) AbstractTensor)
-		!leakey-relu))
 
 (defun !relu (x)
   "
@@ -76,6 +65,7 @@ GeLU(x) = 0.5\\times{x}\\times{(1 + Tanh(\\sqrt{\\frac{2}{π}}\\times{(x + 0.447
 	       (!+ x
 		   (!* 0.044715 (!expt x 3))))))))
 
+(declaim (ftype (function (AbstractTensor &key (:negative-slope single-float)) AbstractTensor) !leakey-relu))
 (defun !leakey-relu (x &key (negative-slope 0.01))
   "
 ## [function] !leakey-relu
@@ -104,17 +94,53 @@ LeakeyReLU(x) = max(x, 0) + negative-slope\\times{min(0, x)}
 		       :false-then negative-slope)))
     (!mul x mask)))
 
+(declaim (ftype (function (AbstractTensor &key (:alpha single-float)) AbstractTensor) !elu))
+(defun !elu (x &key (alpha 1.0))
+  "
+## [function] !elu
 
+```lisp
+(!elu x &key (alpha 1.0))
+```
+
+Applies the Expotential Linear Units Function (ELUs) element-wise as described in [this paper](https://arxiv.org/abs/1511.07289)
+
+```math
+\\begin{equation}
+  ELU(x)=
+  \\begin{cases}
+    \\text{x} & if x>0 \\\\
+    \\text{α*(exp(x)-1)} & \\text{otherwise}
+  \\end{cases}
+\\end{equation}
+```
+"
+  ;; [TODO] Fusion
+  (let* ((mask1 (A>scal x 0 :true-then 0 :false-then 1))
+	 (mask2 (A>scal x 0 :true-then 1 :false-then 0))
+	 (out1  (!* mask1 alpha (!- (!exp x) 1)))
+	 (out2  (!* mask2 x)))
+    (!add out1 out2)))
 
 
 (defun !softmax (x &key (avoid-overflow t) (axis 1))
   "
 ## [function] !softmax
 
-Returns a tensor that applied Softmax function.
+```lisp
+(!softmax x &key (avoid-overflow t) (axis 1))
+```
+
+Returns a tensor that applied Softmax function along the given axis.
 
 ```lisp
 Softmax(x_i) = exp(x_i)\\div{sum(x_j, axis)}
+```
+
+If avoid-overflow is set to t:
+
+```lisp
+x_i = x_i - mean(x)
 ```
 
 ### Inputs
@@ -125,9 +151,11 @@ Softmax(x_i) = exp(x_i)\\div{sum(x_j, axis)}
 "
 
   (if avoid-overflow
-      (let* ((x1 (!sub x (!mean x  :axis axis :keepdims t)))
-	     (z  (!sum   (!exp x1) :axis axis :keepdims t)))
-	(!div (!exp x1) z))
-      (!div (!exp x) (!sum (!exp x) :axis axis :keepdims t))))
+      (let* ((x1    (!sub x (!mean x  :axis axis :keepdims t)))
+	     (expx1 (!exp x1))
+	     (z     (!sum   expx1 :axis axis :keepdims t)))
+	(!div expx1 z))
+      (let ((x1 (!exp x)))
+	(!div x1 (!sum x1 :axis axis :keepdims t)))))
 
 

--- a/source/nn/activation.lisp
+++ b/source/nn/activation.lisp
@@ -1,44 +1,74 @@
 
+;; Non Linear Functions
+
 (in-package :cl-waffe2/nn)
+
+;; [TODO] ドキュメント更新 + Examples + Package追加 + Test !mulとかの型宣言
 
 ;; Softmax
 ;; ReLU
 ;; GeLU
 ;; Leakey-ReLU
-;;
+;; Swish Hardswish Hardtanh
+
+(declaim (ftype (function (AbstractTensor) AbstractTensor)
+		!relu
+		!sigmoid
+		!gelu))
+
+(declaim (ftype (function (AbstractTensor &key (:negative-slope single-float)) AbstractTensor)
+		!leakey-relu))
 
 (defun !relu (x)
   "
 ## [function] !relu
 
-Returns a tensor that applied ReLU element-wise.
+```lisp
+(!relu x)
+```
+
+Computes ReLU to the given tensor.
 
 ```math
 ReLU(x) = max(x, 0)
-```"
-
+```
+"
+  (declare (type AbstractTensor x))
   (!mul x (A>scal x 0.0)))
 
 (defun !sigmoid (x)
   "
 ## [function] !sigmoid
 
-Returns a tensor that applied sigmoid function element-wise.
+```lisp
+(!sigmoid x)
+```
+
+Computes sigmoid function to the given tensor.
 
 ```math
 Sigmoid(x) = \\frac{1}{1 + exp(-x)}
 ```
 "
-  
+  (declare (type AbstractTensor x))
   (!div 1 (!add 1 (!exp (!mul -1 x)))))
 
 (defun !gelu (x)
   "
 ## [function] !gelu
 
-Approximates GeLU (Not tested yet): `(!* 0.5 x (!+ 1 (!tanh (!* (sqrt (/ 2 pi)) (!+ x (!* 0.044715 (!expt x 3)))))))`
+```lisp
+(!gelu x)
+```
+
+Applies the Gaussian Error Linear Units function approximated with:
+
+```math
+GeLU(x) = 0.5\\times{x}\\times{(1 + Tanh(\\sqrt{\\frac{2}{π}}\\times{(x + 0.44715\\times{x^3})}))}
+```
+
 "
-  ;; I dunno if this is really works
+  (declare (type AbstractTensor x))
   (!* 0.5 x
       (!+ 1
 	  (!tanh
@@ -46,8 +76,37 @@ Approximates GeLU (Not tested yet): `(!* 0.5 x (!+ 1 (!tanh (!* (sqrt (/ 2 pi)) 
 	       (!+ x
 		   (!* 0.044715 (!expt x 3))))))))
 
-;; todo (!matmul !t !t) test
-;; Bug: (Proceed (!sum (Proceed (!Softmax x))))
+(defun !leakey-relu (x &key (negative-slope 0.01))
+  "
+## [function] !leakey-relu
+
+```lisp
+(!leakey-relu x &key (negative-slope 0.01))
+```
+
+Applies the element-wise function:
+
+```lisp
+LeakeyReLU(x) = max(x, 0) + negative-slope\\times{min(0, x)}
+```
+
+### Inputs
+
+`x[AbstractTensor]`
+
+`negative-slope[single-float]`
+"
+  (declare (type AbstractTensor x)
+	   (type single-float negative-slope))
+
+  (let ((mask (A>=scal x 0.0
+		       :true-then 1.0
+		       :false-then negative-slope)))
+    (!mul x mask)))
+
+
+
+
 (defun !softmax (x &key (avoid-overflow t) (axis 1))
   "
 ## [function] !softmax
@@ -70,4 +129,5 @@ Softmax(x_i) = exp(x_i)\\div{sum(x_j, axis)}
 	     (z  (!sum   (!exp x1) :axis axis :keepdims t)))
 	(!div (!exp x1) z))
       (!div (!exp x) (!sum (!exp x) :axis axis :keepdims t))))
+
 

--- a/source/nn/criterion.lisp
+++ b/source/nn/criterion.lisp
@@ -2,7 +2,7 @@
 (in-package :cl-waffe2/nn)
 
 ;; TODO: ================================
-;; L1
+;; L1/one-hot
 ;; BinaryCrossEntropy
 ;; KLdiv
 ;; CosineSim (rather than distance.lisp?)
@@ -12,12 +12,22 @@
 ;; BSE
 ;; ======================================
 
-(defun L1Norm (x y &key (reduction :mean))
+
+;; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+;; Tips ... Criterionを使うとき下のユーティリティを定義しておくと便利
+;; Network Template: Criterion
+;;(defun criterion (criterion X Y &key (reductions nil))
+;;  (apply #'call->
+;;	 (funcall criterion X Y)
+;;	 (map 'list #'asnode reductions)))
+;; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+(defun L1Norm (x y &key (reduction t))
   "
 ## [function] L1Norm
 
 ```
-(L1Norm x p &key (:reduction :mean))
+(L1Norm x p &key (:reduction T))
 ```
 
 Returns a tensor that measures L1 Norm between each element in the input `x` and `y`.
@@ -41,11 +51,11 @@ In addition, reading the value of a `:reduction` keyword (one of `:mean` `:sum` 
        (!mean (!abs l)))
       (T (!abs l)))))
 
-(defun mse (x y &key (reduction :mean))
+(defun mse (x y &key (reduction t))
   "
 ## [function] mse
 ```
-(mse x p &key (:reduction :mean))
+(mse x p &key (:reduction T))
 ```
 Returns a tensor that measures the MSE error (L2Norm) between each element in the input `x` and `y`.
 
@@ -110,12 +120,12 @@ In addition, reading the value of a `:reduction` keyword (one of `:mean` `:sum` 
 			  (make-tensor (car (last (shape x) 2)) :dtype (dtype x) :order (order x)))))))
 
 
-(defun cross-entropy-loss (x labels &key (delta 1e-7) (reduction :mean))
+(defun cross-entropy-loss (x labels &key (delta 1e-7) (reduction t))
   "
 ## [fucntion] cross-entropy-loss
 
 ```lisp
-(cross-entropy-loss x labels &key (delta 1e-7) (reduction :mean))
+(cross-entropy-loss x labels &key (delta 1e-7) (reduction t))
 ```
 
 Returns a tensor that measures the Cross-Entropy-Error between each element in the x and labels.
@@ -145,9 +155,9 @@ L_i = -p_ilog(x_i + delta)
   ;; KLDiv: xlogp
   (let ((z (!mul -1 (!mul labels (!loge (!add x delta))))))
     (case reduction
-      (:sum (!sum z))
+      (:sum  (!sum z))
       (:mean (!mean z))
-      (T z))))
+      (T     z))))
 
 (defun softmax-cross-entropy (x labels)
   "

--- a/source/nn/criterion.lisp
+++ b/source/nn/criterion.lisp
@@ -82,9 +82,10 @@ In addition, reading the value of a `:reduction` keyword (one of `:mean` `:sum` 
     (Dy[~ length n-dimension] z[~ length n-dimension] Labels[~ length n-dimension] Batch-Size[scal]
      ->
      X.grad[~ length n-dimension] where scal = 1)
-  (let* ((z1 (!sub z labels))
-	 (dx (!div (!mul dy z1) batch-size)))
+  (let* ((z  (!sub z labels))
+	 (dx (!div (!mul dy z) batch-size)))
     dx))
+
 
 (define-op (Softmax-Cross-Entropy-Node (self &key (axis 1) (delta 1e-7) (avoid-overflow t))
 	    :slots ((softmax       :initform nil :accessor softmax-of)
@@ -109,6 +110,7 @@ In addition, reading the value of a `:reduction` keyword (one of `:mean` `:sum` 
 		   (!softmax a :axis axis :avoid-overflow avoid-overflow)))
 	(celoss  (node->lambda (A[~] B[~] -> OUT[~])
 		   (cross-entropy-loss a b :delta delta))))
+
     (setf (softmax-of self) softmax
 	  (celoss-of  self) celoss)))
 	    
@@ -158,12 +160,12 @@ L_i = -p_ilog(x_i + delta)
       (:mean (!mean z))
       (T     z))))
 
-(defun softmax-cross-entropy (x labels &key (axis 1) (delta 1e-7) (avoid-overflow t) (reduction t))
+(defun softmax-cross-entropy (x labels &key (axis 1) (delta 1e-7) (avoid-overflow nil) (reduction t))
   "
 ## [function] softmax-cross-entropy
 
 ```lisp
-(softmax-cross-entropy x labels &key (axis 1) (delta 1e-7) (avoid-overflow t) (reduction t))
+(softmax-cross-entropy x labels &key (axis 1) (delta 1e-7) (avoid-overflow nil) (reduction t))
 ```
 
 Returns a tensor that measures the Softmax-Cross-Entropy-Error between each element in the x and labels.

--- a/source/nn/package.lisp
+++ b/source/nn/package.lisp
@@ -37,6 +37,7 @@
    #:!leakey-relu
    #:!sigmoid
    #:!gelu
+   #:!elu
    #:!softmax))
 
 (in-package :cl-waffe2/nn)

--- a/source/nn/package.lisp
+++ b/source/nn/package.lisp
@@ -30,9 +30,11 @@
    #:cross-entropy-loss
    #:softmax-cross-entropy
    )
-  
+
+  ;; Non Linear Functions
   (:export
    #:!relu
+   #:!leakey-relu
    #:!sigmoid
    #:!gelu
    #:!softmax))

--- a/source/nn/t/regression.lisp
+++ b/source/nn/t/regression.lisp
@@ -421,7 +421,7 @@
 			 (call
 			  (Simple-MLP in-features hidden-dim)
 			  (make-input `(batch-size ,in-features) :TrainX))))
-	 (model (build lazy-loss :inputs `(:TrainX :TrainY))))
+	 (model (build (!mean lazy-loss) :inputs `(:TrainX :TrainY))))
 
     ;; Initializes and hooks AbstractOptimizers
     (mapc (hooker x (cl-waffe2/optimizers:SGD x :lr lr)) (model-parameters model))

--- a/source/optimizers/defoptimizer.lisp
+++ b/source/optimizers/defoptimizer.lisp
@@ -6,7 +6,7 @@
   (:documentation "
 ## [class] AbstractOptimizer
 
-AbstractTensors with `:requires-grad=t` can find their gradients with the `(backward (build toplevel))` function. AbstractOptimizer is a class which minimizes the value of `toplevel` subject to `(grad tensor)`. In cl-waffe2, we initialize one AbstractOptimizer for one AbstractTensor. Specifically, one is able to create a new AbstractOptimizer with the function `(name tensor &rest constructor-args)`, for example, `(adam (parameter (randn `(3 3))) :lr 1e-3)` to create a new Adam Optimizer, and can be tied to the tensor like: `(hook-optimizer! tensor abstract-optimizer)`. Users can define any optimizer algorithms with the `defoptimizer` macro. Optimizing tied tensors is performed by calling a `(step-optimize optimizer)` method. The parameter to be optimized can be accessed by a `read-parameter` method.
+AbstractTensors with `:requires-grad=t` can find their gradients with the `(backward (build toplevel))` function. AbstractOptimizer is a class which minimizes the value of `toplevel` subject to `(grad tensor)`. In cl-waffe2, we initialize one AbstractOptimizer for one AbstractTensor. Specifically, one is able to create a new AbstractOptimizer with the function `(name tensor &rest constructor-args)`, for example, `(adam (parameter (randn (list 3 3))) :lr 1e-3)` to create a new Adam Optimizer, and can be tied to the tensor like: `(hook-optimizer! tensor abstract-optimizer)`. Users can define any optimizer algorithms with the `defoptimizer` macro. Optimizing tied tensors is performed by calling a `(step-optimize optimizer)` method. The parameter to be optimized can be accessed by a `read-parameter` method.
 
 ### Example: Hooks and calls the optimizer tied to the tensor.
 

--- a/source/optimizers/impls/adam.lisp
+++ b/source/optimizers/impls/adam.lisp
@@ -56,7 +56,7 @@ See the [original paper](https://arxiv.org/abs/1412.6980) for detailed algorithm
 	   :on-call-> ((self v x-grad decay-rate)
 		       (declare (ignore self))
 		       (A+=B v (!mul (!sub 1.0 decay-rate)
-				     (!sub (!square x-grad) v))))))
+				     (!sub (!mul x-grad x-grad) v))))))
 
 (defmodel (Adam-Step-Param (self)
 	   :where (M[~] V[~] Param[~] Lr-t[scal] Eps[scal] -> Param[~] where scal = 1)
@@ -99,11 +99,11 @@ See the [original paper](https://arxiv.org/abs/1412.6980) for detailed algorithm
 	 (grad  (grad param)))
     (with-no-grad
       ;; TODO: Cache?
-
       (apply-adam-step-m
        (adam-m optimizer)
        grad ;; the gradient involved in in-place op
        (make-tensor (beta1-of optimizer)))
+      
       (apply-adam-step-v
        (adam-v optimizer)
        grad ;; never destruct the gradients

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -19,6 +19,8 @@
   
   ;; Advanced Network APIs
   (:export
+   #:node->defun
+   #:node->lambda
    #:defsequence
    #:sequencelist-nth
    #:asnode

--- a/source/vm/allocation.lisp
+++ b/source/vm/allocation.lisp
@@ -134,7 +134,7 @@ If the re-allocation is performed, frees the old one.
 (defun copy-allocate (allocation)
   "Makes a copy of given allocation and its storage vec is also copied so no thread-conflicts would happen."
   (declare (type VMAllocation allocation))
-
+  
   (let ((allocation (copy-vmallocation allocation)))
     (setf (vmalloc-allocated-p allocation) NIL)
     (loop for key being the hash-keys      in (vmalloc-id2pool allocation)

--- a/source/vm/allocation.lisp
+++ b/source/vm/allocation.lisp
@@ -78,10 +78,12 @@ If the re-allocation is performed, frees the old one.
 	   (the number
 		(if (numberp val)
 		    val
-		    (or (gethash val shape-table)
-			(error "adjust-allocation!: The symbol ~a is unknown. Choose from: ~a"
+		    (or (let ((out (gethash val shape-table)))
+			  (when (numberp out) out))
+			(error "adjust-allocation!: The symbol ~a is unknown. Choose from: ~a -> ~a"
 			       val
-			       (alexandria:hash-table-keys shape-table)))))))
+			       (alexandria:hash-table-keys shape-table)
+			       (alexandria:hash-table-values shape-table)))))))
     (loop for tensor being the hash-values in (vmalloc-id2pool allocation)
 	  ;; If the tensor is DYNAMYCALLY SHAPED:
 	  if (some #'symbolp (cl-waffe2/vm.generic-tensor::tensor-input-shape tensor))

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -277,7 +277,7 @@ Before calling the forward method, set any value to these InputTensors first.
 	 (allocator (make-hash-table)))
     (loop for i fixnum upfrom 0 below (length symbols) by 2
 	  do (register-adjustable-shape (nth i symbols) (read-symbol (nth (1+ i) symbols)))
-	     (setf (gethash (nth i symbols) allocator) (read-symbol (nth (1+ i) symbols))))
+	     (setf (gethash (nth i symbols) allocator)  (read-symbol (nth (1+ i) symbols))))
     allocator))
 
 (defmethod cl-waffe2/vm.nodes:forward ((model Compiled-Composite) &rest inputs)
@@ -398,7 +398,7 @@ Compiles the given computation node starting from `toplevel`. The docstring of `
 	  (backward-f   (when construct-backward?
 			  #'(lambda (model)
 			      (with-adjustable-symbol-scope
-				(let ((alloc-inst (set-adjustable-symbols model)))				  
+				(let ((alloc-inst (set-adjustable-symbols model)))
 				  (cl-waffe2/vm::with-static-allocation ((compiled-allocation model))
 				    (cl-waffe2/vm::adjust-allocation! (compiled-allocation model) alloc-inst)
 				    (cl-waffe2/vm:accept-instructions bw-iseq)))))))

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -276,8 +276,8 @@ Before calling the forward method, set any value to these InputTensors first.
 	 (symbols   (nodevariables-symbols var-table))
 	 (allocator (make-hash-table)))
     (loop for i fixnum upfrom 0 below (length symbols) by 2
-	  do (register-adjustable-shape (nth i symbols) (nth (1+ i) symbols))
-	     (setf (gethash (nth i symbols) allocator) (nth (1+ i) symbols)))
+	  do (register-adjustable-shape (nth i symbols) (read-symbol (nth (1+ i) symbols)))
+	     (setf (gethash (nth i symbols) allocator) (read-symbol (nth (1+ i) symbols))))
     allocator))
 
 (defmethod cl-waffe2/vm.nodes:forward ((model Compiled-Composite) &rest inputs)

--- a/source/vm/generic-tensor/call-with-view.lisp
+++ b/source/vm/generic-tensor/call-with-view.lisp
@@ -581,6 +581,11 @@ See also: `with-ranked-loop` to the more elegant wrapping macro.
 butgot ~a."
 	  (map 'list #'shape tensors)) ;; ... (1)
 
+  (when (some #'scalar-p tensors)
+    (error "call-with-view: tensors must not include ScalarTensor.
+  You probably called AbstractNode excepting a Matrix with ScalarTensor.
+  Use the ->mat function to create matrix from scalar."))
+
   (when *freeze-call-with-view*
     (setq force-order t))
   

--- a/source/vm/generic-tensor/dtype.lisp
+++ b/source/vm/generic-tensor/dtype.lisp
@@ -60,10 +60,10 @@
 (defun read-lazy-var (lazy-var)
   (declare (type lazy-variable lazy-var))
 
-  (if *adjustable-shape-table*
-      (coerce (read-adjustable-symbol (lazy-variable-variable lazy-var))
-	      (lazy-variable-dtype lazy-var))
-      lazy-var))
+  (let ((result (read-symbol (lazy-variable-variable lazy-var))))
+    (if (numberp result)
+	(coerce result (lazy-variable-dtype lazy-var))
+	result)))
 
 (defun coerce-lazy (scalar dtype)
   "If scalar is number, coerce to dtype, otherwise lazily evalute"

--- a/source/vm/generic-tensor/render.lisp
+++ b/source/vm/generic-tensor/render.lisp
@@ -180,7 +180,7 @@ The result sequence MUST not over max-length.
   
   (with-output-to-string (out)
     (let ((*matrix-element-displaying-size*
-	    (+ 3 (loop for i fixnum upfrom 0 below (apply #'* (compute-visible-actual-shape tensor))
+	    (+ 3 (loop for i fixnum upfrom 0 below (apply #'* (compute-visible-actual-shape tensor))		       
 		       maximize (length (format nil "~a" (vref tensor i)))))))
       (pprint-vector out tensor tensor t indent)
       out)))

--- a/source/vm/nodes/model-compiler.lisp
+++ b/source/vm/nodes/model-compiler.lisp
@@ -346,9 +346,9 @@ Choose :asif option from:
 "
      named))
 
-  (let* ((composite (eval target-model))
-	 (where-decl-to-use (or (read-where composite) where)))
-
+  (let* ((where-decl-to-use
+	   (or where (read-where (eval target-model)))))
+    
     (when (null where-decl-to-use)
       (error "defmodel-as: Attempted to compile into a ~(~a~) but the composite doesn't provide any available :where declaration.
 
@@ -405,14 +405,14 @@ Or
 			     target-model
 			     where-decl-to-use))))))
 
-    (when (and (read-where composite) where)
-      (warn "defmodel-as: As both the composite ~a and defmodel-as form declared :where form, defmodel was used in preference.
-
-(defmodel-as target-model ... :where ...)
-                                 └── This option is ignored.
-
-"
-	    (car target-model)))
+;;    (when (and (read-where composite) where)
+;;      (warn "defmodel-as: As both the composite ~a and defmodel-as form declared :where form, defmodel was used in preference.
+;;
+;;(defmodel-as target-model ... :where ...)
+;;                                 └── This option is ignored.
+;;
+;;"
+;;	    (car target-model)))
 
     (case asif
       (:function

--- a/source/vm/nodes/node.lisp
+++ b/source/vm/nodes/node.lisp
@@ -131,7 +131,7 @@ butgot: ~a"
 	 (ancestor-param-p (some #'cl-waffe2/vm.generic-tensor:ancestor-param-p inputs)))
     ;; Detecting Shape-Error, And finds combinations that satisfies shape-requirement heuristic.
     ;; Input-State -> Output-State
-    (multiple-value-bind (out-state detected-errors) (funcall transition-function input-states)
+    (multiple-value-bind (out-state detected-errors) (funcall transition-function input-states) ;; ... Finishes in < 1e-6 sec
       ;;(setq out-state (delete-broadcast out-state))
       ;; FixME: ~ = nil isn't allowed. [~ x] with (10) is unexceptedly invaild.
 

--- a/source/vm/vm.lisp
+++ b/source/vm/vm.lisp
@@ -95,16 +95,16 @@ If set to T, the result is displayed on the terminal with the arguments used eac
 (defun apply-instruction (instruction)
   (declare (type WFInstruction instruction)
 	   (optimize (speed 3)))
-  
   (when *logging-vm-execution*
     (let* ((inst (format nil "~a" instruction))
 	   (cnt  (length inst)))
       (format t "= [*logging-vm-execution*] ~a
-Instruction: ~a"
+Instruction: ~a
+~a"
 	      (with-output-to-string (out)
 		(dotimes (i cnt) (princ "=" out)))
 	      inst
-	      ;;(map 'list #'maybe-read-result (wfop-args instruction))
+	      (map 'list #'maybe-read-result (wfop-args instruction))
 	      )))
 
   
@@ -167,7 +167,9 @@ Butgot:
     (when *logging-vm-execution*
       (format t "
 outs:
+~a
 ~%"
+	      outs
 	      ))
     outs))
 


### PR DESCRIPTION
- Added: `!elu` `!leakey-relu` `!gelu`
- Change: softmax-cross-entropy: now they can take avoid-overflow and axis option
- Added: `node->lambda` `node->defun`
- Optimize: `Proceed` ... constructs backward only after toplevel is turned out to be `ancestor-param=t`
- Optimize: `defmodel-as` ... Earlier Compiling is enabled when `name=nil`