### PR TITLE
[Add] lazy, lazy-reduce

### DIFF
--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -104,6 +104,7 @@
 	       
 
 	       (:file "backends/lisp/package")
+	       (:file "backends/lisp/iterator")
 	       (:file "backends/lisp/tensor")
 	       (:file "backends/lisp/generic")
 	       (:file "backends/lisp/arithmetic")

--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -111,6 +111,7 @@
 	       (:file "backends/lisp/mathematics")
 	       (:file "backends/lisp/logical")
 	       (:file "backends/lisp/matrix-ops")
+	       (:file "backends/lisp/lazy")
 	       
 	       (:file "backends/cpu/package")
 	       (:file "backends/cpu/tensor")

--- a/docs/apis/nn.lisp
+++ b/docs/apis/nn.lisp
@@ -34,7 +34,8 @@
 
     (insert "## [Normalization Layers]~%")
 
-    (with-nn-doc (find-class 'LayerNorm) 't)
+    (with-nn-doc (find-class 'BatchNorm2d) 't)
+    (with-nn-doc (find-class 'LayerNorm2d) 't)
 
     (insert "## [Loss Functions]
 

--- a/docs/apis/reference.lisp
+++ b/docs/apis/reference.lisp
@@ -136,6 +136,9 @@ The package `cl-waffe2/vm` is the central of system, and features are focused on
 
     (nodedoc MatmulNode)
 
+    (nodedoc Lazy-Function-Node)
+    (nodedoc Lazy-Reduce-Node)
+
     (nodedoc Where-Operation-Node)
     (nodedoc Compare-Operation-Node)
 
@@ -234,6 +237,9 @@ The package `cl-waffe2/vm` is the central of system, and features are focused on
     (caller-doc !t)
     (caller-doc !matmul)
     (caller-doc !dot)
+
+    (caller-doc lazy)
+    (caller-doc lazy-reduce)
 
     (caller-doc !where)
     (caller-doc !compare)

--- a/docs/cl-waffe2-docs/docs/distributions.md
+++ b/docs/cl-waffe2-docs/docs/distributions.md
@@ -16,11 +16,11 @@ That is, arguments passed to the `make-tensor` function can also be passed direc
 (normal `(10 10) 0.0 1.0 :requires-grad t)
 
 {CPUTENSOR[float] :shape (10 10)  
-  ((2.6659842     0.554722      0.34577075    ~ -1.2258549    -0.2966999    0.30681476)                     
-   (-1.1840748    0.6949223     -0.4091532    ~ -0.21705773   -0.0015053201 -0.18468307)   
+  ((-0.8956928    -0.7403823    0.15017667    ~ -0.14188138   0.37363848    1.6669947)                     
+   (-2.6958134    0.58595663    0.21627972    ~ 0.59890884    0.18428127    -0.17764473)   
                   ...
-   (0.20369011    -0.34034213   -1.9471301    ~ -1.7103479    -0.5075532    0.5285901)
-   (-0.1762271    -0.82231754   -1.1776534    ~ 0.29013038    -0.682993     1.3442547))
+   (-1.2107371    0.13288274    -0.96409506   ~ 0.59915316    -0.10974556   1.8752263)
+   (-0.36284983   -0.7889702    -1.148289     ~ 1.1043916     -0.9403221    1.3875437))
   :facet :exist
   :requires-grad T
   :backward NIL}
@@ -146,9 +146,9 @@ Note: My implementation is unstable, being occurs floating-overflow constantly..
 (beta `(3 3) 5.0 1.0)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((0.76930046 0.98009753 0.7829403)
-   (0.97846824 0.93675464 0.90223414)
-   (0.9986096  0.9756518  0.9841219))
+  ((0.8122957  0.716915   0.900784)
+   (0.90241367 0.8859909  0.9353006)
+   (0.9967051  0.98564094 0.31276488))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -170,9 +170,9 @@ p - Takes 1 with probability p and 0 with probalibity (1-p).
 (bernoulli `(3 3) 0.3)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((1.0 0.0 0.0)
-   (0.0 1.0 1.0)
-   (0.0 0.0 0.0))
+  ((1.0 0.0 1.0)
+   (0.0 0.0 0.0)
+   (0.0 0.0 1.0))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -198,9 +198,9 @@ df - degree of freedom.
 (chisquare `(3 3) 1.0)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((0.26893777   1.2888308    0.96177065)
-   (0.21070044   0.786505     0.081222184)
-   (0.01508548   0.026368493  0.0057155434))
+  ((0.3001082  0.6785706  0.7514469)
+   (0.37084237 0.72724813 2.9567142)
+   (0.1113069  0.59372646 0.0730115))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -227,9 +227,9 @@ The function expotential is a family of initializer functions, and samples the e
 (expotential `(3 3))
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((0.84749633 1.502448   2.520915)
-   (0.05334956 0.26003766 1.0919561)
-   (0.10254855 1.3807392  2.3494713))
+  ((2.6738424   1.2597004   0.17590772)
+   (0.43083134  2.1695578   0.041945376)
+   (3.3903005   0.055759232 0.027370544))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -252,9 +252,9 @@ The function gamma is a family of initializer functions, and samples matrices fr
 (gamma `(3 3) 1.0)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((0.32413    0.19887413 0.83192706)
-   (0.69262534 2.0609252  1.4244914)
-   (0.821297   0.48900715 0.19870564))
+  ((0.42649975  1.1531353   0.9811732)
+   (1.3254013   0.67709714  0.3043218)
+   (0.12860991  0.053134825 0.9059959))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -309,9 +309,9 @@ Input:
 (uniform-random `(3 3) 2 4)
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((3.4243574 3.8678594 2.5862923)
-   (3.4884634 2.9323647 2.8376896)
-   (2.9268043 2.0311823 3.832702))
+  ((3.0768538 2.9161882 3.9561534)
+   (2.9470167 2.854712  2.6984425)
+   (3.770742  3.421638  3.6276934))
   :facet :exist
   :requires-grad NIL
   :backward NIL}
@@ -339,9 +339,9 @@ The function randn is a family of initializer functions, and samples the gaussia
 (randn `(3 3))
 
 {CPUTENSOR[float] :shape (3 3)  
-  ((-0.2180425   0.06464312   0.19720197)
-   (0.05599457   -0.114305586 0.5396595)
-   (-1.6115798   -0.7610963   0.11614592))
+  ((-1.4078823 2.643538   0.81806624)
+   (0.46306393 0.21459135 2.1423104)
+   (-0.3683879 -0.7924386 -0.6262715))
   :facet :exist
   :requires-grad NIL
   :backward NIL}

--- a/docs/cl-waffe2-docs/docs/generic-tensor.md
+++ b/docs/cl-waffe2-docs/docs/generic-tensor.md
@@ -420,7 +420,7 @@ Compiles the given computation node starting from `toplevel`. The docstring of `
 > (setq out (!add (make-input `(a 10) :X) (make-input `(a 10) :Y)))
 ```
 ```
-{CPUTENSOR[float] :shape (A 10) :id TID1996 
+{CPUTENSOR[float] :shape (A 10) :id TID1957 
   :vec-state [maybe-not-computed]
     <<Not allocated: size=(A 10)>>
   :facet :input

--- a/docs/cl-waffe2-docs/docs/nn.md
+++ b/docs/cl-waffe2-docs/docs/nn.md
@@ -19,13 +19,13 @@ ReLU(x) = max(x, 0)
 ```lisp
 (proceed (!relu (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (10 10) :id TID2114 
+{CPUTENSOR[float] :shape (10 10) :id TID2075 
   :vec-state [computed]
-  ((-0.0        -0.0        -0.0        ~ -0.0        -0.0        0.0758239)                   
-   (0.33081433  0.7033231   -0.0        ~ 0.44851843  -0.0        -0.0)   
+  ((-0.0        0.99525183  -0.0        ~ 0.03254504  1.1655586   1.293396)                   
+   (-0.0        -0.0        -0.0        ~ 0.12466652  0.2705505   -0.0)   
                 ...
-   (0.9859774   0.34466082  0.09621465  ~ 0.9216246   1.4845713   0.34032807)
-   (0.48264125  -0.0        -0.0        ~ 0.032608878 0.72863156  1.6821892))
+   (0.78753096  0.10287541  1.0347279   ~ 0.5497315   1.0518545   0.5751236)
+   (0.5249704   0.03094567  2.107657    ~ 1.8177543   0.39457574  -0.0))
   :facet :input
   :belongs-to :memory-pool
   :requires-grad NIL
@@ -50,13 +50,13 @@ GeLU(x) = 0.5\times{x}\times{(1 + Tanh(\sqrt{\frac{2}{π}}\times{(x + 0.44715\ti
 ```lisp
 (proceed (!relu (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (10 10) :id TID2205 
+{CPUTENSOR[float] :shape (10 10) :id TID2166 
   :vec-state [computed]
-  ((0.36130282  -0.0        0.87504226  ~ -0.0        0.9028499   -0.0)                   
-   (-0.0        -0.0        -0.0        ~ 0.77838975  -0.0        -0.0)   
+  ((0.16071448  -0.0        0.97729045  ~ -0.0        0.4751874   1.2899321)                   
+   (1.2699922   -0.0        -0.0        ~ 0.3343071   0.16991097  -0.0)   
                 ...
-   (0.5963682   0.55514115  -0.0        ~ 1.9969639   0.041267265 -0.0)
-   (-0.0        0.7646121   -0.0        ~ 1.2720133   -0.0        0.9884213))
+   (0.76737607  -0.0        -0.0        ~ -0.0        -0.0        2.2673395)
+   (-0.0        -0.0        0.121423334 ~ 0.20510498  -0.0        1.1865982))
   :facet :input
   :belongs-to :memory-pool
   :requires-grad NIL
@@ -80,13 +80,13 @@ Sigmoid(x) = \frac{1}{1 + exp(-x)}
 ```lisp
 (proceed (!sigmoid (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (10 10) :id TID2292 
+{CPUTENSOR[float] :shape (10 10) :id TID2253 
   :vec-state [computed]
-  ((0.48958635 0.8158429  0.49715242 ~ 0.3462106  0.33601856 0.77342373)                  
-   (0.3317039  0.5787033  0.28749508 ~ 0.37375876 0.5790652  0.46743193)   
+  ((0.80199754 0.40615046 0.571633   ~ 0.27047047 0.4991317  0.7153258)                  
+   (0.44781345 0.3880153  0.8394016  ~ 0.7563945  0.5380041  0.37973723)   
                ...
-   (0.34892797 0.37644443 0.6041932  ~ 0.75265163 0.5227069  0.29443073)
-   (0.5836293  0.5905903  0.86408615 ~ 0.6017747  0.4341943  0.25450796))
+   (0.42055935 0.5348928  0.62540334 ~ 0.61547023 0.5792195  0.38193497)
+   (0.24820435 0.46835825 0.2848132  ~ 0.46433806 0.6471651  0.762412))
   :facet :input
   :belongs-to :memory-pool
   :requires-grad NIL
@@ -116,13 +116,13 @@ LeakeyReLU(x) = max(x, 0) + negative-slope\times{min(0, x)}
 ```lisp
 (proceed (!leakey-relu (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (10 10) :id TID2448 
+{CPUTENSOR[float] :shape (10 10) :id TID2409 
   :vec-state [computed]
-  ((1.2495973     0.745614      1.6715057     ~ -0.009638567  0.18777691    1.1906472)                     
-   (0.03819821    -0.011125428  1.8616861     ~ -0.007410889  1.113944      -0.0023454204)   
+  ((-0.0024188054 0.28661168    -0.015332591  ~ 0.28472435    0.12365582    0.9525306)                     
+   (0.2494425     -0.0036886313 -0.0025330153 ~ -0.014749502  -0.00806824   0.26301512)   
                   ...
-   (-3.1367975e-4 0.060880393   0.4047371     ~ 0.54067177    -0.015001696  0.2813693)
-   (-0.0017047632 -0.0036414461 0.78715545    ~ -0.011978014  -0.006375469  0.5117078))
+   (-0.02770405   0.59393775    0.49283808    ~ -0.0011476747 -0.0070601534 1.0203125)
+   (2.3065634     1.1646757     0.5146315     ~ 0.64402       0.25997666    -0.0012870618))
   :facet :input
   :belongs-to :memory-pool
   :requires-grad NIL
@@ -152,13 +152,13 @@ Applies the Expotential Linear Units Function (ELUs) element-wise as described i
 ```lisp
 (proceed (!leakey-relu (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (10 10) :id TID2539 
+{CPUTENSOR[float] :shape (10 10) :id TID2500 
   :vec-state [computed]
-  ((0.10139906    0.22480665    -0.008864752  ~ -0.012594044  -0.0240032    0.42575783)                     
-   (2.48219       0.042828444   -0.002884126  ~ 0.055956405   -7.984822e-4  -0.016727848)   
+  ((0.008027558   -2.1824382e-4 -6.6580845e-4 ~ 0.45391056    1.4279875     -0.0057911277)                     
+   (0.2409328     -6.1130885e-4 1.4046197     ~ -0.0046708696 -0.010976263  -0.0027201648)   
                   ...
-   (0.71814036    -0.0044727987 -0.007339712  ~ 0.09223112    -0.011809034  -0.004170165)
-   (1.1420414     0.45225763    1.2949203     ~ 1.7421316     0.06016421    0.35411915))
+   (0.22395898    1.4551989     -0.0034736458 ~ -0.011780907  -0.014673531  0.64088166)
+   (0.75582784    0.4189211     -0.005367441  ~ -0.0054881466 -0.0031045368 -0.00688607))
   :facet :input
   :belongs-to :memory-pool
   :requires-grad NIL
@@ -194,11 +194,11 @@ x_i = x_i - mean(x)
 ```lisp
 (proceed (!softmax (randn `(3 3))))
 
-{CPUTENSOR[float] :shape (3 3) :id TID2705 
+{CPUTENSOR[float] :shape (3 3) :id TID2666 
   :vec-state [computed]
-  ((0.07293469  0.021375284 0.9056901)
-   (0.41610932  0.20799257  0.37589812)
-   (0.2532427   0.3773796   0.36937764))
+  ((0.35254386 0.40809578 0.23936033)
+   (0.15599205 0.33206308 0.51194483)
+   (0.19293311 0.54487264 0.26219422))
   :facet :input
   :belongs-to :memory-pool
   :requires-grad NIL
@@ -206,10 +206,44 @@ x_i = x_i - mean(x)
 ```
 ## [Normalization Layers]
 
-## [model] LAYERNORM
+## [model] BATCHNORM2D
 
 ```
-(layernorm NORMALIZED-SHAPE &KEY (EPS 1.0e-5) (AFFINE T))
+(batchnorm2d IN-FEATURES &KEY (AFFINE T) (EPS 1.0e-5))
+```
+
+
+which transformation of shapes are defined as:
+```
+(X[N IN-FEATURES H W] -> OUT[N IN-FEATURES H W])
+```
+### Description
+
+Applies Batch Normalization over a 4D input (N C H W) as described in the paper [Batch Normalization](https://arxiv.org/abs/1502.03167).
+
+```math
+BatchNorm(x) = \frac{x - E[x]}{\sqrt{Var[x] + ε}}\times{γ}+β
+```
+
+### Inputs
+
+`in-features[fixnum]` - C from an excepted input size (N C H W)
+
+`affine[bool]` Set T to apply affine transofmration to the output. In default, set to t.
+
+`eps[single-float]` a value added to the denominator for numerical stability. Default: 1e-5.
+
+### Parameters
+
+`alpha` (in-features) is a trainable tensor filled with `1.0`. accessor: `alpha-of`
+
+`beta`  (in-features) is a trainable tensor filled with `0.0`. accessor: `beta-of`
+
+
+## [model] LAYERNORM2D
+
+```
+(layernorm2d NORMALIZED-SHAPE &KEY (EPS 1.0e-5) (AFFINE T))
 ```
 
 
@@ -281,13 +315,13 @@ In addition, reading the value of a `:reduction` keyword (one of `:mean` `:sum` 
 ```lisp
 (proceed (L1Norm (randn `(10 10)) (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (10 10) :id TID2844 
+{CPUTENSOR[float] :shape (10 10) :id TID2805 
   :vec-state [computed]
-  ((1.0957334   0.29280537  2.9622393   ~ 0.28167194  1.5302484   0.42985225)                   
-   (5.3477087   0.24026111  1.5600696   ~ 1.7525486   0.13064909  0.7810056)   
+  ((1.1776998   1.5038658   2.5449793   ~ 0.5941694   2.2806404   0.08711177)                   
+   (0.48231566  1.3320472   0.06845546  ~ 3.004023    0.1486851   1.135155)   
                 ...
-   (0.22767365  0.34116882  0.7626      ~ 0.12396826  1.473518    0.5603208)
-   (2.091651    1.7196728   0.21944374  ~ 2.1875224   0.19380003  1.7210886))
+   (1.8803136   0.8212929   0.38042745  ~ 0.6330358   0.3380822   0.55278665)
+   (1.6317685   1.9104457   1.0400681   ~ 0.40715086  0.35511273  0.36866352))
   :facet :input
   :belongs-to :memory-pool
   :requires-grad NIL
@@ -314,13 +348,13 @@ In addition, reading the value of a `:reduction` keyword (one of `:mean` `:sum` 
 ```lisp
 (proceed (MSE (randn `(10 10)) (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (10 10) :id TID2946 
+{CPUTENSOR[float] :shape (10 10) :id TID2907 
   :vec-state [computed]
-  ((0.363951     0.76453817   1.810197     ~ 4.112536     1.9115908    1.8925937)                    
-   (8.511698     0.23303813   0.5016798    ~ 0.34629875   6.308238e-4  0.36503315)   
+  ((1.1742454    0.11002164   0.26525262   ~ 2.7933347    0.0029415141 1.1674103)                    
+   (0.8411449    0.58088213   0.16601071   ~ 1.910844     0.40484095   0.14785925)   
                  ...
-   (0.8050398    0.68807644   0.3245708    ~ 0.44783399   1.598077     3.2607603)
-   (3.2294188    2.1321013    18.540094    ~ 0.20728952   0.9719871    10.227004))
+   (2.6465602    0.0014556918 2.3077343    ~ 0.20146786   0.402512     0.056699865)
+   (6.0658503    0.4049626    0.036340326  ~ 0.6130799    10.96344     3.112103))
   :facet :input
   :belongs-to :memory-pool
   :requires-grad NIL
@@ -416,7 +450,7 @@ y = xA^\intercal + b
 ```lisp
 (LinearLayer 10 5)
 
-<Composite: LINEARLAYER{W3043}(
+<Composite: LINEARLAYER{W3004}(
     <Input : ((~ BATCH-SIZE 10)) -> Output: ((~ BATCH-SIZE 5))>
 
     WEIGHTS -> (5 10)
@@ -508,7 +542,7 @@ Note: When `Conv2D` is initialised, the output is displayed as -1. This is becau
 ```lisp
 (Conv2D 3 5 '(3 3))
 
-<Composite: CONV2D{W3053}(
+<Composite: CONV2D{W3014}(
     <Input : ((N 3 H_IN W_IN)) -> Output: ((N 5 -1 -1))>
 
     WEIGHT -> (5 3 3 3)

--- a/docs/cl-waffe2-docs/docs/vm.md
+++ b/docs/cl-waffe2-docs/docs/vm.md
@@ -111,29 +111,29 @@ Prints out the compiled cl-waffe2 IR from toplevel to each leaf points to `strea
 
 disassemble-waffe2-ir:
  [Forward]: 
-<WfInst[op=ALLOC{INTERNAL}]     : TID520 <= op(TID520{float, (3 3)} <Param>TID515{float, (3 3)})>
-<WfInst[op=EXPNODE-CPUTENSOR]   : TID520 <= op(<Param>SV4BW(TID515{float, (3 3)}) TID520{float, (3 3)})>
-<WfInst[op=SCALARMUL-CPUTENSOR] : TID550 <= op(TID550{float, (3 1)} <Input>TID542{float, (1)})>
-<WfInst[op=VIEWTENSORNODE-T]    : TID550 <= op(TID550{float, (3 3)} TID550{float, (3 1)})>
-<WfInst[op=ADDNODE-CPUTENSOR]   : TID550 <= op(TID550{float, (3 3)} TID520{float, (3 3)})>
-<WfInst[op=DIVNODE-CPUTENSOR]   : TID520 <= op(SV4BW(TID520{float, (3 3)}) SV4BW(TID550{float, (3 3)}))>
+<WfInst[op=ALLOC{INTERNAL}]     : TID481 <= op(TID481{float, (3 3)} <Param>TID476{float, (3 3)})>
+<WfInst[op=EXPNODE-CPUTENSOR]   : TID481 <= op(<Param>SV4BW(TID476{float, (3 3)}) TID481{float, (3 3)})>
+<WfInst[op=SCALARMUL-CPUTENSOR] : TID511 <= op(TID511{float, (3 1)} <Input>TID503{float, (1)})>
+<WfInst[op=VIEWTENSORNODE-T]    : TID511 <= op(TID511{float, (3 3)} TID511{float, (3 1)})>
+<WfInst[op=ADDNODE-CPUTENSOR]   : TID511 <= op(TID511{float, (3 3)} TID481{float, (3 3)})>
+<WfInst[op=DIVNODE-CPUTENSOR]   : TID481 <= op(SV4BW(TID481{float, (3 3)}) SV4BW(TID511{float, (3 3)}))>
 
 6 Instructions | 3 Tensors | 1 Scalars
 
 
  [Pullback]: 
-<WfInst[op=MOVETENSORNODE-CPUTENSOR] : TID608 <= op(TID608{float, (3 3)} <Input>TID605{float, (3 3)})>
-<WfInst[op=DIVNODE-CPUTENSOR]        : TID608 <= op(TID608{float, (3 3)} TID587{float, (3 3)})>
-<WfInst[op=MOVETENSORNODE-CPUTENSOR] : TID636 <= op(TID636{float, (3 3)} <Input>TID605{float, (3 3)})>
-<WfInst[op=SCALARMUL-CPUTENSOR]      : TID636 <= op(TID636{float, (3 3)} <Input>TID633{float, (1)})>
-<WfInst[op=MULNODE-CPUTENSOR]        : TID582 <= op(TID582{float, (3 3)} TID636{float, (3 3)})>
-<WfInst[op=VIEWTENSORNODE-T]         : TID587 <= op(TID587{float, (3 3)} TID587{float, (3 1)})>
-<WfInst[op=MULNODE-CPUTENSOR]        : TID587 <= op(TID587{float, (3 3)} TID587{float, (3 3)})>
-<WfInst[op=DIVNODE-CPUTENSOR]        : TID582 <= op(TID582{float, (3 3)} TID587{float, (3 3)})>
-<WfInst[op=SYSTEM-LAZY-CONS-T]       : TID608 TID582 <= op(TID608{float, (3 3)} TID582{float, (3 3)})>
-<WfInst[op=EXPNODE-CPUTENSOR]        : TID530 <= op(TID530{float, (3 3)} TID530{float, (3 3)})>
-<WfInst[op=MULNODE-CPUTENSOR]        : TID608 <= op(TID608{float, (3 3)} TID530{float, (3 3)})>
-<WfInst[op={GRAD}SETQ{INTERNAL}]     : <Input>TID517 <= op(<Input>TID517{float, (3 3)} TID608{float, (3 3)})>
+<WfInst[op=MOVETENSORNODE-CPUTENSOR] : TID569 <= op(TID569{float, (3 3)} <Input>TID566{float, (3 3)})>
+<WfInst[op=DIVNODE-CPUTENSOR]        : TID569 <= op(TID569{float, (3 3)} TID548{float, (3 3)})>
+<WfInst[op=MOVETENSORNODE-CPUTENSOR] : TID597 <= op(TID597{float, (3 3)} <Input>TID566{float, (3 3)})>
+<WfInst[op=SCALARMUL-CPUTENSOR]      : TID597 <= op(TID597{float, (3 3)} <Input>TID594{float, (1)})>
+<WfInst[op=MULNODE-CPUTENSOR]        : TID543 <= op(TID543{float, (3 3)} TID597{float, (3 3)})>
+<WfInst[op=VIEWTENSORNODE-T]         : TID548 <= op(TID548{float, (3 3)} TID548{float, (3 1)})>
+<WfInst[op=MULNODE-CPUTENSOR]        : TID548 <= op(TID548{float, (3 3)} TID548{float, (3 3)})>
+<WfInst[op=DIVNODE-CPUTENSOR]        : TID543 <= op(TID543{float, (3 3)} TID548{float, (3 3)})>
+<WfInst[op=SYSTEM-LAZY-CONS-T]       : TID569 TID543 <= op(TID569{float, (3 3)} TID543{float, (3 3)})>
+<WfInst[op=EXPNODE-CPUTENSOR]        : TID491 <= op(TID491{float, (3 3)} TID491{float, (3 3)})>
+<WfInst[op=MULNODE-CPUTENSOR]        : TID569 <= op(TID569{float, (3 3)} TID491{float, (3 3)})>
+<WfInst[op={GRAD}SETQ{INTERNAL}]     : <Input>TID478 <= op(<Input>TID478{float, (3 3)} TID569{float, (3 3)})>
 
 12 Instructions | 7 Tensors | 1 Scalars
 
@@ -172,34 +172,34 @@ See also: `proceed-bench`
 
 [Sorted by Instructions]
  Time(s)   |   Instruction ( * - Beyonds the average execution time)
-3.45e-4    | <WfInst[op=MOVETENSORNODE-CPUTENSOR] : TID885 <= op(TID885{float, (100 100)} <Input>TID801{float, (100 100)})>
-9.2e-5     | <WfInst[op=VIEWTENSORNODE-T]         : TID879 <= op(TID879{float, (100 1)} TID879{float, (100 1)})>
-1.37e-4    | <WfInst[op=SCALARMUL-CPUTENSOR]      : TID879 <= op(TID879{float, (100 1)} <Input>TID810{float, (1)})>
-9.6e-5     | <WfInst[op=VIEWTENSORNODE-T]         : TID879 <= op(TID879{float, (100 100)} TID879{float, (100 1)})>
-0.006066*  | <WfInst[op=ADDNODE-CPUTENSOR]        : TID879 <= op(TID879{float, (100 100)} <Input>TID801{float, (100 100)})>
-9.4e-5     | <WfInst[op=VIEWTENSORNODE-T]         : TID879 <= op(TID879{float, (100 1)} TID879{float, (100 100)})>
-0.001993*  | <WfInst[op=SCALARDIV-CPUTENSOR]      : TID879 <= op(TID879{float, (100 1)} <Input>TID805{float, (1)})>
-9.4e-5     | <WfInst[op=VIEWTENSORNODE-T]         : TID879 <= op(TID879{float, (100 100)} TID879{float, (100 1)})>
-0.004204*  | <WfInst[op=SUBNODE-CPUTENSOR]        : TID885 <= op(TID885{float, (100 100)} TID879{float, (100 100)})>
-9.67e-4    | <WfInst[op=EXPNODE-CPUTENSOR]        : TID885 <= op(TID885{float, (100 100)} TID885{float, (100 100)})>
-1.47e-4    | <WfInst[op=SCALARMUL-CPUTENSOR]      : TID879 <= op(TID879{float, (100 1)} <Input>TID930{float, (1)})>
-1.01e-4    | <WfInst[op=VIEWTENSORNODE-T]         : TID879 <= op(TID879{float, (100 100)} TID879{float, (100 1)})>
-0.005937*  | <WfInst[op=ADDNODE-CPUTENSOR]        : TID879 <= op(TID879{float, (100 100)} TID885{float, (100 100)})>
-0.003947*  | <WfInst[op=DIVNODE-CPUTENSOR]        : TID885 <= op(TID885{float, (100 100)} TID879{float, (100 100)})>
+3.98e-4    | <WfInst[op=MOVETENSORNODE-CPUTENSOR] : TID846 <= op(TID846{float, (100 100)} <Input>TID762{float, (100 100)})>
+1.01e-4    | <WfInst[op=VIEWTENSORNODE-T]         : TID840 <= op(TID840{float, (100 1)} TID840{float, (100 1)})>
+1.49e-4    | <WfInst[op=SCALARMUL-CPUTENSOR]      : TID840 <= op(TID840{float, (100 1)} <Input>TID771{float, (1)})>
+9.8e-5     | <WfInst[op=VIEWTENSORNODE-T]         : TID840 <= op(TID840{float, (100 100)} TID840{float, (100 1)})>
+0.006252*  | <WfInst[op=ADDNODE-CPUTENSOR]        : TID840 <= op(TID840{float, (100 100)} <Input>TID762{float, (100 100)})>
+9.6e-5     | <WfInst[op=VIEWTENSORNODE-T]         : TID840 <= op(TID840{float, (100 1)} TID840{float, (100 100)})>
+0.001905*  | <WfInst[op=SCALARDIV-CPUTENSOR]      : TID840 <= op(TID840{float, (100 1)} <Input>TID766{float, (1)})>
+9.4e-5     | <WfInst[op=VIEWTENSORNODE-T]         : TID840 <= op(TID840{float, (100 100)} TID840{float, (100 1)})>
+0.004064*  | <WfInst[op=SUBNODE-CPUTENSOR]        : TID846 <= op(TID846{float, (100 100)} TID840{float, (100 100)})>
+9.78e-4    | <WfInst[op=EXPNODE-CPUTENSOR]        : TID846 <= op(TID846{float, (100 100)} TID846{float, (100 100)})>
+1.35e-4    | <WfInst[op=SCALARMUL-CPUTENSOR]      : TID840 <= op(TID840{float, (100 1)} <Input>TID891{float, (1)})>
+1.15e-4    | <WfInst[op=VIEWTENSORNODE-T]         : TID840 <= op(TID840{float, (100 100)} TID840{float, (100 1)})>
+0.006132*  | <WfInst[op=ADDNODE-CPUTENSOR]        : TID840 <= op(TID840{float, (100 100)} TID846{float, (100 100)})>
+0.004016*  | <WfInst[op=DIVNODE-CPUTENSOR]        : TID846 <= op(TID846{float, (100 100)} TID840{float, (100 100)})>
 
-14 Instructions | 6 Tensors | Overheads due to SV4BW(...) -> 4.95e-6(s) 
+14 Instructions | 6 Tensors | Overheads due to SV4BW(...) -> 5.38e-6(s) 
 
- Total Time: 0.024220001 sec
+ Total Time: 0.024533 sec
 
 [Sorted by topK]
  Instruction                         | Total time (s) | Time/Total (n-sample=100)
-<WfInst[op=ADDNODE-CPUTENSOR]        | 0.012003       | 49.558212%
-<WfInst[op=SUBNODE-CPUTENSOR]        | 0.004204       | 17.357555%
-<WfInst[op=DIVNODE-CPUTENSOR]        | 0.003947       | 16.29645%
-<WfInst[op=SCALARDIV-CPUTENSOR]      | 0.001993       | 8.228736%
-<WfInst[op=EXPNODE-CPUTENSOR]        | 9.67e-4        | 3.992568%
-<WfInst[op=VIEWTENSORNODE-T]         | 4.7700002e-4   | 1.9694468%
-<WfInst[op=MOVETENSORNODE-CPUTENSOR] | 3.45e-4        | 1.4244426%
-<WfInst[op=SCALARMUL-CPUTENSOR]      | 2.84e-4        | 1.1725847%
+<WfInst[op=ADDNODE-CPUTENSOR]        | 0.012384       | 50.478947%
+<WfInst[op=SUBNODE-CPUTENSOR]        | 0.004064       | 16.565443%
+<WfInst[op=DIVNODE-CPUTENSOR]        | 0.004016       | 16.369787%
+<WfInst[op=SCALARDIV-CPUTENSOR]      | 0.001905       | 7.765051%
+<WfInst[op=EXPNODE-CPUTENSOR]        | 9.78e-4        | 3.9864671%
+<WfInst[op=VIEWTENSORNODE-T]         | 5.04e-4        | 2.054376%
+<WfInst[op=MOVETENSORNODE-CPUTENSOR] | 3.98e-4        | 1.6223047%
+<WfInst[op=SCALARMUL-CPUTENSOR]      | 2.84e-4        | 1.1576245%
 
 ```

--- a/source/backends/lisp/arithmetic.lisp
+++ b/source/backends/lisp/arithmetic.lisp
@@ -1,6 +1,7 @@
 
 (in-package :cl-waffe2/backends.lisp)
 
+;; [TODO] Replace them with iterator
 (macrolet ((define-arith-func (name f)
 	     `(define-with-typevar (,name u) (x y offsetx offsety size incx incy)
 		(declare (optimize (speed 3))
@@ -49,6 +50,7 @@
 (define-impl (AddNode :device LispTensor)
 	     :forward ((self x y)
 		       (let ((adder (matrix-add (dtype x))))
+			 ;; iteration.lisp can be by far faster altenative of call-with-view
 			 `(,@(call-with-view
 			      #'(lambda (x-view
 					 y-view)

--- a/source/backends/lisp/iterator.lisp
+++ b/source/backends/lisp/iterator.lisp
@@ -21,7 +21,7 @@ apply - Set to (apply function array). nil to (dotimes (...) ... )"
   (apply  apply  :type boolean)
   (out-to out-to :type AbstractTensor)
   (args   args   :type list)
-  (opform opform :type (or function symbol list))
+  (opform opform :type (or function symbol))
   (reduced-to reduced-to :type fixnum))
 
 (defun expand-iteration (tensors instructions)
@@ -74,7 +74,7 @@ apply - Set to (apply function array). nil to (dotimes (...) ... )"
 	 (assert (= (length ,results) (the fixnum ,(lli-reduced-to instruction)))
 		 nil
 		 "lazy-reduction: Assertion was failed. the function is excepted to be returning ~a arguments but got ~a"
-		 (lli-reduced-to instruction)
+		 ,(lli-reduced-to instruction)
 		 (length ,results))
 	 (dotimes (,index-symbol ,(lli-reduced-to instruction))
 	   (setf ,(lazy-aref-form (lli-out-to instruction) indices) (nth ,index-symbol ,results))))

--- a/source/backends/lisp/iterator.lisp
+++ b/source/backends/lisp/iterator.lisp
@@ -1,0 +1,88 @@
+
+(in-package :cl-waffe2/backends.lisp)
+
+(defun iterator-symbols (rank)
+  (loop for r upfrom 0 below rank
+	collect
+	(intern (format nil "~a~a" (gensym "L") (code-char (+ 65 r))))))
+
+(defun lisp-name (value)
+  (typecase value
+    (symbol     
+     `(the fixnum (cl-waffe2/vm.generic-tensor::read-symbol ',value)))
+    (T
+     value)))
+
+(defstruct (LazyLispInstruction
+	    (:conc-name lli-)
+	    (:constructor make-lli (opform out-to args &key (apply nil))))
+  "LazyLispInstruction, an blueprint for expand-iteration.
+apply - Set to (apply function array). nil to (dolist (...) ... )"
+  (apply  apply  :type boolean)
+  (out-to out-to :type AbstractTensor)
+  (args   args   :type list)
+  (opform opform :type (or function symbol list)))
+
+(defun expand-iteration (tensors instructions)
+  (let* ((abstract-loop (solve-loop-order tensors 1 T :mode :runtime))
+	 (indices       (iterator-symbols (dims (car tensors)))))
+    (labels ((expand-helper (rank)
+	       (let ((aloop (nth rank abstract-loop))
+		     (index (nth rank indices)))
+		 (case (aloop-mode aloop)
+		   (:batch
+		    `(dotimes (,index ,(lisp-name (aloop-size aloop)))
+		       ,(expand-helper (1+ rank))))
+		   (T
+		    `(progn
+		       ,@(map
+			  'list
+			  #'(lambda (inst)
+			      (expand-instruction
+			       aloop
+			       inst
+			       index
+			       indices))
+			  instructions)))))))		    
+      (expand-helper 0))))
+
+(defun lazy-aref-form (tensor indices)
+  `(aref ,(tensor-id tensor)
+	 (the (unsigned-byte 32)
+	      (+
+	       ,@(loop for dim upfrom 0 below (dims tensor)
+		       for stride in (tensor-actual-stride tensor)
+		       for index in indices
+		       collect
+		       `(the (unsigned-byte 32) (* ,stride ,index)))))))
+
+(defun expand-instruction (aloop instruction index-symbol indices)
+  (declare (type LazyLispInstruction instruction))
+  (if (lli-apply instruction)
+      `(let ((,index-symbol 0))
+	 (declare (ignorable ,index-symbol)
+		  (type (unsigned-byte 32) ,index-symbol))
+	 (setf ,(lazy-aref-form (lli-out-to instruction) indices)
+	       (apply ,(lli-opform instruction)
+		      ,@(loop for tensor in (lli-args instruction)
+			      collect
+			      `(loop for ,index-symbol of-type (unsigned-byte 32)
+				     upfrom 0
+				       below ,(lisp-name (car (last (shape tensor))))
+				     collect
+				     (lazy-aref-form tensor indices))))))
+      `(dolist (,index-symbol ,(lisp-name (aloop-element-n aloop)))
+	 (setf ,(lazy-aref-form (lli-out-to instruction) indices)
+	       (funcall
+		,(lli-opform instruction)
+		,@(loop for tensor in (lli-args instruction)
+			collect
+			(lazy-aref-form tensor indices)))))))
+
+(defun lazy-call-form (tensors instructions)
+  `(locally (declare ,@(loop for tensor in tensors
+			     collect
+			     `(type (simple-array ,(dtype->lisp-type (dtype tensor)) (*)) ,(tensor-id tensor)))
+		     (optimize (speed 3)))
+     ,(expand-iteration tensors instructions)))
+

--- a/source/backends/lisp/lazy.lisp
+++ b/source/backends/lisp/lazy.lisp
@@ -1,0 +1,34 @@
+
+(in-package :cl-waffe2/backends.lisp)
+
+;; LazyXXXNodes are also dispatched by what functions are compiled
+(defun lazy-dispatcher (self x y)
+  (declare (ignore x y))
+  `(,(forward-of self) ,(backward-of self) ,(reduced-of self)))
+
+;; AbstractElementWise
+(define-impl (Lazy-Function-Node :device LispTensor :cache-id #'lazy-dispatcher)
+	     :forward ((self x out)
+		       (lazy-call-form
+			(list x out)
+			(list
+			 (make-lli
+			  (forward-of self)
+			  out
+			  (list x)
+			  :apply nil))
+			out)))
+
+(define-impl (Lazy-Reduce-Node :device LispTensor :cache-id #'lazy-dispatcher)
+	     :forward ((self reduced x)
+		       (lazy-call-form
+			(list reduced x)
+			(list
+			 (make-lli
+			  (forward-of self)
+			  reduced
+			  (list x)
+			  :apply T
+			  :reduced-to (reduced-of self)))
+			reduced)))
+

--- a/source/backends/lisp/t/package.lisp
+++ b/source/backends/lisp/t/package.lisp
@@ -5,6 +5,8 @@
   (:use :cl
         :fiveam
         :cl-waffe2
+        :cl-waffe2/backends.lisp
+        :cl-waffe2/distributions
         :cl-waffe2/base-impl
         :cl-waffe2/base-impl.test
         :cl-waffe2/vm.generic-tensor
@@ -38,4 +40,46 @@
 
 (comparison-test-set LispTensor)
 ;;)
+
+(defun ~= (x y)
+  (- (abs (- x y)) 0.00001))
+
+(defun lazy-test ()
+  (let ((result1
+	  (with-devices (LispTensor)
+	    (tensor-vec (proceed (lazy #'sin (!permute (ax+b `(10 10 10) 1 0) 2 0 1))))))
+	(result2
+	  (tensor-vec (proceed (!sin (!permute (ax+b `(10 10 10) 1 0) 2 0 1))))))
+    (every #'~= result1 result2)))
+
+
+(defun lazy-diff-p ()
+  (let* ((a1 (parameter (ax+b `(3 3) 1 0)))
+	 (a2 (parameter (ax+b `(3 3) 1 0))))
+
+    (proceed-backward
+     (lazy #'sin a1 :diff #'cos))
+
+    (proceed-backward
+     (!sin a2))
+
+    (every #'~= (tensor-vec (grad a1)) (tensor-vec (grad a2)))))
+
+(defun lazy-reduce-test ()
+  (let ((result1
+	  (with-devices (LispTensor)
+	    (tensor-vec (proceed (lazy-reduce #'max (!permute (ax+b `(10 10 10) 1 0) 2 0 1))))))
+	(result2
+	  (tensor-vec (proceed (!max (!permute (ax+b `(10 10 10) 1 0) 2 0 1) :axis 1)))))
+    (every #'~= result1 result2)))
+
+(test lazy-op-test
+  (is (lazy-test)))
+
+(test lazy-diff-p
+  (is (lazy-diff-p)))
+
+(test lazy-reduce-test-max
+  (is (lazy-reduce-test)))
+
 

--- a/source/base-impl/ir.lisp
+++ b/source/base-impl/ir.lisp
@@ -9,6 +9,117 @@
 ;;   RecurrentNode
 ;;
 ;; Additionally,
-;;  ElementWiseNode
-;;
+;;  Lazy-Function
+;;  Lazy-Reduce
+
+;; [TODO] Enhancement:&rest argument for defnode
+
+;; [TODO]
+;;  - LispTensor Implementation
+;;  - Docstring
+;;  - Add: topk
+;;  - Add: Tests
+;;  - Update: Mkdocs
+;;  - Add: define-elwise-impl
+
+(deftype lazy-computable-t ()
+  "A list of types which can be dynamically compiled and cached"
+  `(or symbol list function))
+
+(defun all-bool-p (x) (every #'(lambda (x) (typep x 'boolean)) x))
+(deftype sv4bw-t () ;; = (T NIL T NIL ...)
+  `(or null (and list (satisfies all-bool-p))))
+
+(defnode (Lazy-Function-Node (self forward &key (backward nil) (sv4bw nil))
+	  :slots ((forward   :initarg :forward  :initform nil :accessor forward-of)
+		  (backward  :initarg :backward :initform nil :accessor backward-of)
+		  (reduced-to :initform nil :accessor reduced-of))
+	  :documentation "
+
+"
+	  :where (X[~] OUT[~] -> OUT[~])
+	  :backward ((self dout x out)
+		     (declare (ignore out))
+		     (when (null (backward-of self))
+		       (error "lazy: In order to differentiate the lazy operation ~a, specify :backward.
+(lazy op tensor ... :diff nil)
+                           L Specify this form."
+			      (forward-of self)))
+		     (values (!mul dout (lazy (backward-of self) x)) nil)))
+  (setf (node-save-for-backward self) sv4bw))
+
+(defnode (Lazy-Reduce-Node (self forward &key (backward nil) (sv4bw nil) (reduced 1))
+	  :slots ((forward  :initarg :forward  :initform nil :accessor forward-of)
+		  (backward :initarg :backward :initform nil :accessor backward-of)
+		  (reduced  :initarg :reduced  :initform nil :accessor reduced-of))
+	  :documentation "
+"
+	  :where (Reduced[~ reduced] X[~ dim] -> Reduced[~ reduced]))
+  (setf (node-save-for-backward self) sv4bw))
+
+(declaim (ftype (function (lazy-computable-t
+			   AbstractTensor
+			   &key
+			   (:diff (or null lazy-computable-t))
+			   (:sv4bw sv4bw-t))
+			  AbstractTensor)
+		lazy))
+(defun lazy (op tensor &key (diff nil) (sv4bw nil))
+  "
+## [function] lazy
+
+```lisp
+(lazy op tensor &key (diff nil) (sv4bw nil))
+```
+
+### Input
+
+"
+  (declare (type AbstractTensor tensor)
+	   (type list sv4bw))
+
+  (let ((out
+	  (call (Lazy-Function-Node op :backward diff :sv4bw sv4bw)
+		tensor
+		(!copy tensor :maybe-in-place t))))
+    ;; Returning the first of returned tensors
+    out))
+
+
+(declaim (ftype (function (lazy-computable-t
+			   AbstractTensor
+			   &key
+			   (:reduce-to fixnum)
+			   (:diff (or null lazy-computable-t))
+			   (:sv4bw sv4bw-t))
+			  AbstractTensor)
+		lazy-reduce))
+(defun lazy-reduce (op tensor &key (reduce-to 1) (diff nil) (sv4bw nil))
+  "
+## [function] lazy-reduce
+
+```lisp
+(lazy-reduce op tensor &key (reduce-to 1) (diff nil) (sv4bw nil))
+```
+
+### Input
+
+"
+  (declare (type AbstractTensor tensor)
+	   (type list sv4bw))
+
+  (assert (null diff)
+	  nil
+	  "Assertion Failed: As of this writing, lazy-reduce isn't differentiable... (TODO)
+Set :diff = nil to ignore this assertion")
+  
+  (let* ((reduced (make-input `(,@(butlast (shape tensor)) ,reduce-to) nil
+			      :dtype (dtype tensor)
+			      :order (order tensor)))
+	 (out
+	   (call (Lazy-Reduce-Node op :backward diff :sv4bw sv4bw :reduced reduce-to)
+		 reduced
+		 tensor)))
+    ;; Returning the first of returned tensors
+    out))
 

--- a/source/base-impl/ir.lisp
+++ b/source/base-impl/ir.lisp
@@ -15,9 +15,9 @@
 ;; [TODO] Enhancement:&rest argument for defnode
 
 ;; [TODO]
-;;  - LispTensor Implementation
+;;  - LispTensor Implementation (OK)
 ;;  - Docstring
-;;  - Add: topk
+;;  - Add: topk (OK, standard implはexportしない)
 ;;  - Add: Tests
 ;;  - Update: Mkdocs
 ;;  - Add: define-elwise-impl

--- a/source/base-impl/ir.lisp
+++ b/source/base-impl/ir.lisp
@@ -16,26 +16,45 @@
 
 ;; [TODO]
 ;;  - LispTensor Implementation (OK)
-;;  - Docstring
-;;  - Add: topk (OK, standard implはexportしない)
-;;  - Add: Tests
+;;  - Docstring (OK)
+;;  - Add: topk (OK)
+;;  - Add: Tests Backward Tests
 ;;  - Update: Mkdocs
-;;  - Add: define-elwise-impl
+;;  - Add: define-elwise-impl Add/Moveあたり、、、こっちの実装でReplace
 
 (deftype lazy-computable-t ()
   "A list of types which can be dynamically compiled and cached"
-  `(or symbol list function))
+  `(or symbol function))
 
 (defun all-bool-p (x) (every #'(lambda (x) (typep x 'boolean)) x))
-(deftype sv4bw-t () ;; = (T NIL T NIL ...)
-  `(or null (and list (satisfies all-bool-p))))
 
 (defnode (Lazy-Function-Node (self forward &key (backward nil) (sv4bw nil))
 	  :slots ((forward   :initarg :forward  :initform nil :accessor forward-of)
 		  (backward  :initarg :backward :initform nil :accessor backward-of)
 		  (reduced-to :initform nil :accessor reduced-of))
 	  :documentation "
+An abstract computation node that dynamically compile the given kernel specified by `forward` with a loop, applying it to X and OUT element-wise. A backend `LispTensor` already provides a standard implementation of it and can be used by the `(cl-waffe2/base-impl:lazy ...)` function. This node is useful when calling mathematical functions not provided by cl-waffe2 as standard; (Note that no speed improvement can be expected from SIMD.)
 
+```lisp
+;; Example:
+(lazy #'sin (randn `(3 3)) :diff #'cos :sv4bw t)
+```
+
+### Inputs
+
+- `forward[symbol or function]` indicates a name of function of forward propagation. the function must receive a single argument of corresponding element.
+
+- `backward[symbol or function]` indicates a name of function of backward propagation. As the backward definition indicates, the gradient of the previous node is automatically combined by Lazy-Function-Node. therefore, #'cos is enough for example.
+
+- `sv4bw[boolean]` set T to copy the result of X.
+
+### Workload
+
+- [x] implement
+- [x] make it differentiable
+- [x] compiled kernels are cached in LUT.
+- [ ] parallelize by lparallel
+- [ ] Loop Collapse/Reordering
 "
 	  :where (X[~] OUT[~] -> OUT[~])
 	  :backward ((self dout x out)
@@ -46,40 +65,62 @@
                            L Specify this form."
 			      (forward-of self)))
 		     (values (!mul dout (lazy (backward-of self) x)) nil)))
-  (setf (node-save-for-backward self) sv4bw))
+  (setf (node-save-for-backward self) (list sv4bw nil)))
 
 (defnode (Lazy-Reduce-Node (self forward &key (backward nil) (sv4bw nil) (reduced 1))
 	  :slots ((forward  :initarg :forward  :initform nil :accessor forward-of)
 		  (backward :initarg :backward :initform nil :accessor backward-of)
 		  (reduced  :initarg :reduced  :initform nil :accessor reduced-of))
 	  :documentation "
+As well as `Lazy-Function-Node`, this node dynamically compiles the given kernel specified by `forward` with a loop, applying it to X and OUT element-wise. The only difference is that the last dimension of returned tensor is reduced to `reduced`. The kernel function `forward` wil receive all elements of the last dimension of `X`, and selects from it and return `reduced` values. (Note that the value is returned by `(apply #'values list)`, NOT A LIST.)
+
+See the example of `lazy-reduce`.
+
+As of this writing, this node isn't differentiable.
+
+### Workload
+
+- [x] implement
+- [ ] make it differentiable
+- [ ] caching
+- [ ] parallelize by lparallel
+- [ ] loop oriented optimizations
 "
 	  :where (Reduced[~ reduced] X[~ dim] -> Reduced[~ reduced]))
-  (setf (node-save-for-backward self) sv4bw))
+  (setf (node-save-for-backward self) (list nil sv4bw)))
 
 (declaim (ftype (function (lazy-computable-t
 			   AbstractTensor
 			   &key
-			   (:diff (or null lazy-computable-t))
-			   (:sv4bw sv4bw-t))
+			   (:diff (or null lazy-computable-t)))
 			  AbstractTensor)
 		lazy))
-(defun lazy (op tensor &key (diff nil) (sv4bw nil))
+(defun lazy (op tensor &key (diff nil))
   "
 ## [function] lazy
 
 ```lisp
-(lazy op tensor &key (diff nil) (sv4bw nil))
+(lazy op tensor &key (diff nil))
 ```
 
-### Input
+Invokes AbstractNode `Lazy-Function-Node` that dynamically compile the given kernel specified by `op` with a loop, applying it to tensor and store the result to the copied one (this node can be pruned if unnecessary).
 
+```lisp
+;; Example:
+(lazy #'sin (randn `(3 3)) :diff #'cos)
+```
+### Inputs
+
+- `op[symbol or function]` indicates a name of function of forward propagation. the function must receive a single argument of corresponding element.
+
+- `tensor[AbstractTensor]` a tensor to be applied.
+
+- `diff[symbol or function]` indicates a name of function of backward propagation. As the backward definition indicates, the gradient of the previous node is automatically combined by Lazy-Function-Node. therefore, #'cos is enough for example. If diff is set to something, `save-for-backward` automaticaly becomes T.
 "
-  (declare (type AbstractTensor tensor)
-	   (type list sv4bw))
+  (declare (type AbstractTensor tensor))
 
   (let ((out
-	  (call (Lazy-Function-Node op :backward diff :sv4bw sv4bw)
+	  (call (Lazy-Function-Node op :backward diff :sv4bw (when diff t))
 		tensor
 		(!copy tensor :maybe-in-place t))))
     ;; Returning the first of returned tensors
@@ -90,23 +131,58 @@
 			   AbstractTensor
 			   &key
 			   (:reduce-to fixnum)
-			   (:diff (or null lazy-computable-t))
-			   (:sv4bw sv4bw-t))
+			   (:diff (or null lazy-computable-t)))
 			  AbstractTensor)
 		lazy-reduce))
-(defun lazy-reduce (op tensor &key (reduce-to 1) (diff nil) (sv4bw nil))
+(defun lazy-reduce (op tensor &key (reduce-to 1) (diff nil))
   "
 ## [function] lazy-reduce
 
 ```lisp
-(lazy-reduce op tensor &key (reduce-to 1) (diff nil) (sv4bw nil))
+(lazy-reduce op tensor &key (reduce-to 1) (diff nil))
 ```
+
+(See also: Lazy-Reduce-Node)
+
+As well as `lazy`, this function dynamically compiles the given kernel specified by `op` with a loop, applying it to tensor and stores the result to the copied tensor (can be pruned if unnecessary). The only difference is that the last dimension of returned tensor is reduced to `reduced`. The kernel function `op` wil receive all elements of the last dimension of `X`, and selects from it and return `reduced` values. (Note that the value is returned by `(apply #'values list)`, NOT A LIST.)
 
 ### Input
 
+
+- `op[symbol or function]` indicates a name of function of forward propagation. the function will receive all elements of last dimension.
+
+- `tensor[AbstractTensor]` tensor to be applied.
+
+- `reduced-to[fixnum]` a fixnum indicating the number of elements reduced.
+
+- `diff[symbol or function]` (currently ignored)
+
+- `sv4bw[bool]` (currently ignored)
+
+
+### Examples
+
+`my-topk` is a function to retrieve the Kth largest value in the last dimension.
+
+```lisp
+(defun topk (k)
+  #'(lambda (&rest args)
+      (let ((topN (sort args #'>)))
+	(apply #'values (loop for n upfrom 0 below K collect (nth n topN))))))
+
+(lazy-reduce (topk 3) (ax+b `(10 10) 1 0) :reduce-to 3)
+
+(defun my-topk (tensor k)
+    (lazy-reduce (topk K) tensor :reduce-to k))
+
+(my-topk (ax+b `(10 10) 1 0) 3)
+```
+
+```lisp
+(lazy-reduce #'max (ax+b `(10 10) 1 0))
+```
 "
-  (declare (type AbstractTensor tensor)
-	   (type list sv4bw))
+  (declare (type AbstractTensor tensor))
 
   (assert (null diff)
 	  nil
@@ -117,7 +193,7 @@ Set :diff = nil to ignore this assertion")
 			      :dtype (dtype tensor)
 			      :order (order tensor)))
 	 (out
-	   (call (Lazy-Reduce-Node op :backward diff :sv4bw sv4bw :reduced reduce-to)
+	   (call (Lazy-Reduce-Node op :backward diff :sv4bw (when diff t) :reduced reduce-to)
 		 reduced
 		 tensor)))
     ;; Returning the first of returned tensors

--- a/source/base-impl/ir.lisp
+++ b/source/base-impl/ir.lisp
@@ -14,14 +14,6 @@
 
 ;; [TODO] Enhancement:&rest argument for defnode
 
-;; [TODO]
-;;  - LispTensor Implementation (OK)
-;;  - Docstring (OK)
-;;  - Add: topk (OK)
-;;  - Add: Tests Backward Tests
-;;  - Update: Mkdocs
-;;  - Add: define-elwise-impl Add/Moveあたり、、、こっちの実装でReplace
-
 (deftype lazy-computable-t ()
   "A list of types which can be dynamically compiled and cached"
   `(or symbol function))

--- a/source/base-impl/ir.lisp
+++ b/source/base-impl/ir.lisp
@@ -8,5 +8,7 @@
 ;;   MapNode
 ;;   RecurrentNode
 ;;
-
+;; Additionally,
+;;  ElementWiseNode
+;;
 

--- a/source/base-impl/ir.lisp
+++ b/source/base-impl/ir.lisp
@@ -29,7 +29,7 @@ An abstract computation node that dynamically compile the given kernel specified
 
 ```lisp
 ;; Example:
-(lazy #'sin (randn `(3 3)) :diff #'cos :sv4bw t)
+(lazy #'sin (randn `(3 3)) :diff #'cos)
 ```
 
 ### Inputs

--- a/source/base-impl/package.lisp
+++ b/source/base-impl/package.lisp
@@ -6,6 +6,14 @@
         :cl-waffe2/vm.generic-tensor
 	:cl-waffe2/vm.nodes)
   (:export
+   #:Lazy-Function-Node
+   #:Lazy-Reduce-Node
+   #:lazy
+   #:lazy-reduce
+   #:forward-of
+   #:backward-of
+   #:reduced-of)
+  (:export
    #:MoveTensorNode
    #:MoveScalarTensorNode
    #:movetensor-ignore-me

--- a/source/base-impl/utils.lisp
+++ b/source/base-impl/utils.lisp
@@ -121,4 +121,5 @@ If the shapes does not change before/after padding, returns the given tensor as 
 			       :order ,(order tensor)))))
       (multiple-value-bind (new-tensor* reverser) (apply #'!view new-tensor padding-view)
 	(apply #'!view (!move new-tensor* tensor :force t) reverser)))))
-			     
+
+

--- a/source/nn/norms.lisp
+++ b/source/nn/norms.lisp
@@ -1,7 +1,7 @@
 
 (in-package :cl-waffe2/nn)
 
-(defmodel (BatchNorm (self in-features &key (affine t) (eps 1e-5))
+(defmodel (BatchNorm2D (self in-features &key (affine t) (eps 1e-5))
 	   :documentation "Applies Batch Normalization over a 4D input (N C H W) as described in the paper [Batch Normalization](https://arxiv.org/abs/1502.03167).
 
 ```math
@@ -41,7 +41,7 @@ BatchNorm(x) = \\frac{x - E[x]}{\\sqrt{Var[x] + ε}}\\times{γ}+β
     (setf (alpha-of self) (parameter (ax+b `(,in-features) 0 1))
 	  (beta-of  self) (parameter (ax+b `(,in-features) 0 0)))))
 
-(defmodel (LayerNorm (self normalized-shape &key (eps 1.0e-5) (affine T))
+(defmodel (LayerNorm2D (self normalized-shape &key (eps 1.0e-5) (affine T))
 	   :slots ((alpha :initform nil :accessor alpha-of)
 		   (beta  :initform nil :accessor beta-of)
 		   (shape :initform nil :initarg :normalized-shape :accessor dim-of)

--- a/source/nn/package.lisp
+++ b/source/nn/package.lisp
@@ -17,8 +17,8 @@
    #:Linear-bias)
 
   (:export
-   #:BatchNorm
-   #:LayerNorm)
+   #:BatchNorm2D
+   #:LayerNorm2D)
 
   (:export
    #:Conv2D

--- a/source/vm/generic-tensor/package.lisp
+++ b/source/vm/generic-tensor/package.lisp
@@ -41,6 +41,7 @@
    #:tensor-out-n
    #:tensor-vec
    #:tensor-facet
+   #:tensor-actual-stride
    #:tensor-stride
    #:tensor-name
    #:shape-with-broadcastable

--- a/source/vm/nodes/defnode.lisp
+++ b/source/vm/nodes/defnode.lisp
@@ -556,6 +556,10 @@ The node definitely works, but each time you compile it the function `(compile n
   (or (node-save-for-backward1 node)
       (node-save-for-backward2 node)))
 
+(defun (setf node-save-for-backward) (new-value node)
+  (setf (slot-value node 'save-for-backward-space1) new-value
+	(slot-value node 'save-for-backward-space2) new-value))
+	
 
 (defmacro define-impl-op ((abstract-name
 			   &key

--- a/source/vm/nodes/package.lisp
+++ b/source/vm/nodes/package.lisp
@@ -105,7 +105,9 @@
    #:define-and-impl-node
 
    #:define-impl-op
-   #:define-op)
+   #:define-op
+
+   #:node-save-for-backward)
   ;; Reject-p-utils
   (:export
    #:supported-dtypes-are)

--- a/source/vm/nodes/utils.lisp
+++ b/source/vm/nodes/utils.lisp
@@ -267,3 +267,4 @@ Expands `defnode` and `define-impl` at the same time.
      (define-impl (,abstract-name :device ,device :cache-when-compiled ,cache-when-compiled :reject-p ,reject-p)
 		  :save-for-backward ,save-for-backward
 		  :forward ,forward)))
+


### PR DESCRIPTION
# Changes

## Added: lazy, lazy-reduce

With the `lazy` and `lazy-reduce` functions, users can benefit from loop optimization of cl-waffe2 without adding new backend.

```lisp
;; Example:
(lazy #'sin (randn `(3 3)) :diff #'cos)
```

```lisp
(defun topk (k)
  #'(lambda (&rest args)
      (let ((topN (sort args #'>)))
	(apply #'values (loop for n upfrom 0 below K collect (nth n topN))))))

(lazy-reduce (topk 3) (ax+b `(10 10) 1 0) :reduce-to 3)

(defun my-topk (tensor k)
    (lazy-reduce (topk K) tensor :reduce-to k))

(my-topk (ax+b `(10 10) 1 0) 3)
```

## APIs

- [Add] BatchNorm2D
- [Change] Renamed LayerNorm -> LayerNorm2D
- [Changed] Renamed BatchNorm -> BatchNorm2D