### PR TITLE
[Enhancement] Full Support for Dynamic Shape

### DIFF
--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -50,7 +50,7 @@
   :components ((:file "threads")
 	       (:file "vm/generic-tensor/package")	       
 	       (:file "vm/generic-tensor/conditions")
-	       (:file "vm/generic-tensor/dtype")
+	       
 	       
 	       (:file "vm/generic-tensor/render")
 	       (:file "vm/generic-tensor/default-impls")
@@ -61,6 +61,7 @@
 	       (:file "base-impl/package")
 
 	       (:file "vm/package")
+	       (:file "vm/generic-tensor/dtype")
 	       (:file "vm/lazy-subscript")
 	       (:file "vm/allocation")
 	       
@@ -216,6 +217,7 @@
   :depends-on (:cl-waffe2 :fiveam)
   :components ((:file "vm/t/package")
 	       (:file "vm/t/lazy-axis")
+	       (:file "vm/t/utils")
 	       (:file "vm/generic-tensor/t/package")
 	       (:file "vm/generic-tensor/t/forward")
 	       (:file "vm/generic-tensor/t/backward")
@@ -247,8 +249,7 @@
 	       (:file "nn/t/conv")
 	       (:file "nn/t/activation")
 	       (:file "nn/t/criterion")
-	       (:file "nn/t/regression")
-	       
+	       (:file "nn/t/regression")	       
 	       )
   :perform (test-op (o s)
 		    (symbol-call :fiveam :run! :vm-test)

--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -43,6 +43,7 @@
 	       :trivial-garbage
 	       :cl-waffe2/simd-extension
 
+	       :cl-environments
 	       :numpy-file-format
 	       :jonathan)
   ;; TODO: Use components and split dependencies.
@@ -60,6 +61,7 @@
 	       (:file "base-impl/package")
 
 	       (:file "vm/package")
+	       (:file "vm/lazy-subscript")
 	       (:file "vm/allocation")
 	       
 	       (:file "vm/generic-tensor/cache")
@@ -72,6 +74,7 @@
 	       (:file "optimizers/package")
 	       
 	       (:file "vm/generic-tensor/acceptor" :depends-on ("vm/allocation"))
+	       (:file "vm/generic-tensor/dynamic-shape")
 	       (:file "vm/generic-tensor/tensor")
 	       (:file "vm/generic-tensor/lut")
 	       

--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -214,7 +214,9 @@
   :serial t
   :pathname "source"
   :depends-on (:cl-waffe2 :fiveam)
-  :components ((:file "vm/generic-tensor/t/package")
+  :components ((:file "vm/t/package")
+	       (:file "vm/t/lazy-axis")
+	       (:file "vm/generic-tensor/t/package")
 	       (:file "vm/generic-tensor/t/forward")
 	       (:file "vm/generic-tensor/t/backward")
 	       (:file "vm/generic-tensor/t/view")
@@ -249,6 +251,7 @@
 	       
 	       )
   :perform (test-op (o s)
+		    (symbol-call :fiveam :run! :vm-test)
 		    (symbol-call :fiveam :run! :jit-lisp-test)
 		    
 		    (symbol-call :fiveam :run! :test-nodes)

--- a/docs/cl-waffe2-docs/docs/generic-tensor.md
+++ b/docs/cl-waffe2-docs/docs/generic-tensor.md
@@ -433,7 +433,7 @@ Compiles the given computation node starting from `toplevel`. The docstring of `
 > (setq out (!add (make-input `(a 10) :X) (make-input `(a 10) :Y)))
 ```
 ```
-{CPUTENSOR[float] :shape (A 10) :id TID1860 
+{CPUTENSOR[float] :shape (A 10) :id TID1881 
   :vec-state [maybe-not-computed]
     <<Not allocated: size=(A 10)>>
   :facet :input
@@ -653,7 +653,7 @@ In order to parse the state_dict key, the function `parse-state-dict-key` is ava
 > (make-state-dict (build (call (LinearLayer 10 10) (randn `(10 10)))))
 ```
 ```
-#S(STATE-DICT :TABLE #<HASH-TABLE :TEST EQUAL :COUNT 2 {10037FCF63}>
+#S(STATE-DICT :TABLE #<HASH-TABLE :TEST EQUAL :COUNT 2 {10045F03B3}>
  table-key-to-value:
     param:linearlayer.0.bias    -> CPUTENSOR{FLOAT}(10)
     param:linearlayer.0.weights -> CPUTENSOR{FLOAT}(10 10)

--- a/docs/cl-waffe2-docs/docs/nn.md
+++ b/docs/cl-waffe2-docs/docs/nn.md
@@ -19,7 +19,7 @@ ReLU(x) = max(x, 0)
 ```lisp
 (proceed (!relu (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (10 10) :id TID2209 
+{CPUTENSOR[float] :shape (10 10) :id TID2238 
   :vec-state [computed]
   ((1.2123578   -0.0        0.3656019   ~ 1.4792646   -0.0        0.39568463)                   
    (-0.0        -0.0        0.09934077  ~ -0.0        0.8187249   0.33749792)   
@@ -50,7 +50,7 @@ GeLU(x) = 0.5\times{x}\times{(1 + Tanh(\sqrt{\frac{2}{π}}\times{(x + 0.44715\ti
 ```lisp
 (proceed (!relu (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (10 10) :id TID2300 
+{CPUTENSOR[float] :shape (10 10) :id TID2329 
   :vec-state [computed]
   ((0.9859774   0.34466082  0.09621465  ~ 0.9216246   1.4845713   0.34032807)                   
    (0.48264125  -0.0        -0.0        ~ 0.032608878 0.72863156  1.6821892)   
@@ -80,7 +80,7 @@ Sigmoid(x) = \frac{1}{1 + exp(-x)}
 ```lisp
 (proceed (!sigmoid (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (10 10) :id TID2387 
+{CPUTENSOR[float] :shape (10 10) :id TID2416 
   :vec-state [computed]
   ((0.644825   0.6353275  0.40658134 ~ 0.8804779  0.51031536 0.3184848)                  
    (0.31827003 0.6823543  0.33825305 ~ 0.7810872  0.19540769 0.728776)   
@@ -116,7 +116,7 @@ LeakeyReLU(x) = max(x, 0) + negative-slope\times{min(0, x)}
 ```lisp
 (proceed (!leakey-relu (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (10 10) :id TID2543 
+{CPUTENSOR[float] :shape (10 10) :id TID2578 
   :vec-state [computed]
   ((-0.0062375483 -0.005046675  0.42296785    ~ 1.1128049     0.09089017    -0.008739611)                     
    (0.3376901     0.36640626    1.849651      ~ 0.41286528    -0.0026475843 -0.0107471235)   
@@ -152,7 +152,7 @@ Applies the Expotential Linear Units Function (ELUs) element-wise as described i
 ```lisp
 (proceed (!leakey-relu (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (10 10) :id TID2634 
+{CPUTENSOR[float] :shape (10 10) :id TID2669 
   :vec-state [computed]
   ((-3.1367975e-4 0.060880393   0.4047371     ~ 0.54067177    -0.015001696  0.2813693)                     
    (-0.0017047632 -0.0036414461 0.78715545    ~ -0.011978014  -0.006375469  0.5117078)   
@@ -194,7 +194,7 @@ x_i = x_i - mean(x)
 ```lisp
 (proceed (!softmax (randn `(3 3))))
 
-{CPUTENSOR[float] :shape (3 3) :id TID2800 
+{CPUTENSOR[float] :shape (3 3) :id TID2839 
   :vec-state [computed]
   ((0.64688617 0.20169368 0.1514202)
    (0.36481348 0.0811322  0.5540543)
@@ -315,7 +315,7 @@ In addition, reading the value of a `:reduction` keyword (one of `:mean` `:sum` 
 ```lisp
 (proceed (L1Norm (randn `(10 10)) (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (10 10) :id TID2939 
+{CPUTENSOR[float] :shape (10 10) :id TID2980 
   :vec-state [computed]
   ((1.0184398   2.1191165   0.45206386  ~ 1.0233625   1.4621267   0.39796215)                   
    (1.7387664   0.44385663  0.2733763   ~ 1.8357267   1.6068172   0.9255259)   
@@ -348,7 +348,7 @@ In addition, reading the value of a `:reduction` keyword (one of `:mean` `:sum` 
 ```lisp
 (proceed (MSE (randn `(10 10)) (randn `(10 10))))
 
-{CPUTENSOR[float] :shape (10 10) :id TID3041 
+{CPUTENSOR[float] :shape (10 10) :id TID3082 
   :vec-state [computed]
   ((0.024422618  0.543947     0.0790878    ~ 0.36269054   5.4938188    0.17887937)                    
    (1.8154333    3.0576663    0.697018     ~ 0.6212674    0.0027494146 0.87471426)   
@@ -450,7 +450,7 @@ y = xA^\intercal + b
 ```lisp
 (LinearLayer 10 5)
 
-<Composite: LINEARLAYER{W3138}(
+<Composite: LINEARLAYER{W3179}(
     <Input : ((~ BATCH-SIZE 10)) -> Output: ((~ BATCH-SIZE 5))>
 
     WEIGHTS -> (5 10)
@@ -487,23 +487,19 @@ which transformation of shapes are defined as:
 ```
 (INPUT[N C_IN H_IN W_IN] -> OUTPUT[N C_OUT H_OUT W_OUT] WHERE C_IN =
  IN-CHANNELS C_OUT = OUT-CHANNELS H_OUT =
- (IF (NUMBERP H_IN)
-     (FLOOR
-      (+ 1
-         (/
-          (+ H_IN (* 2 (CAR PADDING))
-             (* (- (CAR DILATION)) (- (CAR KERNEL-SIZE) 1)) -1)
-          (CAR STRIDE))))
-     -1)
+ (FLOOR
+  (+ 1
+     (/
+      (+ H_IN (* 2 (CAR PADDING))
+         (* (- (CAR DILATION)) (- (CAR KERNEL-SIZE) 1)) -1)
+      (CAR STRIDE))))
  W_OUT =
- (IF (NUMBERP W_IN)
-     (FLOOR
-      (+ 1
-         (/
-          (+ W_IN (* 2 (SECOND PADDING))
-             (* (- (SECOND DILATION)) (- (SECOND KERNEL-SIZE) 1)) -1)
-          (SECOND STRIDE))))
-     -1))
+ (FLOOR
+  (+ 1
+     (/
+      (+ W_IN (* 2 (SECOND PADDING))
+         (* (- (SECOND DILATION)) (- (SECOND KERNEL-SIZE) 1)) -1)
+      (SECOND STRIDE)))))
 ```
 ### Description
 
@@ -542,8 +538,50 @@ Note: When `Conv2D` is initialised, the output is displayed as -1. This is becau
 ```lisp
 (Conv2D 3 5 '(3 3))
 
-<Composite: CONV2D{W3148}(
-    <Input : ((N 3 H_IN W_IN)) -> Output: ((N 5 -1 -1))>
+<Composite: CONV2D{W3189}(
+    <Input : ((N 3 H_IN W_IN)) -> Output: ((N 5
+                                            LazyAxis: observe-axis({LazyAxis: f(H_IN PADDING DILATION KERNEL-SIZE STRIDE) = (FLOOR
+                                                          (+ 1
+                                                             (/
+                                                              (+ H_IN
+                                                                 (* 2
+                                                                    (CAR
+                                                                     PADDING))
+                                                                 (*
+                                                                  (-
+                                                                   (CAR
+                                                                    DILATION))
+                                                                  (-
+                                                                   (CAR
+                                                                    KERNEL-SIZE)
+                                                                   1))
+                                                                 -1)
+                                                              (CAR STRIDE))))}, H_IN, (0
+                                                                                       0), (1
+                                                                                            1), (3
+                                                                                                 3), (1
+                                                                                                      1))
+                                            LazyAxis: observe-axis({LazyAxis: f(W_IN PADDING DILATION KERNEL-SIZE STRIDE) = (FLOOR
+                                                          (+ 1
+                                                             (/
+                                                              (+ W_IN
+                                                                 (* 2
+                                                                    (SECOND
+                                                                     PADDING))
+                                                                 (*
+                                                                  (-
+                                                                   (SECOND
+                                                                    DILATION))
+                                                                  (-
+                                                                   (SECOND
+                                                                    KERNEL-SIZE)
+                                                                   1))
+                                                                 -1)
+                                                              (SECOND STRIDE))))}, W_IN, (0
+                                                                                          0), (1
+                                                                                               1), (3
+                                                                                                    3), (1
+                                                                                                         1))))>
 
     WEIGHT -> (5 3 3 3)
     BIAS   -> (5)
@@ -566,13 +604,8 @@ Note: When `Conv2D` is initialised, the output is displayed as -1. This is becau
 which transformation of shapes are defined as:
 ```
 (INPUT[N C H_IN W_IN] -> OUTPUT[N C H_OUT W_OUT] WHERE H_OUT =
- (IF (NUMBERP H_IN)
-     (POOL-OUT-SIZE H_IN (CAR PADDING) (CAR KERNEL-SIZE) (CAR STRIDE))
-     -1)
- W_OUT =
- (IF (NUMBERP W_OUT)
-     (POOL-OUT-SIZE W_IN (SECOND PADDING) (SECOND KERNEL-SIZE) (SECOND STRIDE))
-     -1))
+ (POOL-OUT-SIZE H_IN (CAR PADDING) (CAR KERNEL-SIZE) (CAR STRIDE)) W_OUT =
+ (POOL-OUT-SIZE W_IN (SECOND PADDING) (SECOND KERNEL-SIZE) (SECOND STRIDE)))
 ```
 ### Description
 
@@ -605,13 +638,8 @@ Likewise `Conv2D`, these parameters can be set for both X and Y axis directions.
 which transformation of shapes are defined as:
 ```
 (INPUT[N C H_IN W_IN] -> OUTPUT[N C H_OUT W_OUT] WHERE H_OUT =
- (IF (NUMBERP H_IN)
-     (POOL-OUT-SIZE H_IN (CAR PADDING) (CAR KERNEL-SIZE) (CAR STRIDE))
-     -1)
- W_OUT =
- (IF (NUMBERP W_OUT)
-     (POOL-OUT-SIZE W_IN (SECOND PADDING) (SECOND KERNEL-SIZE) (SECOND STRIDE))
-     -1))
+ (POOL-OUT-SIZE H_IN (CAR PADDING) (CAR KERNEL-SIZE) (CAR STRIDE)) W_OUT =
+ (POOL-OUT-SIZE W_IN (SECOND PADDING) (SECOND KERNEL-SIZE) (SECOND STRIDE)))
 ```
 ### Description
 

--- a/docs/cl-waffe2-docs/docs/vm.md
+++ b/docs/cl-waffe2-docs/docs/vm.md
@@ -111,29 +111,29 @@ Prints out the compiled cl-waffe2 IR from toplevel to each leaf points to `strea
 
 disassemble-waffe2-ir:
  [Forward]: 
-<WfInst[op=ALLOC{INTERNAL}]     : TID351 <= op(TID351{float, (3 3)} <Param>TID346{float, (3 3)})>
-<WfInst[op=EXPNODE-CPUTENSOR]   : TID351 <= op(<Param>SV4BW(TID346{float, (3 3)}) TID351{float, (3 3)})>
-<WfInst[op=SCALARMUL-CPUTENSOR] : TID381 <= op(TID381{float, (3 1)} <Input>TID373{float, (1)})>
-<WfInst[op=VIEWTENSORNODE-T]    : TID381 <= op(TID381{float, (3 3)} TID381{float, (3 1)})>
-<WfInst[op=ADDNODE-CPUTENSOR]   : TID381 <= op(TID381{float, (3 3)} TID351{float, (3 3)})>
-<WfInst[op=DIVNODE-CPUTENSOR]   : TID351 <= op(SV4BW(TID351{float, (3 3)}) SV4BW(TID381{float, (3 3)}))>
+<WfInst[op=ALLOC{INTERNAL}]     : TID354 <= op(TID354{float, (3 3)} <Param>TID349{float, (3 3)})>
+<WfInst[op=EXPNODE-CPUTENSOR]   : TID354 <= op(<Param>SV4BW(TID349{float, (3 3)}) TID354{float, (3 3)})>
+<WfInst[op=SCALARMUL-CPUTENSOR] : TID386 <= op(TID386{float, (3 1)} <Input>TID376{float, (1)})>
+<WfInst[op=VIEWTENSORNODE-T]    : TID386 <= op(TID386{float, (3 3)} TID386{float, (3 1)})>
+<WfInst[op=ADDNODE-CPUTENSOR]   : TID386 <= op(TID386{float, (3 3)} TID354{float, (3 3)})>
+<WfInst[op=DIVNODE-CPUTENSOR]   : TID354 <= op(SV4BW(TID354{float, (3 3)}) SV4BW(TID386{float, (3 3)}))>
 
 6 Instructions | 3 Tensors | 1 Scalars
 
 
  [Pullback]: 
-<WfInst[op=MOVETENSORNODE-CPUTENSOR] : TID439 <= op(TID439{float, (3 3)} <Input>TID436{float, (3 3)})>
-<WfInst[op=DIVNODE-CPUTENSOR]        : TID439 <= op(TID439{float, (3 3)} TID418{float, (3 3)})>
-<WfInst[op=MOVETENSORNODE-CPUTENSOR] : TID467 <= op(TID467{float, (3 3)} <Input>TID436{float, (3 3)})>
-<WfInst[op=SCALARMUL-CPUTENSOR]      : TID467 <= op(TID467{float, (3 3)} <Input>TID464{float, (1)})>
-<WfInst[op=MULNODE-CPUTENSOR]        : TID413 <= op(TID413{float, (3 3)} TID467{float, (3 3)})>
-<WfInst[op=VIEWTENSORNODE-T]         : TID418 <= op(TID418{float, (3 3)} TID418{float, (3 1)})>
-<WfInst[op=MULNODE-CPUTENSOR]        : TID418 <= op(TID418{float, (3 3)} TID418{float, (3 3)})>
-<WfInst[op=DIVNODE-CPUTENSOR]        : TID413 <= op(TID413{float, (3 3)} TID418{float, (3 3)})>
-<WfInst[op=SYSTEM-LAZY-CONS-T]       : TID439 TID413 <= op(TID439{float, (3 3)} TID413{float, (3 3)})>
-<WfInst[op=EXPNODE-CPUTENSOR]        : TID361 <= op(TID361{float, (3 3)} TID361{float, (3 3)})>
-<WfInst[op=MULNODE-CPUTENSOR]        : TID439 <= op(TID439{float, (3 3)} TID361{float, (3 3)})>
-<WfInst[op={GRAD}SETQ{INTERNAL}]     : <Input>TID348 <= op(<Input>TID348{float, (3 3)} TID439{float, (3 3)})>
+<WfInst[op=MOVETENSORNODE-CPUTENSOR] : TID444 <= op(TID444{float, (3 3)} <Input>TID441{float, (3 3)})>
+<WfInst[op=DIVNODE-CPUTENSOR]        : TID444 <= op(TID444{float, (3 3)} TID423{float, (3 3)})>
+<WfInst[op=MOVETENSORNODE-CPUTENSOR] : TID472 <= op(TID472{float, (3 3)} <Input>TID441{float, (3 3)})>
+<WfInst[op=SCALARMUL-CPUTENSOR]      : TID472 <= op(TID472{float, (3 3)} <Input>TID469{float, (1)})>
+<WfInst[op=MULNODE-CPUTENSOR]        : TID418 <= op(TID418{float, (3 3)} TID472{float, (3 3)})>
+<WfInst[op=VIEWTENSORNODE-T]         : TID423 <= op(TID423{float, (3 3)} TID423{float, (3 1)})>
+<WfInst[op=MULNODE-CPUTENSOR]        : TID423 <= op(TID423{float, (3 3)} TID423{float, (3 3)})>
+<WfInst[op=DIVNODE-CPUTENSOR]        : TID418 <= op(TID418{float, (3 3)} TID423{float, (3 3)})>
+<WfInst[op=SYSTEM-LAZY-CONS-T]       : TID444 TID418 <= op(TID444{float, (3 3)} TID418{float, (3 3)})>
+<WfInst[op=EXPNODE-CPUTENSOR]        : TID364 <= op(TID364{float, (3 3)} TID364{float, (3 3)})>
+<WfInst[op=MULNODE-CPUTENSOR]        : TID444 <= op(TID444{float, (3 3)} TID364{float, (3 3)})>
+<WfInst[op={GRAD}SETQ{INTERNAL}]     : <Input>TID351 <= op(<Input>TID351{float, (3 3)} TID444{float, (3 3)})>
 
 12 Instructions | 7 Tensors | 1 Scalars
 
@@ -172,34 +172,34 @@ See also: `proceed-bench`
 
 [Sorted by Instructions]
  Time(s)   |   Instruction ( * - Beyonds the average execution time)
-6.31e-4    | <WfInst[op=MOVETENSORNODE-CPUTENSOR] : TID716 <= op(TID716{float, (100 100)} <Input>TID632{float, (100 100)})>
-1.79e-4    | <WfInst[op=VIEWTENSORNODE-T]         : TID710 <= op(TID710{float, (100 1)} TID710{float, (100 1)})>
-2.81e-4    | <WfInst[op=SCALARMUL-CPUTENSOR]      : TID710 <= op(TID710{float, (100 1)} <Input>TID641{float, (1)})>
-1.07e-4    | <WfInst[op=VIEWTENSORNODE-T]         : TID710 <= op(TID710{float, (100 100)} TID710{float, (100 1)})>
-0.006511*  | <WfInst[op=ADDNODE-CPUTENSOR]        : TID710 <= op(TID710{float, (100 100)} <Input>TID632{float, (100 100)})>
-1.16e-4    | <WfInst[op=VIEWTENSORNODE-T]         : TID710 <= op(TID710{float, (100 1)} TID710{float, (100 100)})>
-0.002286*  | <WfInst[op=SCALARDIV-CPUTENSOR]      : TID710 <= op(TID710{float, (100 1)} <Input>TID636{float, (1)})>
-1.57e-4    | <WfInst[op=VIEWTENSORNODE-T]         : TID710 <= op(TID710{float, (100 100)} TID710{float, (100 1)})>
-0.004234*  | <WfInst[op=SUBNODE-CPUTENSOR]        : TID716 <= op(TID716{float, (100 100)} TID710{float, (100 100)})>
-0.001037   | <WfInst[op=EXPNODE-CPUTENSOR]        : TID716 <= op(TID716{float, (100 100)} TID716{float, (100 100)})>
-1.73e-4    | <WfInst[op=SCALARMUL-CPUTENSOR]      : TID710 <= op(TID710{float, (100 1)} <Input>TID761{float, (1)})>
-1.02e-4    | <WfInst[op=VIEWTENSORNODE-T]         : TID710 <= op(TID710{float, (100 100)} TID710{float, (100 1)})>
-0.006572*  | <WfInst[op=ADDNODE-CPUTENSOR]        : TID710 <= op(TID710{float, (100 100)} TID716{float, (100 100)})>
-0.004344*  | <WfInst[op=DIVNODE-CPUTENSOR]        : TID716 <= op(TID716{float, (100 100)} TID710{float, (100 100)})>
+3.15e-4    | <WfInst[op=MOVETENSORNODE-CPUTENSOR] : TID735 <= op(TID735{float, (100 100)} <Input>TID647{float, (100 100)})>
+9.2e-5     | <WfInst[op=VIEWTENSORNODE-T]         : TID729 <= op(TID729{float, (100 1)} TID729{float, (100 1)})>
+1.39e-4    | <WfInst[op=SCALARMUL-CPUTENSOR]      : TID729 <= op(TID729{float, (100 1)} <Input>TID656{float, (1)})>
+9.6e-5     | <WfInst[op=VIEWTENSORNODE-T]         : TID729 <= op(TID729{float, (100 100)} TID729{float, (100 1)})>
+0.005877*  | <WfInst[op=ADDNODE-CPUTENSOR]        : TID729 <= op(TID729{float, (100 100)} <Input>TID647{float, (100 100)})>
+9.2e-5     | <WfInst[op=VIEWTENSORNODE-T]         : TID729 <= op(TID729{float, (100 1)} TID729{float, (100 100)})>
+0.00194*   | <WfInst[op=SCALARDIV-CPUTENSOR]      : TID729 <= op(TID729{float, (100 1)} <Input>TID651{float, (1)})>
+9.7e-5     | <WfInst[op=VIEWTENSORNODE-T]         : TID729 <= op(TID729{float, (100 100)} TID729{float, (100 1)})>
+0.00403*   | <WfInst[op=SUBNODE-CPUTENSOR]        : TID735 <= op(TID735{float, (100 100)} TID729{float, (100 100)})>
+9.36e-4    | <WfInst[op=EXPNODE-CPUTENSOR]        : TID735 <= op(TID735{float, (100 100)} TID735{float, (100 100)})>
+1.18e-4    | <WfInst[op=SCALARMUL-CPUTENSOR]      : TID729 <= op(TID729{float, (100 1)} <Input>TID780{float, (1)})>
+9.9e-5     | <WfInst[op=VIEWTENSORNODE-T]         : TID729 <= op(TID729{float, (100 100)} TID729{float, (100 1)})>
+0.006106*  | <WfInst[op=ADDNODE-CPUTENSOR]        : TID729 <= op(TID729{float, (100 100)} TID735{float, (100 100)})>
+0.00389*   | <WfInst[op=DIVNODE-CPUTENSOR]        : TID735 <= op(TID735{float, (100 100)} TID729{float, (100 100)})>
 
-14 Instructions | 6 Tensors | Overheads due to SV4BW(...) -> 6.09e-6(s) 
+14 Instructions | 6 Tensors | Overheads due to SV4BW(...) -> 5.48e-6(s) 
 
- Total Time: 0.026730001 sec
+ Total Time: 0.023827 sec
 
 [Sorted by topK]
  Instruction                         | Total time (s) | Time/Total (n-sample=100)
-<WfInst[op=ADDNODE-CPUTENSOR]        | 0.013083       | 48.945004%
-<WfInst[op=DIVNODE-CPUTENSOR]        | 0.004344       | 16.251404%
-<WfInst[op=SUBNODE-CPUTENSOR]        | 0.004234       | 15.839881%
-<WfInst[op=SCALARDIV-CPUTENSOR]      | 0.002286       | 8.552188%
-<WfInst[op=EXPNODE-CPUTENSOR]        | 0.001037       | 3.879536%
-<WfInst[op=VIEWTENSORNODE-T]         | 6.61e-4        | 2.472877%
-<WfInst[op=MOVETENSORNODE-CPUTENSOR] | 6.31e-4        | 2.3606431%
-<WfInst[op=SCALARMUL-CPUTENSOR]      | 4.5399996e-4   | 1.6984661%
+<WfInst[op=ADDNODE-CPUTENSOR]        | 0.011983       | 50.291687%
+<WfInst[op=SUBNODE-CPUTENSOR]        | 0.00403        | 16.913586%
+<WfInst[op=DIVNODE-CPUTENSOR]        | 0.00389        | 16.326017%
+<WfInst[op=SCALARDIV-CPUTENSOR]      | 0.00194        | 8.142023%
+<WfInst[op=EXPNODE-CPUTENSOR]        | 9.36e-4        | 3.9283168%
+<WfInst[op=VIEWTENSORNODE-T]         | 4.7600002e-4   | 1.9977337%
+<WfInst[op=MOVETENSORNODE-CPUTENSOR] | 3.15e-4        | 1.3220297%
+<WfInst[op=SCALARMUL-CPUTENSOR]      | 2.57e-4        | 1.0786084%
 
 ```

--- a/examples/examples.lisp
+++ b/examples/examples.lisp
@@ -426,3 +426,6 @@
 (proceed (lazy #'sin (ax+b `(3 3) 0 1) :diff #'cos))
 (proceed (lazy-reduce #'max (ax+b `(3 3 3) 1 0)))
 
+;; Lazy Reshape
+(print (!reshape (make-input `(N C H W) nil) (~ N C H W -> (* N C H) W)))
+

--- a/examples/mnist/cnn.lisp
+++ b/examples/mnist/cnn.lisp
@@ -26,8 +26,9 @@
       (mapc (hooker x (Adam x :lr lr)) (model-parameters compiled-model))
       (values compiled-model model))))
 
-(with-cpu-jit (CPUTensor LispTensor)
-  (proceed-bench (call (MNIST-CNN) (randn `(100 1 28 28))) :backward t))
+;;(with-cpu-jit (CPUTensor LispTensor)
+;;  (format t "[INFO] Doing CNN benchmark...~%")
+;;  (proceed-bench (call (MNIST-CNN) (randn `(100 1 28 28))) :backward t))
 
 (defun step-cnn (model X Y)
   (let ((act-loss (forward model X Y)))

--- a/source/backends/JITCPUTensor/tensor.lisp
+++ b/source/backends/JITCPUTensor/tensor.lisp
@@ -69,6 +69,7 @@ That is:
 ```
 "
   `(with-devices (JITCPUTensor ,@more-devices)
+     (setf *lazy-c-source* "")
      ,@body))
 
 (defmacro with-tensor-ptr ((bind tensor) &body body)

--- a/source/backends/cpu/im2col.lisp
+++ b/source/backends/cpu/im2col.lisp
@@ -15,7 +15,7 @@
 			    (with-tensor-ptrs ((x* x) (col* col))
 			      (funcall (make-im2col (dtype x) (order x))
 				       col*
-				       N C H W
+				       (car (shape x)) C H W
 				       h-out w-out
 				       k-h k-w
 				       padding-h padding-w
@@ -38,7 +38,7 @@
 			    (with-tensor-ptrs ((col* col) (out* output-to))
 			      (funcall (make-col2im (dtype col) (order col))
 				       col*
-				       N C H W
+				       (car (shape col)) C H W
 				       h-out w-out
 				       k-h k-w
 				       padding-h  padding-w

--- a/source/backends/lisp/im2col.lisp
+++ b/source/backends/lisp/im2col.lisp
@@ -105,7 +105,7 @@
 						    (col* (col :direction 'simple-array :sync t)))
 			      (funcall (im2col-caller (dtype x))
 				       col* (tensor-stride col)
-				       N C
+				       (car (shape x)) C
 				       h-out w-out
 				       k-h k-w
 				       padding-h padding-w
@@ -130,7 +130,7 @@
 						    (col* (col       :direction 'simple-array :sync t)))
 			      (funcall (col2im-caller (dtype col))
 				       col* (tensor-stride col)
-				       N C
+				       (car (shape col)) C
 				       h-out w-out
 				       k-h k-w
 				       padding-h padding-w

--- a/source/base-impl/arithmetic.lisp
+++ b/source/base-impl/arithmetic.lisp
@@ -15,7 +15,7 @@
 
 (deftype function-args-t ()
   "Indicates the list of types that can be arguments of functions."
-  `(or AbstractTensor number symbol))
+  `(or AbstractTensor number symbol cl-waffe2/vm:LazyAxis))
 
 ;; Numbers to Tensors
 (defun number->stensor (scalar tensor)
@@ -26,9 +26,9 @@
 				     (if (typep tensor 'AbstractTensor)
 					 (dtype tensor)
 					 (dtype-of scalar))))
-      (if (symbolp scalar) ;; Dynamic Shape
-	  (make-tensor scalar :dtype :uint32)
-	  scalar)))
+      (if (typep scalar 'AbstractTensor)
+	  scalar
+	  (make-tensor scalar :dtype :uint32))))
 
 ;; ===============================================================
 ;; Defnode Parts

--- a/source/base-impl/fundamental.lisp
+++ b/source/base-impl/fundamental.lisp
@@ -298,10 +298,12 @@ Tips: If a function is passed as the first element of `subscript`, the subscript
 shapes can contain t at once, this function also infers t."
 
   (when (some #'(lambda (x) (and (not (eql x t))
-				 (symbolp x)))
+				 (or
+				  (cl-waffe2/vm::lazyaxis-p x)
+				  (symbolp x))))
 	      after-shape)
     (when (some #'(lambda (x) (eql x t)) after-shape)
-      (error "!reshape: Adjustable shapes and `t` cant used in the same time."))
+      (error "!reshape: can't infer the value of t because adjustable shapes and `t` cant used in the same time."))
     (return-from parse-reshape-args after-shape))
   
   (assert (<= (count t after-shape) 1)

--- a/source/base-impl/fundamental.lisp
+++ b/source/base-impl/fundamental.lisp
@@ -356,9 +356,7 @@ Returns a InputTensor with the same number of elements bu with the specified `sh
 ### Examples
 
 ```lisp
-;; Both are valid.
 (!reshape (randn `(3 3)) 1 9)
-(!reshape (randn `(3 3)) `(1 9))
 
 (!reshape (randn `(3 3)) t)
 
@@ -367,6 +365,9 @@ Returns a InputTensor with the same number of elements bu with the specified `sh
 
 ;; can compose several higher-order functions
 (!reshape (ax+b `(5 3 2) 1 0) (compose #'reverse #'shape)) ;; => (2 3 5) Tensor
+
+;; (* A B) is regarded as a LazyAxis
+(!reshape (make-input `(A B) nil) `(* A B))
 ```
 
 ### Workloads
@@ -376,12 +377,7 @@ Returns a InputTensor with the same number of elements bu with the specified `sh
 "
   (declare (type AbstractTensor tensor))
 
-  (let* (;; Both `(3 3 3) `((3 3 3)) is vaild
-	 (shapes (if (and (listp (car shapes))
-			  (= (length shapes) 1))
-		     (car shapes)
-		     shapes))
-	 ;; Symbols are regarded as a LazyAxis
+  (let* (;; Symbols are regarded as a LazyAxis
 	 (shapes (if (functionp (car shapes))
 		     (funcall   (car shapes) tensor)
 		     (loop for s in shapes

--- a/source/base-impl/fundamental.lisp
+++ b/source/base-impl/fundamental.lisp
@@ -230,15 +230,9 @@ Subscripts are following:
 
 2. `fixnum` points out the specified index.
 
-3. `(start end)` slices the area.
+3. `(start end)` slices the area: `[start, end)`
 
-4. `(start end step-by)` slices the area by `step-by`. step-by can be a negative-fixnum. (Not tested)
-
-5. `(:broadcast N-times)` broadcasts the axis for N-times, the axis to be broadcasted must be 1 or broadcasted-axis.
-
-6. `(:tflist ...)` (TODO)
-
-7. `(:indices ...)` (TODO)
+4. `(:broadcast N-times)` broadcasts the axis for N-times, the axis to be broadcasted must be 1 or broadcasted-axis.
 
 ### Return
 
@@ -251,7 +245,7 @@ Tips: If a function is passed as the first element of `subscript`, the subscript
   (let* ((subscripts (if (functionp (car subscripts))
 			 (funcall (car subscripts) tensor)
 			 subscripts))
-	 (out (apply #'cl-waffe2/vm.generic-tensor::view tensor subscripts))
+	 (out (apply #'cl-waffe2/vm.generic-tensor:view tensor subscripts))
 	 (broadcast-reverser
 	   (loop for s in (tensor-view out)
 		 if (and (listp (force-list s))
@@ -284,8 +278,9 @@ Tips: If a function is passed as the first element of `subscript`, the subscript
 			  ;; [TODO] Detect This Error Before Execution.
 			  (assert (= (total x) (total y))
 				  nil
-				  "ReshapeTensorNode: Attempted to move x to y but failed because the total sizes considering dynamically shape do not match:
+				  "ReshapeTensorNode: Attempted to move x to y but failed because the total sizes considering the dynamic shape do not match:
 ~a and ~a" x y)
+			  ;; Shares the storage:
 			  (setf (tensor-vec y) (tensor-vec x))
 			  y))
 
@@ -293,37 +288,53 @@ Tips: If a function is passed as the first element of `subscript`, the subscript
 ;; Reshaping APIs
 ;; ===============================================================
 
-(defun parse-reshape-args (before-shape after-shape)
-  "check after-shape is consisted of positive fixnum.
-shapes can contain t at once, this function also infers t."
+(defun parse-reshape-args (base-shape reshape-to)
+  "check base-shape and reshape-to are compatible
+If any solves T=?
+The role of this function is divided to these two:
+    - Checks if reshape-to is a vaild argument?
+    - Returns a valid shape that make-input can receive
+"
 
-  (when (some #'(lambda (x) (and (not (eql x t))
-				 (or
-				  (cl-waffe2/vm::lazyaxis-p x)
-				  (symbolp x))))
-	      after-shape)
-    (when (some #'(lambda (x) (eql x t)) after-shape)
-      (error "!reshape: can't infer the value of t because adjustable shapes and `t` cant used in the same time."))
-    (return-from parse-reshape-args after-shape))
-  
-  (assert (<= (count t after-shape) 1)
-	  nil
-	  "!reshape: Assertion Failed because t only appears at once.")
+  (assert (<= (count t reshape-to) 1)
+	  ()
+	  "!reshape: the symbol `t` can only be used at once.
+When attempting: ~a -> ~a" base-shape reshape-to)
 
   (assert (every #'(lambda (x)
-		     (or (eql x t)
-			 (> x 0)))
-		 after-shape)
-	  nil
-	  "!reshape: Assertion Failed because shapes aren't consisted of positive fixnum.")
+		     (or (typep x 'cl-waffe2/vm:LazyAxis)
+			 (symbolp x)
+			 (and (integerp x)
+			      (>= x 1))))
+		 reshape-to)
+	  ()
+	  "!reshape: invaild operation.
+(!reshape tensor ~a)
+                  L shapes should be consisted of:
+                       - LazyAxis
+                       - Fixnum (>=1)
+                       - Symbol (Registered as a dynamic shape?)
+                       - T (can be used at once)" reshape-to)
+  
+  (let ((include-t-p (position t reshape-to)))
 
-  (let* ((without-t (loop for s in after-shape unless (eql s t) collect s))
-	 (t-inferred (/ (apply #'* before-shape) (apply #'* without-t))))
-    (loop for s in after-shape
-	  if (eql s t)
-	    collect t-inferred
-	  else
-	    collect s)))
+    (when (null include-t-p)
+      ;; Early Return since this function finished its role.
+      (return-from parse-reshape-args reshape-to))
+
+    (let* ((shape-without-t
+	     (loop for s in reshape-to unless (eql s t) collect s))
+	   (total-base-shape
+	     (cl-waffe2/vm:make-lazyaxis `(* ,@base-shape)))
+	   (total-shape-without-t
+	     (cl-waffe2/vm:make-lazyaxis `(* ,@shape-without-t)))
+	   (t-inferred
+	     (cl-waffe2/vm:make-lazyaxis `(/ ,total-base-shape ,total-shape-without-t))))
+      (loop for s in reshape-to
+	    if (eql s t)
+	      collect t-inferred
+	    else
+	      collect s))))
 
 (declaim (ftype (function (AbstractTensor &rest (and (not null) (or function boolean fixnum))) AbstractTensor) !reshape))
 (defun !reshape (tensor &rest shapes)
@@ -334,54 +345,79 @@ shapes can contain t at once, this function also infers t."
 (!reshape tensor &rest shapes)
 ```
 
-Changes the shape of given tensor.
-
-Before and after the operation, the total elements of tensors must correspond.
+Returns a InputTensor with the same number of elements bu with the specified `shapes`.
 
 ### Inputs
 
-`tensor` `AbstractTensor` but must not includes `symbol` in the shape.
+`tensor[AbstractTensor]` Shapes can include: Fixnum, Symbol, and LazyAxis.
 
+`shapes[list]` specify the shape of tensors transformed to. This form can include `t` at once and the value of t is automatically inferred given shapes. This form is consisted of: `Fixnum(>=1)`, `T`, `Symbol` and `LazyAxis`. If the first element of `shapes` is a function, the form `shapes` including rest will be replaced with the returned value. the function form must be: `#'(lambda (tensor) after-shape)`
 
-`shapes` could be one of: fixnum `t`. `t` can be used at one, but the value of t is automatically inferenced.
-
-Note: If the first element of `shapes` is a function, `shapes` are overwritten with the function's value.
+### Examples
 
 ```lisp
+;; Both are valid.
+(!reshape (randn `(3 3)) 1 9)
+(!reshape (randn `(3 3)) `(1 9))
+
+(!reshape (randn `(3 3)) t)
+
+;; the ~ macro is useful for transforming lazy shapes
+(!reshape (make-input `(N C H W) :X) (~ N C H W -> (* N C H) W))
+
+;; can compose several higher-order functions
 (!reshape (ax+b `(5 3 2) 1 0) (compose #'reverse #'shape)) ;; => (2 3 5) Tensor
 ```
+
+### Workloads
+
+- [ ] Compiling error for dynamic shapes.
+
 "
   (declare (type AbstractTensor tensor))
-  
-  (let* ((shapes (if (functionp (car shapes))
+
+  (let* (;; Both `(3 3 3) `((3 3 3)) is vaild
+	 (shapes (if (and (listp (car shapes))
+			  (= (length shapes) 1))
+		     (car shapes)
+		     shapes))
+	 ;; Symbols are regarded as a LazyAxis
+	 (shapes (if (functionp (car shapes))
 		     (funcall   (car shapes) tensor)
 		     (loop for s in shapes
 			   if (or (eql s t)
 				  (numberp s))
 			     collect s
 			   else
-			     collect (cl-waffe2/vm:make-lazyaxis s))))
+			     collect
+			     (if (symbolp s)
+				 s
+				 (cl-waffe2/vm:make-lazyaxis s)))))
+	 ;; Solving T=?
 	 (shapes (parse-reshape-args (shape tensor) shapes))
+
+	 ;; Creates a new area (this creation is later optimized by compilers)
 	 (result (make-input shapes nil
 			     :dtype (dtype tensor)
 			     :order (order tensor))))
 
-    (when (and (every #'numberp (shape result))
+    (when (and (every #'numberp (shape tensor))
 	       (every #'numberp shapes))
       (assert (= (apply #'* (shape tensor))
 		 (apply #'* shapes))
-	      nil
-	      "Reshaping failed because the total sizes do not match."))
-    ;; (!view tensor `(2 4) `(2 4)) -> Copy
-    ;; (!view tensor  0 t t t)
+	      ()
+	      "!reshape: Assertion Failed because the total elements must correspond with before and after the operation.
+The operation was:
+   FROM:~a -> TO:~a" (shape tensor) shapes))
+
+    ;; [TODO] Adding LazyAssertion
+    
     (let ((out (forward (ReshapeTensorNode (shape tensor) shapes)
 			(->contiguous tensor)
 			result)))
       out)))
 
-;; !squeeze/!unsqueeze
-
-;; TO ADD: (defun !lazy-reshape (tensor &rest shapes) ) reshape but can include symbol as shapes
+;; [TODO] !squeeze/!unsqueeze
 
 ;; Memo:
 ;; The behaviour of ScalarTensor is ugly? because...

--- a/source/base-impl/fundamental.lisp
+++ b/source/base-impl/fundamental.lisp
@@ -355,14 +355,19 @@ Note: If the first element of `shapes` is a function, `shapes` are overwritten w
   
   (let* ((shapes (if (functionp (car shapes))
 		     (funcall   (car shapes) tensor)
-		     shapes))
+		     (loop for s in shapes
+			   if (or (eql s t)
+				  (numberp s))
+			     collect s
+			   else
+			     collect (cl-waffe2/vm:make-lazyaxis s))))
 	 (shapes (parse-reshape-args (shape tensor) shapes))
 	 (result (make-input shapes nil
 			     :dtype (dtype tensor)
 			     :order (order tensor))))
 
-    (when (and (not (some #'symbolp (shape result)))
-	       (not (some #'symbolp shapes)))
+    (when (and (every #'numberp (shape result))
+	       (every #'numberp shapes))
       (assert (= (apply #'* (shape tensor))
 		 (apply #'* shapes))
 	      nil

--- a/source/base-impl/package.lisp
+++ b/source/base-impl/package.lisp
@@ -14,6 +14,7 @@
    #:backward-of
    #:reduced-of)
   (:export
+   #:~
    #:MoveTensorNode
    #:MoveScalarTensorNode
    #:movetensor-ignore-me

--- a/source/base-impl/reshapers.lisp
+++ b/source/base-impl/reshapers.lisp
@@ -23,7 +23,7 @@ For example:
 	(error "broadcast-to: Couldn't broadcast together because ranks does not match. ~a and ~a" tensor object-tensor))
       (loop for shape-tbc    in (shape tensor)
 	    for shape-object in (shape object-tensor)
-	    if (= shape-tbc shape-object)
+	    if (equal shape-tbc shape-object)
 	      collect t
 	    else
 	      collect (progn

--- a/source/base-impl/transform.lisp
+++ b/source/base-impl/transform.lisp
@@ -27,7 +27,7 @@
     (T
      (error "%transform: unknown syntax of view: ~a" arg))))
 
-;; TODO: This feature isn't enough.
+;; TODO: This feature is still hard to satisfy
 (defmacro %transform (&body transform-syntax)
   "
 ## [macro] %transform

--- a/source/base-impl/utils.lisp
+++ b/source/base-impl/utils.lisp
@@ -1,16 +1,15 @@
 
 (in-package :cl-waffe2/base-impl)
 
-
 (defun padding (tensor pad-width
 		&key
-		  (pad-maker #'cl-waffe2/distributions:ax+b)
-		  (initargs `(0 0)))
+		  (pad-maker #'make-input)
+		  (initargs `(nil)))
   "
 ## [function] padding
 
 ```lisp
-(padding tensor pad-width &key (pad-maker #'ax+b) (initargs `(0 0)))
+(padding tensor pad-width &key (pad-maker #'make-input) (initargs `(nil)))
 ```
 
 Creating a new InputTensor with shape after padding, the function `padding` moves the given tensor into a new area.

--- a/source/nn/conv.lisp
+++ b/source/nn/conv.lisp
@@ -65,15 +65,11 @@ Note: When `Conv2D` is initialised, the output is displayed as -1. This is becau
 			   C_in  = in-channels
 			   C_out = out-channels
 			   ;; H_out = floor(((H_in + 2 * padding[0] - dilation[0] * (kernel_size[0] - 1) - 1) / stride[0]) + 1)
-			   H_out = (if (numberp H_in) ;; If H_in is a symbol, return -1 (=undetermined, later determined.)
-				       (floor (+ 1 (/ (+ H_in (* 2 (car padding)) (* (- (car dilation)) (- (car kernel-size) 1)) -1)
+			   H_out = (floor (+ 1 (/ (+ H_in (* 2 (car padding)) (* (- (car dilation)) (- (car kernel-size) 1)) -1)
 						      (car stride))))
-				       -1)
 			   ;; W_out = floor(((W_in + 2 * padding[1] - dilation[1] * (kernel_size[1] - 1) - 1) / stride[1]) + 1)
-			   W_out = (if (numberp W_in)
-				       (floor (+ 1 (/ (+ W_in (* 2 (second padding)) (* (- (second dilation)) (- (second kernel-size) 1)) -1)
-						      (second stride))))
-				       -1))
+			   W_out = (floor (+ 1 (/ (+ W_in (* 2 (second padding)) (* (- (second dilation)) (- (second kernel-size) 1)) -1)
+						      (second stride)))))
 	   :on-call-> apply-conv2d)
 		       
   (assert (typep kernel-size 'list)
@@ -108,4 +104,3 @@ Note: When `Conv2D` is initialised, the output is displayed as -1. This is becau
 			    (!add out (%transform bias[i] -> [~ i]))
 			    out)))
 	    (!permute (!reshape out N h-out w-out C-out) 3 0 2 1)))))))
-

--- a/source/nn/conv.lisp
+++ b/source/nn/conv.lisp
@@ -104,3 +104,4 @@ Note: When `Conv2D` is initialised, the output is displayed as -1. This is becau
 			    (!add out (%transform bias[i] -> [~ i]))
 			    out)))
 	    (!permute (!reshape out N h-out w-out C-out) 3 0 2 1)))))))
+

--- a/source/nn/im2col.lisp
+++ b/source/nn/im2col.lisp
@@ -46,7 +46,7 @@ stride-x stride-y - stride[0], stride[1] respectively.
     ;; -> N C k-h k-w h-out w-out
     (call-> result
 	    (asnode #'!permute (torch-order 0 4 5 1 2 3))
-	    (asnode #'!reshape (* N H-out W-out) t))))
+	    (asnode #'!reshape (~ N H-out W-out C K-h K-w -> (* N H-out W-out) (* C K-h K-w))))))
 
 (defun unfold (input dilation kernel-size stride padding)
   "
@@ -92,5 +92,4 @@ Note that `dilation`, `kernel-size`, `stride`, and `padding` are given in this f
 		      h-out w-out (car stride) (second stride)
 		      (car padding) (second padding)
 		      (car dilation) (second dilation))))))
-
 

--- a/source/nn/pool.lisp
+++ b/source/nn/pool.lisp
@@ -46,12 +46,8 @@ Likewise `Conv2D`, these parameters can be set for both X and Y axis directions.
 	   ;; [TODO]: Delete (if (numberp ...))
 	   :where (Input[N C H_in W_in] -> Output[N C H_out W_out]
 			   where
-			   H_out = (if (numberp H_in)
-				       (pool-out-size H_in (car padding) (car kernel-size) (car stride))
-				       -1)
-			   W_out = (if (numberp W_out)
-				       (pool-out-size W_in (second padding) (second kernel-size) (second stride))
-				       -1))
+			   H_out = (pool-out-size H_in (car padding) (car kernel-size) (car stride))
+			   W_out = (pool-out-size W_in (second padding) (second kernel-size) (second stride)))
 	   :on-call-> apply-maxpool2d))
 
 (defmodel (AvgPool2D (self kernel-size
@@ -80,12 +76,8 @@ Likewise `Conv2D`, these parameters can be set for both X and Y axis directions.
 	   ;; [TODO]: Delete (if (numberp ...))
 	   :where (Input[N C H_in W_in] -> Output[N C H_out W_out]
 			   where
-			   H_out = (if (numberp H_in)
-				       (pool-out-size H_in (car padding)    (car kernel-size) (car stride))
-				       -1)
-			   W_out = (if (numberp W_out)
-				       (pool-out-size W_in (second padding) (second kernel-size) (second stride))
-				       -1))
+			   H_out = (pool-out-size H_in (car padding) (car kernel-size) (car stride))
+			   W_out = (pool-out-size W_in (second padding) (second kernel-size) (second stride)))
 	   :on-call-> apply-avgpool2d))
 
 (defmethod apply-maxpool2d ((self MaxPool2D) input)
@@ -95,7 +87,7 @@ Likewise `Conv2D`, these parameters can be set for both X and Y axis directions.
 	    (W-out (pool-out-size W-in (second padding) (second kernel-size) (second stride))))
 	(call-> input
 		(asnode #'unfold  `(1 1) kernel-size stride padding)
-		(asnode #'!reshape t (apply #'* kernel-size))
+		(asnode #'!reshape N `(* ,@kernel-size))
 		(asnode #'!max     :axis 1)
 		(asnode #'!reshape N H-out W-out C)
 		(asnode #'!permute 3 0 2 1))))))
@@ -107,8 +99,7 @@ Likewise `Conv2D`, these parameters can be set for both X and Y axis directions.
 	    (W-out (pool-out-size W-in (second padding) (second kernel-size) (second stride))))
 	(call-> input
 		(asnode #'unfold  `(1 1) kernel-size stride padding)
-		(asnode #'!reshape t (apply #'* kernel-size))
+		(asnode #'!reshape N `(* ,@kernel-size))
 		(asnode #'!mean     :axis 1)
 		(asnode #'!reshape N H-out W-out C)
 		(asnode #'!permute 3 0 2 1))))))
-

--- a/source/nn/pool.lisp
+++ b/source/nn/pool.lisp
@@ -87,7 +87,7 @@ Likewise `Conv2D`, these parameters can be set for both X and Y axis directions.
 	    (W-out (pool-out-size W-in (second padding) (second kernel-size) (second stride))))
 	(call-> input
 		(asnode #'unfold  `(1 1) kernel-size stride padding)
-		(asnode #'!reshape N `(* ,@kernel-size))
+		(asnode #'!reshape t `(* ,@kernel-size))
 		(asnode #'!max     :axis 1)
 		(asnode #'!reshape N H-out W-out C)
 		(asnode #'!permute 3 0 2 1))))))
@@ -99,7 +99,8 @@ Likewise `Conv2D`, these parameters can be set for both X and Y axis directions.
 	    (W-out (pool-out-size W-in (second padding) (second kernel-size) (second stride))))
 	(call-> input
 		(asnode #'unfold  `(1 1) kernel-size stride padding)
-		(asnode #'!reshape N `(* ,@kernel-size))
+		(asnode #'!reshape t `(* ,@kernel-size))
 		(asnode #'!mean     :axis 1)
 		(asnode #'!reshape N H-out W-out C)
 		(asnode #'!permute 3 0 2 1))))))
+

--- a/source/vm/allocation.lisp
+++ b/source/vm/allocation.lisp
@@ -80,6 +80,8 @@ If the re-allocation is performed, frees the old one.
 		    val
 		    (or (let ((out (gethash val shape-table)))
 			  (when (numberp out) out))
+			(when (symbol-lazyaxis val)
+			  (observe-axis (symbol-lazyaxis val)))			
 			(error "adjust-allocation!: The symbol ~a is unknown. Choose from: ~a -> ~a"
 			       val
 			       (alexandria:hash-table-keys shape-table)
@@ -116,7 +118,7 @@ If the re-allocation is performed, frees the old one.
       ;; Reading the orig-shape
       (when (not (scalar-p tensor))
 	(setf (slot-value tensor 'cl-waffe2/vm.generic-tensor::orig-shape)
-	      (map 'list #'cl-waffe2/vm.generic-tensor::read-symbol
+	      (map 'list #'maybe-observe-axis
 		   (cl-waffe2/vm.generic-tensor::original-shape tensor))))
       
       (when (null (cl-waffe2/vm.generic-tensor::vec tensor))

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -114,7 +114,6 @@ The NodeVariables structure stores the tensors and Shapes that have been lazily 
 Giving values to delay-evaluated tensors.
 "
   (declare (type NodeVariables nodevars))
-  
   (let ((input-tensor (gethash variable-name (nodevariables-variables nodevars))))
     
     (when (null input-tensor)
@@ -141,7 +140,7 @@ The operation was: Setting ~a <- ~a
             
       ;; InputTensor <- Actual-Tensor
       (embody-actual-tensor input-tensor actual-tensor)
-
+      
       ;; Update hash-table
       (maphash
        #'(lambda (key value)
@@ -278,15 +277,24 @@ Before calling the forward method, set any value to these InputTensors first.
 	 (lazyaxis-list))
     (loop for i fixnum upfrom 0 below (length symbols) by 2 do
       (let ((symbol-place (nth i symbols))
-	    (symbol-value (nth (1+ i) symbols))) ;; If symbol is registed at the prior scope? read fixnum as possible
+	    (symbol-value (read-symbol (nth (1+ i) symbols)))) ;; If symbol is registed at the prior scope? read fixnum as possible
 	(if (cl-waffe2/vm:symbol-lazyaxis symbol-place)
+	    ;; LazyAxis -> Determine later
 	    (push symbol-place lazyaxis-list)
 	    (progn
+	      (when (null symbol-value)
+		(error "set-adjustable-symbols: the adjustable symbol ~a -> ~a wasn't registerd well?" symbol-place symbol-value))
 	      (register-adjustable-shape symbol-place symbol-value)
 	      (setf (gethash symbol-place allocator) symbol-value)))))
+
+    ;; Given symbols ignoring LazyAxis, determine the result of LazyAxis
     (dolist (lazyaxis lazyaxis-list)
       (let* ((axis (cl-waffe2/vm:symbol-lazyaxis lazyaxis))
 	     (val  (cl-waffe2/vm:observe-axis axis)))
+	
+	(when (null val)
+	  (error "set-adjustable-symbols: the adjustable symbol ~a wasn't registered well?" axis))
+
 	(register-adjustable-shape lazyaxis val)
 	(setf (gethash lazyaxis allocator) val)))
     allocator))
@@ -309,8 +317,8 @@ Before calling the forward method, set any value to these InputTensors first.
 	(loop for val   in inputs
 	      for place in places
 	      for name  in input-args do
-		(loop for  shape in (tensor-input-shape place)
-		      for  value in (shape val)
+		(loop for shape in (tensor-input-shape place)
+		      for value in (shape val)
 		      if (or (null (gethash shape shape-table))
 			     (= (gethash shape shape-table) (read-symbol value)))
 			do (setf (gethash shape shape-table) (read-symbol value))
@@ -534,9 +542,12 @@ Or, your network may be disconnected at a certain position."
 		(with-output-to-string (out)
 		  (maphash
 		   #'(lambda (size stride)
-		       (format out "+(~a x ~a)"
+		       (format out "+(~a x ~a)~a"
 			       size
-			       (/ stride 1e+6)))
+			       (/ stride 1e+6)
+			       (if (<= (hash-table-count adjust-size) 1)
+				   ""
+				   (format nil "~%                      "))))
 		   adjust-size))
 		""))))
 

--- a/source/vm/generic-tensor/do-compiled-loop.lisp
+++ b/source/vm/generic-tensor/do-compiled-loop.lisp
@@ -113,9 +113,9 @@ Examples:
 	   (type (member :heuristic :runtime) mode)
 	   (optimize (speed 3)))
 
-  (dolist (tensor tensors)
-    (when (some #'symbolp (shape tensor))
-      (setf (slot-value tensor 'visible-shape) (translate-adjustable-shape (shape tensor)))))
+  ;;(dolist (tensor tensors)
+  ;;  (when (some #'symbolp (shape tensor))
+    ;;  (setf (slot-value tensor 'visible-shape) (translate-adjustable-shape (shape tensor)))))
   
   (when (not (eql mode :runtime))
     (assert (every #'(lambda (x)

--- a/source/vm/generic-tensor/dtype.lisp
+++ b/source/vm/generic-tensor/dtype.lisp
@@ -71,6 +71,6 @@
       (coerce scalar dtype)
       (if (symbolp scalar)
 	  (make-lazy-variable :variable scalar :dtype dtype)
-	  scalar)))
+	  (cl-waffe2/vm:make-lazyaxis scalar))))
 
 

--- a/source/vm/generic-tensor/dynamic-shape.lisp
+++ b/source/vm/generic-tensor/dynamic-shape.lisp
@@ -50,8 +50,14 @@
 		      if (cl-waffe2/vm::LazyAxis-p s)
 			collect (cl-waffe2/vm:lazyaxis-symbol s)
 		      else
-			collect s)))
-    (setf (original-shape self) result)))
+			collect s))
+	(result1 (loop for s in (tensor-input-shape self)
+		       if (cl-waffe2/vm::LazyAxis-p s)
+			 collect (cl-waffe2/vm:lazyaxis-symbol s)
+		       else
+			 collect s)))
+    (setf (original-shape self) result
+	  (tensor-input-shape self) result1)))
 
 (defparameter *print-visible-shape* nil)
 
@@ -62,6 +68,8 @@
 		     (or (cl-waffe2/vm:symbol-lazyaxis x)
 			 x))
 	   (tensor-visible-shape tensor))
-      (tensor-visible-shape tensor)))
+      (if *adjustable-shape-table*
+	  (map 'list #'read-symbol (tensor-visible-shape tensor))
+	  (tensor-visible-shape tensor))))
 
 (defun lazy-shape (tensor) (let ((*print-visible-shape* t)) (shape tensor)))

--- a/source/vm/generic-tensor/dynamic-shape.lisp
+++ b/source/vm/generic-tensor/dynamic-shape.lisp
@@ -1,0 +1,67 @@
+
+(in-package :cl-waffe2/vm.generic-tensor)
+
+;;
+;; The paradigm of cl-waffe2 Dynamic Shaping.
+;;
+
+;; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+;; Dynamic Shaping is a feature which most of DL JIT Compiler supports and avoid recompiling due to the change of shape.
+;; In cl-waffe2, we define Dynamic Shape as:
+;;   1. OrigShape, Visible-Shape, Stride is a subject to encapsulate by LazyAxis.
+;;     - These slots (a list of fixnum or LazyAxis) can contain a symbol.
+;;       And Basically has these two state:
+;;       Observe Mode   |  Lazy Mode
+;;        (10 10 10)   <- (LazyAxis: A*B, LazyAxis: B, 10) 
+;;     Once (tensor-fix-adjustable-shape tensor) was called, these LazyAxis are "fixed" and got a list of fixnum.
+;;
+;;   2. Adjustable Shape Declaration
+;;     - we rely tensor-input-shape on determing what symbols are adjustable shape:
+;;       Initially, AbstractTensor (make-input `(A B) nil) has these slots:
+;;          - Shape      = (A B)
+;;          - InputShape = (A B)
+;;          - Stride     = (B 1)
+;;          - OrigShape  = (A B)
+;;
+;;     After compiling the node the tensor involved, cl-waffe2 compiler collects a list of adjustable symbol given tensors.
+;;     In this case: TABLE=`(A B)
+;;     In order to execute the node, users have to determine the value of A and B by set-input.
+;;     Provided tensor (e.g.: (10 10) AbstractTensor) cl-waffe2 compares corresponding position to InputShape
+;;          - Shape      = (10 10)
+;;          - InputShape = (A B)
+;;     And succesfully determined as: A, B=10, 10
+;; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+(defun maybe-read-lazy-shape (lazy-shape)
+  (map
+   'list
+   #'cl-waffe2/vm::maybe-observe-axis-no-err
+   lazy-shape))
+
+(defun observe-lazy-shape (lazy-shape)
+  (map 'list #'cl-waffe2/vm:maybe-observe-axis lazy-shape))
+
+(defclass Dynamic-Shaped-Abstract-Tensor ()
+  ((orig-shape         :initform nil :initarg :shape :accessor original-shape :type list)
+   (visible-shape      :initform nil :accessor tensor-visible-shape :type list)))
+;; If Shape=(A*B A) -> Symbol ({|A*B| A)
+(defmethod init-dynamic-shape ((self Dynamic-Shaped-Abstract-Tensor))
+  (let ((result (loop for s in (original-shape self)
+		      if (cl-waffe2/vm::LazyAxis-p s)
+			collect (cl-waffe2/vm:lazyaxis-symbol s)
+		      else
+			collect s)))
+    (setf (original-shape self) result)))
+
+(defparameter *print-visible-shape* nil)
+
+(defun shape (tensor)
+  (declare (type Dynamic-Shaped-Abstract-Tensor tensor))
+  (if *print-visible-shape*
+      (map 'list #'(lambda (x)
+		     (or (cl-waffe2/vm:symbol-lazyaxis x)
+			 x))
+	   (tensor-visible-shape tensor))
+      (tensor-visible-shape tensor)))
+
+(defun lazy-shape (tensor) (let ((*print-visible-shape* t)) (shape tensor)))

--- a/source/vm/generic-tensor/package.lisp
+++ b/source/vm/generic-tensor/package.lisp
@@ -29,7 +29,8 @@
    #:make-compiled-kernel
    #:find-cached-function
    #:*memory-pool*
-   #:*static-alloc-state*)
+   #:*static-alloc-state*
+   #:lazy-shape)
   ;; Tensor classes
 
   (:export

--- a/source/vm/generic-tensor/render.lisp
+++ b/source/vm/generic-tensor/render.lisp
@@ -185,8 +185,7 @@ The result sequence MUST not over max-length.
      (tensor-stride tensor)
      (calc-strides (translate-adjustable-shape (original-shape tensor)) (order tensor))
      (tensor-stride tensor)
-     (sync (tensor-stride tensor) (reverse (tensor-permute-order tensor)))))
-  
+     (sync (tensor-stride tensor) (reverse (tensor-permute-order tensor)))))  
   
   (with-output-to-string (out)
     (let ((*matrix-element-displaying-size*

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -1039,7 +1039,7 @@ Creates a new tensor with :requires-grad=t from the given tensor. If the tensor 
 
 (defmethod print-object ((tensor AbstractTensor) stream)
   (when *with-printing-tensor-omitted*
-    (format stream "<<~a Tensor (Omitted)>>" (shape tensor))
+    (format stream "<<~a Tensor (Omitted)>>" (lazy-shape tensor))
     (return-from print-object))
   
   (format stream
@@ -1059,7 +1059,12 @@ Creates a new tensor with :requires-grad=t from the given tensor. If the tensor 
 		(T
 		 ;; It has a view
 		 (format nil ":shape ~a -> :view ~a -> :visible-shape ~a"
-			 (slot-value tensor 'orig-shape)
+			 (map
+			  'list
+			  #'(lambda (s)
+			      (or (cl-waffe2/vm:symbol-lazyaxis s)
+				  s))			 
+			  (slot-value tensor 'orig-shape))
 			 (slot-value tensor 'view)
 			 (render-shape tensor)))))
 	  (if (eql (tensor-facet tensor) :input)

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -384,10 +384,9 @@ This function is setfable and inlined.
 	    (T (or (vec tensor) (get-from-global-memory-pool tensor))))))
     (if (scalar-p tensor)
 	(if (typep out 'cl-waffe2/vm:LazyAxis)
-	    (let ((out1 (read-symbol (cl-waffe2/vm:lazyaxis-symbol out))))
-	      ;; If cl-waffe2 succeed to observe out1 as a fixnum: returna fixnum
-	      (or (when (symbolp out1) out)
-		  out1))
+	    (if *adjustable-shape-table*
+		(cl-waffe2/vm:observe-axis out)
+		out)
 	    (if (lazy-variable-p out)
 		(read-lazy-var out)
 		out))

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -385,7 +385,9 @@ This function is setfable and inlined.
     (if (scalar-p tensor)
 	(if (typep out 'cl-waffe2/vm:LazyAxis)
 	    (if *adjustable-shape-table*
-		(cl-waffe2/vm:observe-axis out)
+		(progn
+		  (setf (cl-waffe2/vm::lazyaxis-read-as out) nil)
+		  (cl-waffe2/vm:observe-axis out))
 		out)
 	    (if (lazy-variable-p out)
 		(read-lazy-var out)

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -595,9 +595,8 @@ The size of tensor created with make-tensor should be determined.
 		     :facet :exist
 		     :view view)))
 
-;; It is allowed: (make-input `(batch-size 512))
-(defun make-input (shape
-		   named
+;; It is allowed: (make-input `(batch-size 512) nil)
+(defun make-input (shape named
 		   &key
 		     (create-from nil)
 		     (scalar-p nil)

--- a/source/vm/generic-tensor/tensor.lisp
+++ b/source/vm/generic-tensor/tensor.lisp
@@ -106,7 +106,7 @@ PriorityN must be a subclass of cl-waffe2/vm.generic-tensor:AbstractTensor")
    ;; For MemoryPool
    (allocate-time-state :initform nil :type (or null Adjustable-Shape-State) :accessor tensor-alloc-state)
    (protect-me :initform nil :accessor tensor-protect-me) ;; Set T, and In-place mutation is ignored.
-   (input-shape :initarg :input-shape :initform nil :reader tensor-input-shape))
+   (input-shape :initarg :input-shape :initform nil :accessor tensor-input-shape))
   (:documentation "
 ## [class] AbstractTensor
 

--- a/source/vm/generic-tensor/utils.lisp
+++ b/source/vm/generic-tensor/utils.lisp
@@ -179,7 +179,10 @@ If there's any undetermined one, returns an error (TODO: Add Conditions)"
       (when (cl-waffe2/vm:symbol-lazyaxis s)
 	(cl-waffe2/vm:observe-axis
 	 (cl-waffe2/vm:symbol-lazyaxis s)))
-      (error "translate-adjustable-shape: encountered unknown symbol: ~a" s)))))
+      (error "read-adjustable-symbol: encountered unknown symbol: ~a
+~a"
+	     s
+	     (cl-waffe2/vm::render-debug-info))))))
 
 (defmacro with-adjustable-symbol ((symbol-name symbol-value) &body body)
   "Adding an element: symbol-name -> symbol-value to *adjustable-shape-table*, which can be read by translate-adjustable-shape function.
@@ -194,7 +197,7 @@ Usage:
 "
 
   `(let* ((*adjustable-shape-table* (or *adjustable-shape-table* (make-hash-table))))
-
+     
      (setf (gethash ,symbol-name *adjustable-shape-table*) ,symbol-value)
 	 
      ,@body))

--- a/source/vm/generic-tensor/view.lisp
+++ b/source/vm/generic-tensor/view.lisp
@@ -39,7 +39,9 @@
 		       (subscript-view subscript)
 		       (if (typep (subscript-char subscript) 'symbol)
 			   (format nil ">~a∊~a"
-				   (subscript-char subscript)
+				   (or (cl-waffe2/vm:symbol-lazyaxis
+					(subscript-char subscript))
+				       (subscript-char subscript))
 				   (subscript-constraints subscript))
 			   ">")))))
   (constraints nil :type list) ;; x is in (10 30) t ... inf, min=0

--- a/source/vm/lazy-subscript.lisp
+++ b/source/vm/lazy-subscript.lisp
@@ -1,14 +1,398 @@
 
+;;
+;; lazy-subscript.lisp provides a solver for dynamic shaping.
+;; Since cl-waffe2 tensor supports dynamic shaping and changed later, arithmetic operations used cl-waffe2 apis (e.g.: !reshape) 
+;; have to deal with lazy symbols.
+;; For Example, Considering flatten A(N 1 2 3), (apply #'!reshape a (* N 1 2 3)) should not work.
+;; with ~ macro, can be written as: (apply #'!reshape (~ a b -> (* a b))).
+;;
+;; This file provides functional programming-like features dedicated to lazy-subscript.
+;;
+
+;; Subscript DSL is a high order function:
+;;
+;; DYNAMIC_SHAPE = {N=10, 20}
+;;   Node Constructions:
+;;     Conv2D where N C H W -> N C-out h-out w-out where C-out = ... H-out = ... W-out = ...
+;;        ... = LazyAxis: f(DYNAMIC_SHAPE, MORE_SYMBOLS) -> FIXNUM
+;;
+;; =(x: LazyAxis, Y:T) := LazyAssertNode(observe(X) = Y)
+;;
+;; forward is a function where computes the next inputs of nodes/composites
+;; (forward model A[10 10 10] B[10 10 10]) : All shapes are determined. Shape Transformation is instantly executed
+;; (forward model A[10 A B]   B[10 A B]    : All shapes are NOT determined. shape computation is also lazily evaluated.
+
 (in-package :cl-waffe2/vm)
 
-;; Here solves Adjustable Shape
-;; Basic Arithmetic Operations on Subscripts:
-;; e.g.: A + B
-;; e.g.: (* 3 (+ H 2)) + 1 ...
+;; Specs/Changes:
+;;  Tensor.shape = (list LazyShape[0] LazyShape[1] LazyShape[2] ...)
 
-;; I wanna fix:
-;; (if (numberp ...)) In Conv2D/Pool2D Subscript DSL
+;; Usage:
+;;   (!reshape x (transform N C H W -> (* N C H) W))
+;;   (%transform x[N C H W] -> [(* N C H) W]) (TODO)
 
-(defstruct Lazy-Expression (body))
+;; Goals:
+;;   (!reshape x (transform N C H W -> (* N C H) W)) ... Reshape/Permute/Viewの数はlambdaにすべき(Style)
+;;   (call (conv2d 3 6 `(5 5)) 3 3)
+;;
+
+
+;; make-lazyaxis (Lazy and Encapsulate)
+;;  -> (shape tensor) (tensor-view ...) and observe the result.
+
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+
+(defstruct (LazyAxis
+	    (:constructor %make-lazyaxis (arguments form step)))
+  (arguments arguments :type list)
+  (form      (if (listp form)
+		 (parse-lazy-exp form)
+		 form))
+  (constraints nil  :type list)
+  (step        step :type function)
+  (read-as     nil)
+  (id          (gensym "axis")))
+
+(defstruct (LazyAssertion
+	    (:constructor make-lazy-assert (f evaluated-to)))
+  "
+## [struct] LazyAssertion
+subject is f compared to evaluated-to
+e.g.: A is = compared to 2
+"
+  (f f :type (member := :>= :<= :> :<))
+  (evaluated-to evaluated-to))
+
+(defmethod print-object ((lazyaxis LazyAxis) stream)
+  (if (lazyaxis-arguments lazyaxis)
+      (if (= (length (lazyaxis-arguments lazyaxis)) 1)
+	  (format stream "LazyAxis: ~a"
+		  (lazyaxis-form lazyaxis))	  
+	  (format stream "LazyAxis: f~a = ~a"
+		  (lazyaxis-arguments lazyaxis)
+		  (lazyaxis-form lazyaxis)))
+      (format stream "LazyAxis: ~a"
+	      (lazyaxis-form lazyaxis))))
+
+(defstruct (LazyIR
+	    (:constructor make-lazyIR (type car cdr)))
+  (type type :type (member :number :dynamic-shape :rest :arithmetic :function))
+  (car  car)
+  (cdr  cdr))
+
+(defun ir->list (lazyir)
+  (declare (type lazyir lazyir))
+  (ecase (lazyir-type lazyir)
+    (:number        (lazyir-car lazyir))
+    (:dynamic-shape (lazyir-car lazyir))
+    (:rest          (lazyir-car lazyir))
+    (:arithmetic   `(,(lazyir-car lazyir) ,@(map 'list #'ir->list (lazyir-cdr lazyir))))
+    (:function     `(,(lazyir-car lazyir) ,@(map 'list #'ir->list (lazyir-cdr lazyir))))))
+
+(defun interpret-lazy (lazyir)
+  (declare (type lazyir lazyir))
+  (ecase (lazyir-type lazyir)
+    (:number
+     (let ((out (lazyir-car lazyir)))
+       (if (numberp out)
+	   out
+	   (observe-axis out))))
+    (:dynamic-shape (observe-variable (cadr (cadr (lazyir-car lazyir)))))
+    (:rest          (observe-axis (second (lazyir-car lazyir))))
+    (:arithmetic (apply (the symbol (lazyir-car lazyir)) (map 'list #'interpret-lazy (lazyir-cdr lazyir))))
+    (:function   (apply (the symbol (lazyir-car lazyir)) (map 'list #'interpret-lazy (lazyir-cdr lazyir))))))
+
+(defmethod print-object ((lazyir LazyIR) stream)
+  (format stream "~a"
+	  (ecase (lazyir-type lazyir)
+	    (:number        (lazyir-car lazyir))
+	    (:dynamic-shape
+	     ;; (READ_SYMBOL 'A) -> 'A
+	     (cadadr (lazyir-car lazyir))) 
+	    (:rest
+	     (format nil "{~a}" (second (lazyir-car lazyir))))
+	    (:arithmetic
+	     (with-output-to-string (out)
+	       (format out "(")
+	       (dotimes (nth (length (lazyir-cdr lazyir)))
+		 (format out "~a" (nth nth (lazyir-cdr lazyir)))
+		 (unless (= nth (1- (length (lazyir-cdr lazyir))))
+		   (format out "~a" (lazyir-car lazyir))))
+	       (format out ")")))
+	    (:function
+	     (with-output-to-string (out)
+	       (format out "~(~a~)(" (lazyir-car lazyir))
+	       (dotimes (nth (length (lazyir-cdr lazyir)))
+		 (format out "~a" (nth nth (lazyir-cdr lazyir)))
+		 (unless (= nth (1- (length (lazyir-cdr lazyir))))
+		   (format out ", ")))
+	       (format out ")"))))))
+
+(defparameter *local-variable-table* nil)
+(defun observe-variable (symbol)
+  (or (and *local-variable-table*
+	   (gethash symbol *local-variable-table*))
+      (cl-waffe2/vm.generic-tensor::read-symbol symbol)))
+			 
+(defun parse-lazy-exp (exp)
+  (trivia:ematch exp
+    ((list* (or '+ '- '* '/) _)
+     (parse-lazy-arithmetic (car exp) (cdr exp)))
+    ((list* (or 'quote
+		'#.(car ``nil))
+	    _)
+     (make-lazyir :number
+		  exp nil))
+    ((list* (type symbol) _)     
+     (multiple-value-bind (ident) (cl-environments:function-information (car exp))
+       (when (or
+	      (eql ident :special-form)
+	      (eql ident :macro))
+	 (warn "parse-lazy-exp: Don't include a macro form as LazySubscript: ~a, otherwise produces the wrong result.
+
+Describe the transformation of shapes as simple as possible.
+   LazySubscript is consisted of these factors:
+        - Functions
+        - Numbers
+        - Symbols
+   Other factors that effects on the result, should be written at outside of :where."
+	       exp)))
+     (parse-lazy-function (car exp) (cdr exp)))
+    ((type number)
+     (make-lazyir :number
+		  exp
+		  nil))
+    ((and (type symbol)
+	  (not (type keyword)))
+     (make-lazyir :dynamic-shape
+		  `(observe-variable ',exp)
+		  nil))
+    ((type LazyAxis)
+     (make-lazyir :rest
+		  `(observe-axis ,exp)
+		  nil))
+    (_
+     (make-lazyir :number
+		  exp
+		  nil))))
+
+(defun parse-lazy-arithmetic (car cdr)
+  (let ((args (map 'list #'parse-lazy-exp cdr)))
+    (if (every #'(lambda (ir)
+		   (and (eql (lazyir-type ir) :number)
+			(typep (lazyir-car ir) 'fixnum)))
+	       args)
+	(make-lazyIR :number
+		     (apply car (map 'list #'lazyir-car args))
+		     nil)
+	(make-lazyIR :arithmetic
+		     car
+		     args))))
+
+(defun parse-lazy-function (car cdr)
+  ;; [TODO]
+  ;; Assert: car = function-name
+  (let ((args (map 'list #'parse-lazy-exp cdr)))
+    (if (every #'(lambda (ir)
+		   (and (eql (lazyir-type ir) :number)
+			(typep (lazyir-car ir) 'fixnum)))
+	       args)
+	(make-lazyIR :number
+		     (apply car (map 'list #'lazyir-car args))
+		     nil)
+	(make-lazyIR :function
+		     car
+		     (map 'list #'parse-lazy-exp cdr)))))
+
+(defun ir->args (ir)
+  (let ((result))
+    (labels ((helper (ir-of)
+	       (when (eql (lazyir-type ir-of) :dynamic-shape)
+		 (push (cadadr (lazyir-car ir-of)) result))
+	       (dolist (var (reverse (lazyir-cdr ir-of)))
+		 (helper var))))
+      (helper ir)
+      (delete-duplicates result))))
+
+;;(defparameter *exp->compiled-cache* (make-hash-table :test #'equal))
+(defun make-lazyaxis (expression)
+  "
+## [function] make-lazyaxis
+
+```lisp
+(make-lazyaxis expression)
+```
+
+Creates a LazyAxis from given expression.
+
+```lisp
+(make-lazyaxis `(* A B))   ;; LazyAxis: (A B) -> A * B
+(make-lazyaxis `(floor A)) ;; LazyAxis: A     -> floor(A)
+(make-lazyaxis 1)          ;; LazyAxis: 1
+(make-lazyaxis `(+ 1 1))   ;; LazyAxis: 2
+```
+
+No macro usings are allowed; functions and fixnum, list are available.
+"
+  (let* ((lazyir (parse-lazy-exp expression))
+	 (args   (ir->args lazyir))
+	 (form   (ir->list lazyir)))
+    (if (and (typep (lazyir-car lazyir) 'fixnum)
+	     (eql (lazyir-type lazyir) :number))
+	(lazyir-car lazyir)
+	(%make-lazyaxis
+	 args
+	 lazyir
+	 (if (listp form)
+	     #'(lambda () (interpret-lazy lazyir))
+	     #'(lambda () form))))))
+
+(defun make-dumpable-lazy-axis (expression)
+  (let* ((lazyir (parse-lazy-exp expression))
+	 (args   (ir->args lazyir))
+	 (form   (ir->list lazyir)))
+    (values
+     args
+     lazyir
+     (if (listp form)
+	 `(lambda () ,(ir->list lazyir))
+	 `(lambda () ,form)))))
+
+(defun make-higher-order-lazyaxis (arguments lazy-axis)
+  "
+## [function] make-higher-order-lazyaxis
+
+(make-higher-order-lazy-axis
+    `(A B 1)
+    LazyAxis: f(A B C) = A*B*C)
+=>
+LazyAxis: f(A B) = A*B
+
+Arguments can be received as:
+    - observe-axis lazy-exp &rest args
+    - dynamic shape table (global)
+"
+  (assert (= (length arguments) (length (lazyaxis-arguments lazy-axis)))
+	  nil
+	  "make-higher-order-lazyaxis: Assertion failed because the length of arguments do not match")
+
+  (let ((remaining-args (loop for arg in arguments
+			      for a   in (lazyaxis-arguments lazy-axis)
+			      if (symbolp arg)
+				collect arg)))
+    (%make-lazyaxis
+     remaining-args
+     (parse-lazy-exp `(observe-axis ,lazy-axis ,@arguments))
+     #'(lambda ()
+	 (apply
+	  #'observe-axis
+	  lazy-axis
+	  (loop for arg in arguments
+		if (symbolp arg)
+		  collect (observe-variable arg)
+		else
+		  collect arg))))))
+
+;; Compose Several Axis (Arguments as LazyAxis)
+(defun observe-axis (lazy-expression &rest args)
+  "
+## [function] observe-axis
+
+
+```lisp
+(observe-axis lazy-expression &rest args)
+```
+= funcall for lazy-expression
+
+set the corresponding arg = nil to ignore.
+
+Observes the result of LazyAxis obtained by calling lazyaxis-step function. The result is always fixnum.
+
+LazyAxis: f(IN N) = floor((1+((IN+(2*N)+0+-1)/2)))
+(observe-axis * 1 2)
+"
+  (declare (type LazyAxis lazy-expression))
+  (or
+   (lazyaxis-read-as lazy-expression)
+   (let ((vars (or *local-variable-table* (make-hash-table))))
+     (loop for nth fixnum upfrom 0
+	   for arg in (lazyaxis-arguments lazy-expression)
+	   if (nth nth args)
+	     do (setf (gethash arg vars) (nth nth args)))
+     (let* ((*local-variable-table* vars)
+	    (out (funcall (lazyaxis-step lazy-expression))))
+       (if (or (listp out) (typep out 'fixnum))
+	   (setf (lazyaxis-read-as lazy-expression) out)
+	   out)))))
+
+;; [TODO] Under this mode=T, changing adjustable shape is a invaild operation.
+(defparameter *observe-mode* nil "
+## [parameter] *observe-mode*
+
+Set this parameter a list of tensors to determine all Lazy Subscripts when fixnum is needed (e.g.: when printing tensor, looping)
+
+If this parameter is set to nil, maybe-observe-axis can return LazyAxis.")
+
+(defmacro with-fixing-adjustable-shape ((&rest tensors) &body body)
+  "under this macro, all adjustable shape is fixed"
+  `(let ((*observe-mode* T))
+     (dolist (tensor (list ,@tensors))
+       (dolist (axis `(,@(slot-value tensor 'cl-waffe2/vm.generic-tensor::orig-shape)
+		       ,@(slot-value tensor 'cl-waffe2/vm.generic-tensor::visible-shape)
+		       ,@(slot-value tensor 'cl-waffe2/vm.generic-tensor::stride)
+		       ,@(slot-value tensor 'cl-waffe2/vm.generic-tensor::input-shape)))
+	 (when (typep axis 'LazyAxis)
+	   (setf (lazyaxis-read-as axis) nil)
+	   (observe-axis axis))))		      
+     ,@body))
+
+(defun tensor-fix-adjustable-shape (tensor)
+  (dolist (axis `(,@(slot-value tensor 'cl-waffe2/vm.generic-tensor::orig-shape)
+		  ,@(slot-value tensor 'cl-waffe2/vm.generic-tensor::visible-shape)
+		  ,@(slot-value tensor 'cl-waffe2/vm.generic-tensor::stride)
+		  ,@(slot-value tensor 'cl-waffe2/vm.generic-tensor::input-shape)))
+    (when (typep axis 'LazyAxis)
+      (setf (lazyaxis-read-as axis) nil)
+      (observe-axis axis))))
+
+(defun maybe-observe-axis (value)
+  (if (typep value 'LazyAxis)
+      (if (every (compose #'numberp #'cl-waffe2/vm.generic-tensor::read-symbol) (lazyaxis-arguments value)) ;; Can determine?
+	  (observe-axis value)
+	  value)
+      (if (symbolp value)
+	  (cl-waffe2/vm.generic-tensor::read-adjustable-symbol value)
+	  value)))
+
+(defun maybe-observe-axis-no-err (value)
+  (typecase value
+    (LazyAxis
+     (or (lazyaxis-read-as value)
+	 (when *observe-mode*
+	   (maybe-observe-axis value))
+	 value))
+    (symbol
+     (cl-waffe2/vm.generic-tensor::read-symbol value))
+    (number
+     value)
+    (T
+     value)))
+
+) ;; eval-when
+
+;; [FIXME]
+;; When I have enough time, Reimplement dynamic-shaping as much better ... elegant way.
+(defparameter *lazyaxis->symbol* (make-hash-table :test #'equal))
+(defparameter *symbol->lazyaxis* (make-hash-table :test #'equal))
+
+(defmethod lazyaxis-symbol ((lazyaxis LazyAxis))
+  (or (gethash (format nil "~a" lazyaxis) *lazyaxis->symbol*)
+      (let ((id (gensym "AXIS")))
+	(setf (gethash id *symbol->lazyaxis*) lazyaxis
+	      (gethash (format nil "~a" lazyaxis) *lazyaxis->symbol*) id))))
+
+(defun symbol-lazyaxis (symbol)
+  (gethash symbol *symbol->lazyaxis*))
 
 

--- a/source/vm/lazy-subscript.lisp
+++ b/source/vm/lazy-subscript.lisp
@@ -408,7 +408,7 @@ If this parameter is set to nil, maybe-observe-axis can return LazyAxis.")
 
 (defmethod lazyaxis-symbol ((lazyaxis LazyAxis))
   (or (gethash (format nil "~a" lazyaxis) *lazyaxis->symbol*)
-      (let ((id (gensym "AXIS")))
+      (let ((id (gensym "LAZYAXIS")))
 	(setf (gethash id *symbol->lazyaxis*) lazyaxis
 	      (gethash (format nil "~a" lazyaxis) *lazyaxis->symbol*) id))))
 

--- a/source/vm/lazy-subscript.lisp
+++ b/source/vm/lazy-subscript.lisp
@@ -97,9 +97,13 @@ e.g.: A is = compared to 2
      (let ((out (lazyir-car lazyir)))
        (if (numberp out)
 	   out
-	   (observe-axis out))))
+	   (progn
+	     (setf (lazyaxis-read-as out) nil)
+	     (observe-axis out)))))
     (:dynamic-shape (observe-variable (cadr (cadr (lazyir-car lazyir)))))
-    (:rest          (observe-axis (second (lazyir-car lazyir))))
+    (:rest          (let ((out (second (lazyir-car lazyir))))
+		      (setf (lazyaxis-read-as out) nil)
+		      (observe-axis out)))
     (:arithmetic (apply (the symbol (lazyir-car lazyir)) (map 'list #'interpret-lazy (lazyir-cdr lazyir))))
     (:function   (apply (the symbol (lazyir-car lazyir)) (map 'list #'interpret-lazy (lazyir-cdr lazyir))))))
 

--- a/source/vm/lazy-subscript.lisp
+++ b/source/vm/lazy-subscript.lisp
@@ -375,6 +375,10 @@ If this parameter is set to nil, maybe-observe-axis can return LazyAxis.")
   nil)
 
 (defun maybe-observe-axis (value)
+  "Reads the given value as a fixnum.
+value is excepted as: LazyAxis, Symbol, Fixnum, rest...
+If value is dynamic-shape -> observe it and returns as a fixnum
+Otherwise                 -> Return as it is."
   (if (typep value 'LazyAxis)
       (if (every (compose #'numberp #'cl-waffe2/vm.generic-tensor::read-symbol) (lazyaxis-arguments value)) ;; Can determine?
 	  (observe-axis value)

--- a/source/vm/lazy-subscript.lisp
+++ b/source/vm/lazy-subscript.lisp
@@ -329,7 +329,7 @@ LazyAxis: f(IN N) = floor((1+((IN+(2*N)+0+-1)/2)))
 "
   (declare (type LazyAxis lazy-expression))
   (or
-   (lazyaxis-read-as lazy-expression)
+   ;;(lazyaxis-read-as lazy-expression)
    (let ((vars (or *local-variable-table* (make-hash-table))))
      (loop for nth fixnum upfrom 0
 	   for arg in (lazyaxis-arguments lazy-expression)
@@ -363,13 +363,16 @@ If this parameter is set to nil, maybe-observe-axis can return LazyAxis.")
      ,@body))
 
 (defun tensor-fix-adjustable-shape (tensor)
+  "Resets all results of adjustable shape belongs to tensor"
+  (declare (type AbstractTensor tensor))
   (dolist (axis `(,@(slot-value tensor 'cl-waffe2/vm.generic-tensor::orig-shape)
 		  ,@(slot-value tensor 'cl-waffe2/vm.generic-tensor::visible-shape)
 		  ,@(slot-value tensor 'cl-waffe2/vm.generic-tensor::stride)
 		  ,@(slot-value tensor 'cl-waffe2/vm.generic-tensor::input-shape)))
     (when (typep axis 'LazyAxis)
       (setf (lazyaxis-read-as axis) nil)
-      (observe-axis axis))))
+      (observe-axis axis)))
+  nil)
 
 (defun maybe-observe-axis (value)
   (if (typep value 'LazyAxis)

--- a/source/vm/nodes/shape-error.lisp
+++ b/source/vm/nodes/shape-error.lisp
@@ -30,7 +30,7 @@
   (format nil "~a{~a}~a"
 	  (class-name (class-of tensor))
 	  (dtype      tensor)
-	  (shape tensor)))
+	  (cl-waffe2/vm.generic-tensor:lazy-shape tensor)))
 
 (defun build-shape-error (forward-or-call model
 			  where-decl

--- a/source/vm/nodes/shape-error.lisp
+++ b/source/vm/nodes/shape-error.lisp
@@ -71,10 +71,8 @@ Suggestion"
 	   (type (or AbstractNode Composite)))
 
   (with-output-to-string (out)
-    (format out "[Shaping Error]:")
-
     (if (eql forward-or-call :call)
-	(format out " The Composite ~a was called with invaild arguments." model-name)
+	(format out "The Composite ~a was called with invaild arguments." model-name)
 	(case (checkpoint-state *shape-error-when*)
 	  (:forward
 	   (format out " The AbstractNode ~a was called with invaild arguments." model-name))

--- a/source/vm/nodes/utils.lisp
+++ b/source/vm/nodes/utils.lisp
@@ -9,7 +9,8 @@
 	  :where (A[~] -> A[~])
 	  :documentation ""))
 
-(define-impl (InstantKernelNode :device t :cache-when-compiled nil)
+(defun gensym-id (&rest args) (declare (ignore args)) `(,(gensym)))
+(define-impl (InstantKernelNode :device t :cache-id #'gensym-id)
 	     :forward ((self x)
 		       (let ((result (funcall (instant-call-form self))))
 			 (setf (out-scalar-p self) (cl-waffe2/vm.generic-tensor:scalar-p x))

--- a/source/vm/package.lisp
+++ b/source/vm/package.lisp
@@ -8,6 +8,22 @@
    :cl-waffe2/vm.nodes
    :cl-waffe2/base-impl)
   (:export
+   ;; LazyAxis
+   #:LazyAxis
+   #:lazyaxis-arguments
+   #:lazyaxis-constraints
+   #:lazyaxis-id
+   #:lazyaxis-symbol
+   #:symbol-lazyaxis
+   #:make-lazyaxis
+   #:observe-axis
+   #:maybe-observe-axis
+   #:make-lazy-assert
+   #:make-higher-order-lazyaxis
+
+   #:with-fixing-adjustable-shape
+   #:tensor-fix-adjustable-shape)
+  (:export
    #:*opt-level*
    #:*logging-vm-execution*   
    #:accept-instructions

--- a/source/vm/t/lazy-axis.lisp
+++ b/source/vm/t/lazy-axis.lisp
@@ -54,11 +54,21 @@
 	     (Conv2D out-channels1 out-channels2 `(5 5))
 	     (asnode #'!relu)
 	     (MaxPool2D `(2 2))
-	     (asnode #'!reshape t (* 16 4 4)) 
+	     (asnode #'!reshape t (* 16 4 4))
 	     (LinearLayer (* 16 4 4) 10))
 
 (defun cnn-build-test ()
   (build (call (LazyCNN) (make-input `(N 1 28 28) :X)) :inputs `(:X))
   )
+
+;; テストを追加すること
+
 ;; ReshapeTest
-;;(print (!reshape (make-input `(3 3 3 3)) (~ N C H W -> N C H W)))
+;; (print (!reshape (make-input `(3 3 3 3)) (~ N C H W -> N C H W)))
+;; Rendering test?
+;; Shape-Error-Test
+;; JIT CNN BUILD TEST
+;; StateDict Save And Load
+;; Error Rendering
+;; ADjustable shape with do-compiled-loop
+

--- a/source/vm/t/lazy-axis.lisp
+++ b/source/vm/t/lazy-axis.lisp
@@ -28,7 +28,6 @@
   (is (lazy-axis-net-1))
   (is (lazy-axis-net-adjust-later)))
 
-
 (defun conv2d-forward-test ()
   (call (Conv2D 3 6 `(5 5)) (make-input `(N 3 25 25) nil)))
 
@@ -44,5 +43,4 @@
   (is (max-pool2d-forward-test)))
 
 ;; ReshapeTest
-;;(!reshape (randn `(3 3 3 3)) (~ N C H W -> N C H W))
-
+;;(print (!reshape (make-input `(3 3 3 3)) (~ N C H W -> N C H W)))

--- a/source/vm/t/lazy-axis.lisp
+++ b/source/vm/t/lazy-axis.lisp
@@ -24,6 +24,7 @@
      (= 7.0 (vref (forward out (ax+b `(3 4) 0 0)) 0))
      (= 8.0 (vref (forward out (ax+b `(4 4) 0 0)) 0)))))
 
+;; ScalarTensors with LazyAxis works well?
 (test lazy-axis-scalar-test
   (is (lazy-axis-net-1))
   (is (lazy-axis-net-adjust-later)))
@@ -34,13 +35,30 @@
 (defun avg-pool2d-forward-test ()
   (call (AvgPool2d `(5 5)) (make-input `(N 3 25 25) nil)))
 
-(defun max-poo2d-forward-test ()
+(defun max-pool2d-forward-test ()
   (call (MaxPool2d `(5 5)) (make-input `(N 3 25 25) nil)))
 
+
+;; Testing just a node construction
 (test dynamic-cnn-node-construction-test
   (is (conv2d-forward-test))
   (is (avg-pool2d-forward-test))
   (is (max-pool2d-forward-test)))
 
+(defsequence LazyCNN (&key
+		      (out-channels1 4)
+		      (out-channels2 16))
+	     (Conv2D 1 out-channels1 `(3 3))
+	     (asnode #'!relu)     
+	     (MaxPool2D    `(2 2))
+	     (Conv2D out-channels1 out-channels2 `(5 5))
+	     (asnode #'!relu)
+	     (MaxPool2D `(2 2))
+	     (asnode #'!reshape t (* 16 4 4)) 
+	     (LinearLayer (* 16 4 4) 10))
+
+(defun cnn-build-test ()
+  (build (call (LazyCNN) (make-input `(N 1 28 28) :X)))
+  )
 ;; ReshapeTest
 ;;(print (!reshape (make-input `(3 3 3 3)) (~ N C H W -> N C H W)))

--- a/source/vm/t/lazy-axis.lisp
+++ b/source/vm/t/lazy-axis.lisp
@@ -58,7 +58,7 @@
 	     (LinearLayer (* 16 4 4) 10))
 
 (defun cnn-build-test ()
-  (build (call (LazyCNN) (make-input `(N 1 28 28) :X)))
+  (build (call (LazyCNN) (make-input `(N 1 28 28) :X)) :inputs `(:X))
   )
 ;; ReshapeTest
 ;;(print (!reshape (make-input `(3 3 3 3)) (~ N C H W -> N C H W)))

--- a/source/vm/t/lazy-axis.lisp
+++ b/source/vm/t/lazy-axis.lisp
@@ -28,6 +28,21 @@
   (is (lazy-axis-net-1))
   (is (lazy-axis-net-adjust-later)))
 
-;; ReshapeTest
 
-(!reshape (randn `(3 3 3 3)) (~ N C H W -> N C H W))
+(defun conv2d-forward-test ()
+  (call (Conv2D 3 6 `(5 5)) (make-input `(N 3 25 25) nil)))
+
+(defun avg-pool2d-forward-test ()
+  (call (AvgPool2d `(5 5)) (make-input `(N 3 25 25) nil)))
+
+(defun max-poo2d-forward-test ()
+  (call (MaxPool2d `(5 5)) (make-input `(N 3 25 25) nil)))
+
+(test dynamic-cnn-node-construction-test
+  (is (conv2d-forward-test))
+  (is (avg-pool2d-forward-test))
+  (is (max-pool2d-forward-test)))
+
+;; ReshapeTest
+;;(!reshape (randn `(3 3 3 3)) (~ N C H W -> N C H W))
+

--- a/source/vm/t/lazy-axis.lisp
+++ b/source/vm/t/lazy-axis.lisp
@@ -1,0 +1,33 @@
+
+(in-package :cl-waffe2/vm.test)
+
+(in-suite :vm-test)
+
+(defun lazy-axis-net-1 ()
+  (let ((out (build
+	      (!add
+	       (make-input `(A B) :X)
+	       (make-tensor
+		(make-lazyaxis `(+ A B))))
+	      :inputs `(:X))))
+    (progn
+      (= 7.0 (vref (forward out (ax+b `(3 4) 0 0)) 0)))))
+
+(defun lazy-axis-net-adjust-later ()
+  (let ((out (build
+	      (!add
+	       (make-input `(A B) :X)
+	       (make-tensor
+		(make-lazyaxis `(+ A B))))
+	      :inputs `(:X))))
+    (and
+     (= 7.0 (vref (forward out (ax+b `(3 4) 0 0)) 0))
+     (= 8.0 (vref (forward out (ax+b `(4 4) 0 0)) 0)))))
+
+(test lazy-axis-scalar-test
+  (is (lazy-axis-net-1))
+  (is (lazy-axis-net-adjust-later)))
+
+;; ReshapeTest
+
+(!reshape (randn `(3 3 3 3)) (~ N C H W -> N C H W))

--- a/source/vm/t/package.lisp
+++ b/source/vm/t/package.lisp
@@ -4,6 +4,7 @@
 (defpackage :cl-waffe2/vm.test
   (:use
    :cl
+   :cl-waffe2
    :cl-waffe2/vm
    :cl-waffe2/vm.nodes
    :cl-waffe2/vm.generic-tensor

--- a/source/vm/t/package.lisp
+++ b/source/vm/t/package.lisp
@@ -1,0 +1,25 @@
+
+(in-package :cl-user)
+
+(defpackage :cl-waffe2/vm.test
+  (:use
+   :cl
+   :cl-waffe2/vm
+   :cl-waffe2/vm.nodes
+   :cl-waffe2/vm.generic-tensor
+   :cl-waffe2/distributions
+   :cl-waffe2/nn
+   :fiveam
+   :cl-waffe2/base-impl
+   :cl-waffe2/backends.cpu
+   :cl-waffe2/backends.lisp
+   :cl-waffe2/backends.jit.cpu))
+
+(in-package :cl-waffe2/vm.test)
+
+(def-suite :vm-test)
+(in-suite  :vm-test)
+
+(defun ~= (x y)
+  (< (- x y) 0.00001))
+

--- a/source/vm/t/utils.lisp
+++ b/source/vm/t/utils.lisp
@@ -9,4 +9,38 @@
 ;; asnode
 ;; node->defun
 ;; state-dict
+;; StateDict
 
+(defsequence LazyLinear (in-features hidden-size out-features)
+	     "Testing model for LinearLayer's backwards"
+	     (LinearLayer in-features out-features)
+	     (asnode #'!relu)
+	     (LinearLayer out-features hidden-size) ;; 2th
+	     (asnode #'!relu)
+	     (LinearLayer hidden-size out-features) ;; 3th
+	     (asnode #'!relu)
+	     (asnode #'!mean))
+
+(defun save-model-test ()
+  (let ((model (build
+		(call (LazyLinear 20 10 5) (make-input `(batch-size 20) :X))
+		:inputs `(:X))))
+    (let ((result (forward model (ax+b `(1 20) 1 0))))
+      (save-weights model "./assets/model_weight_restore_tester.wf2model" :wf2model)
+      (tensor-vec result))))
+  
+(defun restore-model-test (compare-to)
+  (let ((model (build
+		(call (LazyLinear 20 10 5) (make-input `(batch-size 20) :X))
+		:inputs `(:X))))
+    (load-weights model "./assets/model_weight_restore_tester.wf2model" :wf2model)
+    (every #'= compare-to (tensor-vec (forward model (ax+b `(1 20) 1 0))))))
+
+(defun save-and-restore ()
+  (let ((res (save-model-test)))
+    (restore-model-test res)))
+
+(test save-and-restore-model-test
+  (is (save-and-restore)))
+
+  

--- a/source/vm/t/utils.lisp
+++ b/source/vm/t/utils.lisp
@@ -1,0 +1,12 @@
+
+(in-package :cl-waffe2/vm.test)
+
+;; Testing Utils (change-facet ...)
+
+(in-suite :vm-test)
+
+;; change-facet
+;; asnode
+;; node->defun
+;; state-dict
+

--- a/source/vm/utils.lisp
+++ b/source/vm/utils.lisp
@@ -141,3 +141,21 @@
     (setf (wfop-grad-adder-p (car out)) t)
     out))
 
+(defun render-debug-info ()
+  "Displays all global variables related to the error"
+  (with-output-to-string (out)
+    (format out "= [DebugInfo] =====~%")
+    (format out "Global Variables:~%")
+    (format out "Dynamic Shape:~%")
+    (maphash #'(lambda (k v)
+		 (format out "    ~a -> ~a~%"
+			 (if (symbol-lazyaxis k)
+			     (format nil "~a(~a)" k (symbol-lazyaxis k))
+			     k)
+			 v))
+	     cl-waffe2/vm.generic-tensor::*adjustable-shape-table*)
+    (format out "LazyAxis Table:~%")
+    (maphash #'(lambda (s axis)
+		 (format out "    ~a -> ~a~%" s axis))
+	     *symbol->lazyaxis*)))
+

--- a/source/vm/vm.lisp
+++ b/source/vm/vm.lisp
@@ -26,7 +26,6 @@ This parameter is useful for printing how all instructions are performed. If set
 ")
 
 (declaim (inline maybe-read-result write-result apply-instructions apply-inst-sv4bw))
-
 (defmodel (SV4BW-Copier (self)
 	   :on-call-> ((self x y)
 		       (declare (ignore self))
@@ -223,7 +222,9 @@ disassemble:
 ~a
 
 condition:
-  ~a"
+  ~a
+
+~a"
 	 position
 	 (with-output-to-string (out)
 	   (let* ((start (max 0 (- position 3)))
@@ -236,7 +237,8 @@ condition:
 		       do (format out "~a*: ~a~%" nth (nth nth iseq))
 		     else
 		       do (format out "~a : ~a~%" nth (nth nth iseq))))))
-	 condition))
+	 condition
+	 (render-debug-info)))
 
 (declaim (ftype (function (list) t) accept-instructions))
 (defun accept-instructions (iseq)


### PR DESCRIPTION
# Changes

## Doing !reshape for DynamicShape

```lisp
TEST> (!reshape (make-input `(N C H W) nil)
		(~ N C H W -> (* N C H) W))
{CPUTENSOR[float] :shape (LazyAxis: f(N C H) = (N*C*H) LazyAxis: W) :id TID2755206 
  :vec-state [maybe-not-computed]
    <<Not allocated: size=(LazyAxis: f(N C H) = (N*C*H) LazyAxis: W)>>
  :facet :input
  :belongs-to :memory-pool
  :requires-grad NIL
  :backward <Node: RESHAPETENSORNODE-T (A[BEFORE] B[AFTER] -> B[AFTER])>}
```

The shape of `AbstractTensor` is now given as a `LazyAxis` structure; which can contain S-expression. This feature is advantageous in networks where the batch-size changes frequently, as it allows operations to be performed without having to recompile. As for CNN, complex shape transmissions can be represented as reported in #132 .

```lisp
(call (Conv2d 3 6 `(5 5)) (make-input `(N 3 25 25) :X))
```

is now a valid operation.