### PR TITLE
[Enhancement] Increased the safety of defmodel-as

### DIFF
--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -252,17 +252,18 @@
 	       (:file "nn/t/regression")	       
 	       )
   :perform (test-op (o s)
-		    (symbol-call :fiveam :run! :vm-test)
-		    (symbol-call :fiveam :run! :jit-lisp-test)
-		    
 		    (symbol-call :fiveam :run! :test-nodes)
 		    (symbol-call :fiveam :run! :test-tensor)
+		    
 		    (symbol-call :fiveam :run! :base-impl-test)
-
-		    (symbol-call :fiveam :run! :jit-cpu-test)
+		    (symbol-call :fiveam :run! :jit-lisp-test)
+		    
 		    (symbol-call :fiveam :run! :lisp-backend-test)
 		    (symbol-call :fiveam :run! :test-backends-cpu)
-		    (symbol-call :fiveam :run! :nn-test)))
+		    (symbol-call :fiveam :run! :jit-cpu-test)
+		    
+		    (symbol-call :fiveam :run! :nn-test)
+		    (symbol-call :fiveam :run! :vm-test)))
 
 
 (defpackage :cl-waffe2-docs-asdf

--- a/docs/apis/reference.lisp
+++ b/docs/apis/reference.lisp
@@ -288,7 +288,9 @@ The package `cl-waffe2/vm` is the central of system, and features are focused on
       (with-op-doc (macro-function 'defsequence) 't)
       (with-op-doc (macro-function 'hooker) 't)
       (with-op-doc (macro-function 'node->lambda) 't)
-      (with-op-doc (macro-function 'node->defun) 't))
+      (with-op-doc (macro-function 'node->defun) 't)
+      (with-op-doc (macro-function 'node->defnode) 't)
+      )
     
     (with-op-doc #'show-backends 'function)
     (with-op-doc #'set-devices-toplevel 'function)))

--- a/docs/cl-waffe2-docs/docs/generic-tensor.md
+++ b/docs/cl-waffe2-docs/docs/generic-tensor.md
@@ -653,7 +653,7 @@ In order to parse the state_dict key, the function `parse-state-dict-key` is ava
 > (make-state-dict (build (call (LinearLayer 10 10) (randn `(10 10)))))
 ```
 ```
-#S(STATE-DICT :TABLE #<HASH-TABLE :TEST EQUAL :COUNT 2 {10045F03B3}>
+#S(STATE-DICT :TABLE #<HASH-TABLE :TEST EQUAL :COUNT 2 {10045083B3}>
  table-key-to-value:
     param:linearlayer.0.bias    -> CPUTENSOR{FLOAT}(10)
     param:linearlayer.0.weights -> CPUTENSOR{FLOAT}(10 10)

--- a/docs/cl-waffe2-docs/docs/utils.md
+++ b/docs/cl-waffe2-docs/docs/utils.md
@@ -352,7 +352,7 @@ Creates a lambda function obtained by tracing and compiling the computation node
 ## [macro] node->defun
 
 ```lisp
-(node->defun (name (&rest where) &body body))
+(node->defun name (&rest where) &body body)
 ```
 
 Defines a function obtained by tracing and compiling the computation node described in the body.
@@ -380,6 +380,31 @@ Defines a function obtained by tracing and compiling the computation node descri
   :belongs-to :memory-pool
   :requires-grad NIL
   :backward NIL}
+```
+
+## [macro] node->defnode
+
+```lisp
+(node->defun name (&rest where) &body body)
+```
+
+Defines a differentiable AbstractNode obtained by tracing and compiling the computation node described in the body.
+
+### Inputs
+
+`name[symbol]` the function is defined after it
+
+`where` declares the shape transforms. the tensor names used here are the same as those used in body.
+
+`body` Describe the construction of the computation node here.
+
+### Example
+
+```lisp
+(node->defnode log-softmax (A[~] -> OUT[~])
+    (!softmax (!loge a) :axis 1))
+
+(proceed (log-softmax (parameter (ax+b `(3 3) 0 1))))
 ```
 
 ## [function] show-backends

--- a/docs/cl-waffe2-docs/docs/vm.md
+++ b/docs/cl-waffe2-docs/docs/vm.md
@@ -172,34 +172,34 @@ See also: `proceed-bench`
 
 [Sorted by Instructions]
  Time(s)   |   Instruction ( * - Beyonds the average execution time)
-3.15e-4    | <WfInst[op=MOVETENSORNODE-CPUTENSOR] : TID735 <= op(TID735{float, (100 100)} <Input>TID647{float, (100 100)})>
-9.2e-5     | <WfInst[op=VIEWTENSORNODE-T]         : TID729 <= op(TID729{float, (100 1)} TID729{float, (100 1)})>
-1.39e-4    | <WfInst[op=SCALARMUL-CPUTENSOR]      : TID729 <= op(TID729{float, (100 1)} <Input>TID656{float, (1)})>
+3.39e-4    | <WfInst[op=MOVETENSORNODE-CPUTENSOR] : TID735 <= op(TID735{float, (100 100)} <Input>TID647{float, (100 100)})>
+8.9e-5     | <WfInst[op=VIEWTENSORNODE-T]         : TID729 <= op(TID729{float, (100 1)} TID729{float, (100 1)})>
+1.37e-4    | <WfInst[op=SCALARMUL-CPUTENSOR]      : TID729 <= op(TID729{float, (100 1)} <Input>TID656{float, (1)})>
 9.6e-5     | <WfInst[op=VIEWTENSORNODE-T]         : TID729 <= op(TID729{float, (100 100)} TID729{float, (100 1)})>
-0.005877*  | <WfInst[op=ADDNODE-CPUTENSOR]        : TID729 <= op(TID729{float, (100 100)} <Input>TID647{float, (100 100)})>
-9.2e-5     | <WfInst[op=VIEWTENSORNODE-T]         : TID729 <= op(TID729{float, (100 1)} TID729{float, (100 100)})>
-0.00194*   | <WfInst[op=SCALARDIV-CPUTENSOR]      : TID729 <= op(TID729{float, (100 1)} <Input>TID651{float, (1)})>
-9.7e-5     | <WfInst[op=VIEWTENSORNODE-T]         : TID729 <= op(TID729{float, (100 100)} TID729{float, (100 1)})>
-0.00403*   | <WfInst[op=SUBNODE-CPUTENSOR]        : TID735 <= op(TID735{float, (100 100)} TID729{float, (100 100)})>
-9.36e-4    | <WfInst[op=EXPNODE-CPUTENSOR]        : TID735 <= op(TID735{float, (100 100)} TID735{float, (100 100)})>
-1.18e-4    | <WfInst[op=SCALARMUL-CPUTENSOR]      : TID729 <= op(TID729{float, (100 1)} <Input>TID780{float, (1)})>
-9.9e-5     | <WfInst[op=VIEWTENSORNODE-T]         : TID729 <= op(TID729{float, (100 100)} TID729{float, (100 1)})>
-0.006106*  | <WfInst[op=ADDNODE-CPUTENSOR]        : TID729 <= op(TID729{float, (100 100)} TID735{float, (100 100)})>
-0.00389*   | <WfInst[op=DIVNODE-CPUTENSOR]        : TID735 <= op(TID735{float, (100 100)} TID729{float, (100 100)})>
+0.006105*  | <WfInst[op=ADDNODE-CPUTENSOR]        : TID729 <= op(TID729{float, (100 100)} <Input>TID647{float, (100 100)})>
+8.4e-5     | <WfInst[op=VIEWTENSORNODE-T]         : TID729 <= op(TID729{float, (100 1)} TID729{float, (100 100)})>
+0.00186*   | <WfInst[op=SCALARDIV-CPUTENSOR]      : TID729 <= op(TID729{float, (100 1)} <Input>TID651{float, (1)})>
+1.04e-4    | <WfInst[op=VIEWTENSORNODE-T]         : TID729 <= op(TID729{float, (100 100)} TID729{float, (100 1)})>
+0.003839*  | <WfInst[op=SUBNODE-CPUTENSOR]        : TID735 <= op(TID735{float, (100 100)} TID729{float, (100 100)})>
+9.22e-4    | <WfInst[op=EXPNODE-CPUTENSOR]        : TID735 <= op(TID735{float, (100 100)} TID735{float, (100 100)})>
+1.16e-4    | <WfInst[op=SCALARMUL-CPUTENSOR]      : TID729 <= op(TID729{float, (100 1)} <Input>TID780{float, (1)})>
+9.8e-5     | <WfInst[op=VIEWTENSORNODE-T]         : TID729 <= op(TID729{float, (100 100)} TID729{float, (100 1)})>
+0.005926*  | <WfInst[op=ADDNODE-CPUTENSOR]        : TID729 <= op(TID729{float, (100 100)} TID735{float, (100 100)})>
+0.003747*  | <WfInst[op=DIVNODE-CPUTENSOR]        : TID735 <= op(TID735{float, (100 100)} TID729{float, (100 100)})>
 
-14 Instructions | 6 Tensors | Overheads due to SV4BW(...) -> 5.48e-6(s) 
+14 Instructions | 6 Tensors | Overheads due to SV4BW(...) -> 4.79e-6(s) 
 
- Total Time: 0.023827 sec
+ Total Time: 0.023462 sec
 
 [Sorted by topK]
  Instruction                         | Total time (s) | Time/Total (n-sample=100)
-<WfInst[op=ADDNODE-CPUTENSOR]        | 0.011983       | 50.291687%
-<WfInst[op=SUBNODE-CPUTENSOR]        | 0.00403        | 16.913586%
-<WfInst[op=DIVNODE-CPUTENSOR]        | 0.00389        | 16.326017%
-<WfInst[op=SCALARDIV-CPUTENSOR]      | 0.00194        | 8.142023%
-<WfInst[op=EXPNODE-CPUTENSOR]        | 9.36e-4        | 3.9283168%
-<WfInst[op=VIEWTENSORNODE-T]         | 4.7600002e-4   | 1.9977337%
-<WfInst[op=MOVETENSORNODE-CPUTENSOR] | 3.15e-4        | 1.3220297%
-<WfInst[op=SCALARMUL-CPUTENSOR]      | 2.57e-4        | 1.0786084%
+<WfInst[op=ADDNODE-CPUTENSOR]        | 0.012031       | 51.278664%
+<WfInst[op=SUBNODE-CPUTENSOR]        | 0.003839       | 16.362629%
+<WfInst[op=DIVNODE-CPUTENSOR]        | 0.003747       | 15.970506%
+<WfInst[op=SCALARDIV-CPUTENSOR]      | 0.00186        | 7.927713%
+<WfInst[op=EXPNODE-CPUTENSOR]        | 9.22e-4        | 3.9297588%
+<WfInst[op=VIEWTENSORNODE-T]         | 4.71e-4        | 2.0075016%
+<WfInst[op=MOVETENSORNODE-CPUTENSOR] | 3.39e-4        | 1.4448895%
+<WfInst[op=SCALARMUL-CPUTENSOR]      | 2.53e-4        | 1.0783395%
 
 ```

--- a/source/network.lisp
+++ b/source/network.lisp
@@ -306,7 +306,7 @@ Creates a lambda function obtained by tracing and compiling the computation node
 ## [macro] node->defun
 
 ```lisp
-(node->defun (name (&rest where) &body body))
+(node->defun name (&rest where) &body body)
 ```
 
 Defines a function obtained by tracing and compiling the computation node described in the body.
@@ -343,14 +343,12 @@ Defines a function obtained by tracing and compiling the computation node descri
        :asif :function
        :named ,name)))
 
-
-#|
 (defmacro node->defnode (name (&rest where) &body body)
   "
 ## [macro] node->defnode
 
 ```lisp
-(node->defun (name (&rest where) &body body))
+(node->defun name (&rest where) &body body)
 ```
 
 Defines a differentiable AbstractNode obtained by tracing and compiling the computation node described in the body.
@@ -377,6 +375,6 @@ Defines a differentiable AbstractNode obtained by tracing and compiling the comp
 	 (asnode #'(lambda (,@(car parsed)) ,@body))
        :where ,where
        :asif :node
-       :differentiable nil
+       :differentiable t
        :named ,name)))
-|#
+

--- a/source/vm/allocation.lisp
+++ b/source/vm/allocation.lisp
@@ -28,6 +28,11 @@
 ;; AbstractNode: f(lambda_fw, lambda_bw, tensors) -> g(tensors) where g is a thread-safe compiled program.
 ;; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+;; [TODO] If the given IR includes Compiled-Composite(defmodel-as) and allocations information for it is available.
+;;         Use these information and merge them.
+;;        Such nodes are subclass of AbstractCompositeNode.
+;;
+
 (defun tensor-tmp-p (tensor &optional (include-scalar nil))
   "Returns T if the given tensor is subject to be optimized locality"
   (declare (type AbstractTensor tensor))

--- a/source/vm/compile.lisp
+++ b/source/vm/compile.lisp
@@ -229,7 +229,7 @@ Tips: `disassemble-waffe2-ir` to display compiled Instruction Sequence.
 	      (when optimize-locality
 		(dolist (device-name *using-backend*)
 		  (multiple-value-setq (iseq-fw iseq-bw) (on-finalizing-compiling device-name iseq-fw iseq-bw))))
-	      
+
 	      (values iseq-fw iseq-bw leaves dout allocation))))))))
 
 #+sbcl(setf sb-ext:*inline-expansion-limit* 4)

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -495,8 +495,9 @@ Or, your network may be disconnected at a certain position."
   (let* ((allocation (cl-waffe2/vm::copy-allocate (compiled-allocation model)))
 	 (table      (cl-waffe2/vm::vmalloc-id2pool allocation)))
     (flet ((replace-new (tensor)
-	     (or (gethash (tensor-id tensor) table)
-		 tensor)))
+	     (when tensor
+	       (or (gethash (tensor-id tensor) table)
+		   tensor))))
       (let ((dout (replace-new (compiled-dout model)))
 	    (out  (replace-new (compiled-out  model))))
 	(make-instance 'Compiled-Composite

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -502,7 +502,7 @@ Or, your network may be disconnected at a certain position."
 	    (out  (replace-new (compiled-out  model))))
 	(make-instance 'Compiled-Composite
 		       ;; Duplicate Memory-Pool
-		       :allocation (cl-waffe2/vm::copy-allocate (compiled-allocation model))
+		       :allocation allocation
 		       
 		       :compiled-forward  (compiled-forward model)
 		       :compiled-backward (compiled-backward model)
@@ -510,7 +510,7 @@ Or, your network may be disconnected at a certain position."
 		       :dout dout
 		       :out  out
 		       
-		       :inputs    (compiled-inputs model)
+		       :inputs    (compiled-inputs model) ;; a list of keywords
 		       :variables (copy-variable-table (compiled-variables model) allocation))))))
 
 ;; TODO -> (defmethod free-model ((model Compiled-Composite)))

--- a/source/vm/nodes/model-compiler.lisp
+++ b/source/vm/nodes/model-compiler.lisp
@@ -130,7 +130,10 @@ Note that this function isn't subject to lazy-evaluation, and all arguments need
 				if (and need-backward
 					(cl-waffe2/vm.generic-tensor:ancestor-param-p arg))
 				  collect (progn
-					    (setf (slot-value tensor 'requires-grad) t						  
+					    ;; The size of gradients are dynamically changed;
+					    ;; Allocate Manually
+					    (setf (slot-value tensor 'requires-grad) t
+						  (cl-waffe2/vm.generic-tensor:ancestor-param-p tensor) T
 						  (cl-waffe2/vm.generic-tensor::tensor-id-lock-p tensor) T
 						  (slot-value tensor 'cl-waffe2/vm.generic-tensor::grad)
 						  (make-input (shape tensor) nil
@@ -265,7 +268,8 @@ And manages its allocation not to cause conflicts in the threads."))
 				    (apply #'values
 					   (loop for argument in (cl-waffe2/vm.generic-tensor::compiled-inputs (read-compiled-model ,self))
 						 if (cl-waffe2/vm.generic-tensor:grad (get-input (read-compiled-model ,self) argument))
-						   collect (cl-waffe2/vm.generic-tensor:grad (get-input (read-compiled-model ,self) argument))
+						   collect
+						   (cl-waffe2/vm.generic-tensor:grad (get-input (read-compiled-model ,self) argument))
 						 else
 						   collect nil)))))
 

--- a/source/vm/nodes/static-node.lisp
+++ b/source/vm/nodes/static-node.lisp
@@ -7,19 +7,16 @@
 ;; Memo: (call (StaticNode) (parameter (randn `(10 10)))) is n't working for backward
 ;; But (call (StaticNode) (!copy (parameter (randn `(10 10))))) is working.
 
+;; define-impl-op is the way to describe lambda expression of Wengert List directly by users.
+
 ;; ===========================================================
-;; Static Composite ==========================================
+;; = Static Composite ========================================
 ;; ===========================================================
 
-;; Parameters
-(defparameter *under-composite-node-mode* 0 "Incf 1 when go deeper with compis-temode, If count>=2, save-for-backwards are ignored.")
+(defparameter *under-composite-node-mode* 0 "Indicates the depth of scope of static-node. Incf 1 when go deeper with compis-temode, If count>=2, save-for-backwards are ignored.")
 
 (defparameter *composite-node-self-global* nil "Used by with-setting-save4bw, with-reading-save4bw")
 
-
-
-
-;; Using proceed instead composite-function is now much wiser desicion.
 
 ;; Implementation of save-for-backward/read-save-for-backward
 ;; Both of them are called with save-for-backward function binded by with-composite-node-mode
@@ -43,7 +40,6 @@
 	  ;; Do allocation of place
 	  ;; Set it to the slot
 	  (setf (slot-value self name) place)))
-
       (cl-waffe2/vm::%vm-move (slot-value self name) tensor)
 
       ;; FixME

--- a/source/vm/nodes/t/composite.lisp
+++ b/source/vm/nodes/t/composite.lisp
@@ -80,10 +80,13 @@
      (!sumup-static a))
     (= 1 (vref (grad a) 0))))
 
+;; Backward tests
 (test defmodel-as-diff-test
   (is (defmodel->node-diff-1))
   (is (defmodel->node-diff-1-vm))
   (is (defmodel->node-diff-2)))
 
-;; TODO:    Loop Collapse
-;; Support: lazy-values
+;; 1. もうちょっとdefmodel->node-diffのテスト増やすべき
+;; 2. Backward opt
+;; 3. connected with dynamic-shape?
+;; 4. node->defnode

--- a/source/vm/nodes/t/composite.lisp
+++ b/source/vm/nodes/t/composite.lisp
@@ -86,7 +86,86 @@
   (is (defmodel->node-diff-1-vm))
   (is (defmodel->node-diff-2)))
 
-;; 1. もうちょっとdefmodel->node-diffのテスト増やすべき
-;; 2. Backward opt
-;; 3. connected with dynamic-shape?
-;; 4. node->defnode
+(node->defnode !softmax-jit-lazy (A[~] -> B[~])
+  (!softmax a))
+
+(test node->defnode-test
+  (is
+   (M=
+    (proceed (!softmax (ax+b `(20 20) 0 2)))
+    (proceed (!softmax-jit-lazy (ax+b `(20 20) 0 2))))))
+
+(node->defnode !gelu-jit-lazy (A[~] -> B[~])
+  (!gelu a))
+
+(test defmodel-as-node-diff-test-GeLU
+  (is
+   (let ((a (parameter (ax+b `(10 10) 0.001 2)))
+	 (b (parameter (ax+b `(10 10) 0.001 2))))
+     (proceed-backward
+      (!mean (!gelu-jit-lazy a)))
+     (proceed-backward
+      (!mean (!gelu-jit-lazy b)))
+     (and
+      (not (= (vref (grad a) 0) 0.0))
+      (M= (grad a) (grad b))))))
+
+(defun meet-with-dynamic-shape-larger ()
+  (let ((model (build
+		(!gelu-jit-lazy (make-input `(A B) :X))
+		:inputs `(:X))))
+    ;; Every time Reallocation
+    (forward model (ax+b `(1 10) 0 2))
+    (forward model (ax+b `(2 10) 0 1))
+    (forward model (ax+b `(3 10) 0 2))
+    (every #'(lambda (x) (= x 0.841192))
+	   (tensor-vec (forward model (ax+b `(4 10) 0 1))))))
+
+(defun meet-with-dynamic-shape-smaller ()
+  (let ((model (build
+		(!gelu-jit-lazy (make-input `(A B) :X))
+		:inputs `(:X))))
+    ;; Re-using allocations
+    (forward model (ax+b `(4 10) 0 2))
+    (forward model (ax+b `(3 10) 0 1))
+    (forward model (ax+b `(2 10) 0 2))
+    (let ((out (forward model (ax+b `(1 10) 0 1))))
+      (every #'(lambda (nth)
+		 (= (vref out nth) 0.841192))
+	     (loop for i upfrom 0 below 10 collect i)))))
+
+(defun meet-with-dynamic-shape-complicated ()
+  (let ((model (build
+		(!relu (!gelu-jit-lazy (!relu (make-input `(A B) :X))))
+		:inputs `(:X))))
+    ;; Re-using allocations
+    (forward model (ax+b `(4 10) 0 2))
+    (backward model)
+    (forward model (ax+b `(3 10) 0 1))
+    (forward model (ax+b `(2 10) 0 2))
+    (let ((out (forward model (ax+b `(1 10) 0 1))))
+      (every #'(lambda (nth)
+		 (= (vref out nth) 0.841192))
+	     (loop for i upfrom 0 below 10 collect i)))))
+
+(test meet-with-dynamic-shape
+  (is (meet-with-dynamic-shape-larger))
+  (is (meet-with-dynamic-shape-smaller))
+  (is (meet-with-dynamic-shape-complicated)))
+
+;; !sin a !sin b was computed at once.
+(node->defnode !arith-test (A[~] B[~] -> C[~])
+  (!add (!sin a) (!sin b)))
+
+;; Confirmed !arith-test backward was called at once.
+(defun backward-route-test ()
+  (let ((a (parameter (ax+b `(10 10) 0 2)))
+	(b (parameter (ax+b `(10 10) 0 2))))
+    (proceed-backward (!arith-test a b))
+    (cl-waffe2/vm:disassemble-waffe2-ir (!arith-test a b))
+    (list (grad a) (grad b))))
+
+(test defmodel-as-backward-route-test
+  (is (backward-route-test)))
+
+

--- a/source/vm/utils.lisp
+++ b/source/vm/utils.lisp
@@ -120,7 +120,7 @@
 			 (cl-waffe2/base-impl::ScalarAndScalarAdd)
 			 (grad tensor)
 			 grad)))
-		     (if (= (tensor-grad-count tensor) 0)			 
+		     (if (= (tensor-grad-count tensor) 0)
 			 (progn
 			   (incf (tensor-grad-count tensor) 1)
 			   (node-compile-into-vm


### PR DESCRIPTION
- [BugFix] `defmodel-as :asif :node` isn't working.
    - forward/backward mode.
    - interoperate with dynamic shapes
    - Once a model was compiled, no further compiling is required as long as compatible cache was found

- [Add] node->defnode