### PR TITLE
[Optimize] WfInstruction Appearance Enhancement dedicated to fuse instructions optimization.

### DIFF
--- a/cl-waffe2.asd
+++ b/cl-waffe2.asd
@@ -59,6 +59,7 @@
 	       (:file "vm/nodes/package")
 	       (:file "vm/nodes/symbolic")
 	       (:file "base-impl/package")
+	       (:file "base-impl/attributes")
 
 	       (:file "vm/package")
 	       (:file "vm/generic-tensor/dtype")

--- a/source/base-impl/attributes.lisp
+++ b/source/base-impl/attributes.lisp
@@ -11,9 +11,21 @@
 Loads a system pointer from B to A:
 A* = B* where A[~] B[~] -> A[~]"))
 
+(defmethod ensure-loadp ((node Loadp-Node) args out-to)
+  "Ensures the node is declared as A* = B* forms"
+  (and
+   (= (length out-to) 1)
+   (= (length args)   2)
+   (equal (car out-to) (car args))))
+
 (defclass Rebundant-Node () nil
   (:documentation "
 AbstractNodes which extends this class is destinated to be eliminated when compiled and after backprop iseq is constructed.
+"))
+
+(defclass Load-MySelf-Node () nil
+  (:documentation "
+AbstractNodes which extends this class is interpreted as: lambda(x) (tensor-vec x)
 "))
 
 

--- a/source/base-impl/attributes.lisp
+++ b/source/base-impl/attributes.lisp
@@ -1,0 +1,19 @@
+
+(in-package :cl-waffe2/base-impl)
+
+;; Abstract nodes can inherit these classes to determine which attributes to use for optimization
+
+;; [TODO] (defclass AbstractMoveNode)
+;; MoveScalarTensorNode ... should be pruned likewise MoveTensorNode
+
+(defclass Loadp-Node () nil
+  (:documentation "
+Loads a system pointer from B to A:
+A* = B* where A[~] B[~] -> A[~]"))
+
+(defclass Rebundant-Node () nil
+  (:documentation "
+AbstractNodes which extends this class is destinated to be eliminated when compiled and after backprop iseq is constructed.
+"))
+
+

--- a/source/base-impl/attributes.lisp
+++ b/source/base-impl/attributes.lisp
@@ -9,14 +9,24 @@
 (defclass Loadp-Node () nil
   (:documentation "
 Loads a system pointer from B to A:
-A* = B* where A[~] B[~] -> A[~]"))
+A* = B* where A[~] B[~] -> A[~]
+Accordingly, its forward definition is given as:
+#'(lambda (from to)
+    (setf (tensor-vec from) (tensor-vec to))
+    from)"))
+
+(defclass Loadp-Node-Rev () nil
+  (:documentation "
+#'(lambda (from to)
+     (setf (tensor-vec to) (tensor-vec from))
+     to)"))
 
 (defmethod ensure-loadp ((node Loadp-Node) args out-to)
-  "Ensures the node is declared as A* = B* forms"
+  "Ensures the node is declared as A* = B* forms.
+FROM <- (FROM, TO)"
   (and
    (= (length out-to) 1)
-   (= (length args)   2)
-   (equal (car out-to) (car args))))
+   (= (length args)   2)))
 
 (defclass Rebundant-Node () nil
   (:documentation "

--- a/source/base-impl/fundamental.lisp
+++ b/source/base-impl/fundamental.lisp
@@ -756,6 +756,7 @@ CL-WAFFE2-REPL> (proceed-bench (!sum (randn `(3 3))))
 ;; ===============================================================
 
 (defnode (Flexible-Rank-Node (myself At)
+	  :extends (Load-Myself-Node)
 	  :where (A[~] -> A[~])
 	  :slots ((at :initarg :at :reader flex-at))
 	  :backward ((self dout dx)

--- a/source/base-impl/matrix-ops.lisp
+++ b/source/base-impl/matrix-ops.lisp
@@ -32,6 +32,7 @@ C\\gets{gemm(1.0, A, B, 0.0, C)}
 "))
 
 (defnode (LazyTransposeNode (self)
+	  :extends (load-myself-node)
 	  :where (A[~ i j] -> A[~ i j])
 	  :slots ((raw-tensor :accessor raw-tensor))
 	  :documentation "LazyTransposeNode is a matmul-dedicated node to implement zero-cost transpose.

--- a/source/base-impl/package.lisp
+++ b/source/base-impl/package.lisp
@@ -24,7 +24,9 @@
   ;; Attributes
   (:export
    #:Loadp-Node
-   #:Rebundant-Node)
+   #:ensure-loadp
+   #:Rebundant-Node
+   #:Load-MySelf-Node)
   
   (:export
    #:AddNode

--- a/source/base-impl/package.lisp
+++ b/source/base-impl/package.lisp
@@ -24,6 +24,7 @@
   ;; Attributes
   (:export
    #:Loadp-Node
+   #:Loadp-Node-Rev
    #:ensure-loadp
    #:Rebundant-Node
    #:Load-MySelf-Node)

--- a/source/base-impl/package.lisp
+++ b/source/base-impl/package.lisp
@@ -21,6 +21,11 @@
    #:mv-lazy-sv4bw
    #:movetensor-save-for-backward
    #:move-maybe-in-place)
+  ;; Attributes
+  (:export
+   #:Loadp-Node
+   #:Rebundant-Node)
+  
   (:export
    #:AddNode
    #:SubNode

--- a/source/vm/allocation.lisp
+++ b/source/vm/allocation.lisp
@@ -493,7 +493,8 @@ Reading from the last iseq, the function attributes T at each last reference"
 	  do (setf (wfop-op inst) #'(lambda (grad-place grad)
 				      (setf (tensor-vec grad-place) (tensor-vec grad))
 				      grad)
-		   (wfop-node inst) #'(lambda () "SETQ{INTERNAL}"))))
+		   (wfop-node inst) #'(lambda () "SETQ{INTERNAL}")
+		   (wfop-loadp inst) t)))
 
 
 

--- a/source/vm/compile.lisp
+++ b/source/vm/compile.lisp
@@ -227,6 +227,8 @@ Tips: `disassemble-waffe2-ir` to display compiled Instruction Sequence.
 		  (iseq-bw (or bw backward)))
 
 	      (when optimize-locality
+		(setq iseq-fw (simplify-iseq iseq-fw)
+		      iseq-bw (simplify-iseq iseq-bw))
 		(dolist (device-name *using-backend*)
 		  (multiple-value-setq (iseq-fw iseq-bw) (on-finalizing-compiling device-name iseq-fw iseq-bw))))
 

--- a/source/vm/control-flow.lisp
+++ b/source/vm/control-flow.lisp
@@ -7,6 +7,9 @@
 ;;    MapNode(Block1, Block2)
 
 ;; [TODO] inside of *block* error messaging
+#|
+Not tested yet but this feature should be implemented in the future release
+so ive decide to leave this code as it is.
 (defparameter *block* nil)
 (defun make-block (iseq)
   (let ((block-name (gensym "BLOCK")))
@@ -23,4 +26,4 @@
 	       (format out "    ~a~%" i)))
 	   (format out "}")))
      nil)))
-
+|#

--- a/source/vm/control-flow.lisp
+++ b/source/vm/control-flow.lisp
@@ -1,0 +1,26 @@
+
+(in-package :cl-waffe2/vm)
+
+;; Provides two IRs:
+;;  [Block]
+;;    IfNode(Block1, Block2)
+;;    MapNode(Block1, Block2)
+
+;; [TODO] inside of *block* error messaging
+(defparameter *block* nil)
+(defun make-block (iseq)
+  (let ((block-name (gensym "BLOCK")))
+    (make-wfop
+     #'(lambda ()
+	 (let ((*block* block-name))
+	   (accept-instructions iseq)))
+     (wfop-self (car (last iseq)))
+     #'(lambda ()
+	 (with-output-to-string (out)
+	   (format out "{~a~%" block-name)
+	   (with-indent-to iseq
+	     (dolist (i iseq)
+	       (format out "    ~a~%" i)))
+	   (format out "}")))
+     nil)))
+

--- a/source/vm/ir.lisp
+++ b/source/vm/ir.lisp
@@ -72,19 +72,20 @@ SV4BW (i.e: save-for-backward) is a temporary tensor to compute backwards and cl
   ;;  LOADP: A* = B*
   (when (wfop-loadp inst)
     (let ((opname "<WfInst[load_pointer{SYS}]"))
-      (format
-       stream
-       "~a~a : ~a* = ~a*>~a"
-       opname
-       (with-output-to-string (out)
-	 (dotimes (i (- *opname-indent-to* (length opname))) (princ " " out)))
-       (tensor-id (wfop-self inst))
-       (tensor-id (second (wfop-args inst)))
-       (if *no-newline*
-	   ""
-	   (format nil "~%"))))
-    
-    (return-from print-object))
+      (multiple-value-bind (from to) (read-loadp inst)
+	(format
+	 stream
+	 "~a~a : ~a* = ~a*>~a"
+	 opname
+	 (with-output-to-string (out)
+	   (dotimes (i (- *opname-indent-to* (length opname))) (princ " " out)))
+	 (tensor-id from)
+	 (tensor-id to)
+	 (if *no-newline*
+	     ""
+	     (format nil "~%"))))
+      
+      (return-from print-object)))
   
   (let ((ignored-p (and (movetensor-p (wfop-node inst))
 			(movetensor-ignore-me (wfop-node inst)))))

--- a/source/vm/ir.lisp
+++ b/source/vm/ir.lisp
@@ -10,7 +10,7 @@
 
 (defstruct (WfInstruction
 	    (:conc-name wfop-)
-	    (:constructor make-wfop (op self node args &key (sv4bw nil) (out-to nil) (block-iseq nil) (grad-adder-p nil))))
+	    (:constructor make-wfop (op self node args &key (sv4bw nil) (out-to nil) (block-iseq nil) (grad-adder-p nil) (loadp nil))))
   "
 ## [struct] WfInstruction
 
@@ -59,13 +59,33 @@ SV4BW (i.e: save-for-backward) is a temporary tensor to compute backwards and cl
   (sv4bw sv4bw :type list)
   (error-check-p nil :type boolean) ;; Indicates the first shape-inspection has done?
   (bw-is-leaf-p nil :type boolean)
-  (grad-adder-p grad-adder-p :type boolean))
+  (grad-adder-p grad-adder-p :type boolean)
+  (loadp loadp :type boolean))
 
 (defparameter *omit-args-n* 5)
 (defparameter *opname-indent-to* 0 "Adds a space for this param times")
 (defparameter *no-newline* nil)
 
 (defmethod print-object ((inst WFInstruction) stream)
+
+  ;; loadp has a special form when displayed:
+  ;;  LOADP: A* = B*
+  (when (wfop-loadp inst)
+    (let ((opname "<WfInst[load_pointer{SYS}]"))
+      (format
+       stream
+       "~a~a : ~a* = ~a*>~a"
+       opname
+       (with-output-to-string (out)
+	 (dotimes (i (- *opname-indent-to* (length opname))) (princ " " out)))
+       (tensor-id (wfop-self inst))
+       (tensor-id (second (wfop-args inst)))
+       (if *no-newline*
+	   ""
+	   (format nil "~%"))))
+    
+    (return-from print-object))
+  
   (let ((ignored-p (and (movetensor-p (wfop-node inst))
 			(movetensor-ignore-me (wfop-node inst)))))
     (format stream

--- a/source/vm/nodes/utils.lisp
+++ b/source/vm/nodes/utils.lisp
@@ -207,6 +207,7 @@ Return:
 ;; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 (defnode (System-Lazy-Cons (self a b)
+	  :extends (cl-waffe2/base-impl:Rebundant-Node)
 	  :where (A[a-size] B[b-size] -> A[a-size] B[a-size] where a-size = (shape a) b-size = (shape b)))
   (setf (ignore-shape-error self) t))
 

--- a/source/vm/nodes/utils.lisp
+++ b/source/vm/nodes/utils.lisp
@@ -227,6 +227,7 @@ Return:
 (defmacro define-and-impl-node ((abstract-name
 				 (self &rest constructor-arguments)
 				 &key
+				   (extends nil)
 				   (device t)
 				   (cache-when-compiled t)
 				   (reject-p nil)
@@ -243,6 +244,7 @@ Return:
 (define-and-impl-node (abstract-name
 				 (self &rest constructor-arguments)
 				 &key
+                                   (extends nil)
 				   (device t)
 				   (cache-when-compiled t)
 				   (reject-p nil)
@@ -259,6 +261,7 @@ Expands `defnode` and `define-impl` at the same time.
 "
   `(eval-when (:compile-toplevel :load-toplevel :execute)
      (defnode (,abstract-name (,self ,@constructor-arguments)
+	       :extends ,extends
 	       :where ,where
 	       :out-scalar-p ,out-scalar-p
 	       :slots ,slots

--- a/source/vm/optimize-ir.lisp
+++ b/source/vm/optimize-ir.lisp
@@ -17,6 +17,17 @@ from-tensor* = to-tensor*
    :out-to `(,from-tensor)
    :loadp t))
 
+(defun read-loadp (instruction)
+  "Return: (values A B) where A* = B* if loadp=t, otherwise returns nil"
+  (when (wfop-loadp instruction)
+    (if (typep (wfop-node instruction) 'cl-waffe2/base-impl:Loadp-Node-Rev)
+	(values
+	 (wfop-self instruction)
+	 (first  (wfop-args instruction)))
+	(values
+	 (wfop-self instruction)
+	 (second (wfop-args instruction))))))
+
 ;; Reshape/LazyTranspose Moving/Replacing
 ;; Permute/View loadp mutation
 (defun simplify-iseq (iseq)
@@ -40,6 +51,17 @@ from-tensor* = to-tensor*
 	      (class-name (class-of (wfop-node inst)))
 	      (wfop-self inst)
 	      (car (wfop-args inst))))
+	    (cl-waffe2/base-impl:loadp-node
+	     (assert
+	      (cl-waffe2/base-impl:ensure-loadp (wfop-node inst) (wfop-args inst) (wfop-out-to inst))
+	      ()
+	      "simplify-iseq: Can't simplify this node: ~a
+because the transformation wasn't described in A <= A, B forms." inst)
+	     (setf (wfop-loadp inst) t)
+	     inst)
+	    (cl-waffe2/base-impl:loadp-node-rev
+	     (setf (wfop-loadp inst) t)
+	     inst)
 	    (T
 	     inst))))
 

--- a/source/vm/optimize-ir.lisp
+++ b/source/vm/optimize-ir.lisp
@@ -3,25 +3,44 @@
 
 (defun make-loadp (node-name from-tensor to-tensor)
   "Reshape/Permute/View etc ... -> Loadp(pointer)
-to-tensor* = from-tensor*
-
+from-tensor* = to-tensor*
 [op=Loadp]"
 
   (make-wfop
    #'(lambda (from to)
        (setf (tensor-vec from) (tensor-vec to))
        from)
-   to-tensor
+   from-tensor
    #'(lambda ()
        (format nil "Loadp(from: ~a)" node-name))
    `(,from-tensor ,to-tensor)
-   :out-to `(,to-tensor)
+   :out-to `(,from-tensor)
    :loadp t))
 
-;;(print (make-loadp 'aaa (make-tensor 1) (make-tensor 1)))
-
-(defun reduce-ir-diversity (iseq)
-  ""
+;; Reshape/LazyTranspose Moving/Replacing
+;; Permute/View loadp mutation
+(defun simplify-iseq (iseq)
+  "Returns a list of instructions applied these operations:
+- Moving ReshapeTensor to the top of instructions, places Loadp where it was
+- Deletes an instruction which is a subclass of Rebundant-Node class.
+- Sets loadp=t if the node is a subclass of Loadp-Node"
   ;; Subtype of LoadpInstruction class, SystemIR class (lazy-cons)
   ;; Reshape ... 一番上に持ってくる + Replace with make-loadp
-  )
+  ;; Rebundant-Node
+  ;; Reshapeじゃなくて...Loadp-But-KeepMe-Node
+  ;; Replace-Loadp-Node
+
+  (loop for inst in iseq
+	if (and
+	    (not (typep (wfop-node inst) 'cl-waffe2/base-impl:Rebundant-Node)))
+	  collect
+	  (typecase (wfop-node inst)
+	    (cl-waffe2/base-impl:load-myself-node
+	     (make-loadp
+	      (class-name (class-of (wfop-node inst)))
+	      (wfop-self inst)
+	      (car (wfop-args inst))))
+	    (T
+	     inst))))
+
+

--- a/source/vm/optimize-ir.lisp
+++ b/source/vm/optimize-ir.lisp
@@ -1,3 +1,27 @@
 
 (in-package :cl-waffe2/vm)
 
+(defun make-loadp (node-name from-tensor to-tensor)
+  "Reshape/Permute/View etc ... -> Loadp(pointer)
+to-tensor* = from-tensor*
+
+[op=Loadp]"
+
+  (make-wfop
+   #'(lambda (from to)
+       (setf (tensor-vec from) (tensor-vec to))
+       from)
+   to-tensor
+   #'(lambda ()
+       (format nil "Loadp(from: ~a)" node-name))
+   `(,from-tensor ,to-tensor)
+   :out-to `(,to-tensor)
+   :loadp t))
+
+;;(print (make-loadp 'aaa (make-tensor 1) (make-tensor 1)))
+
+(defun reduce-ir-diversity (iseq)
+  ""
+  ;; Subtype of LoadpInstruction class, SystemIR class (lazy-cons)
+  ;; Reshape ... 一番上に持ってくる + Replace with make-loadp
+  )

--- a/source/vm/optimize-ir.lisp
+++ b/source/vm/optimize-ir.lisp
@@ -35,11 +35,6 @@ from-tensor* = to-tensor*
 - Moving ReshapeTensor to the top of instructions, places Loadp where it was
 - Deletes an instruction which is a subclass of Rebundant-Node class.
 - Sets loadp=t if the node is a subclass of Loadp-Node"
-  ;; Subtype of LoadpInstruction class, SystemIR class (lazy-cons)
-  ;; Reshape ... 一番上に持ってくる + Replace with make-loadp
-  ;; Rebundant-Node
-  ;; Reshapeじゃなくて...Loadp-But-KeepMe-Node
-  ;; Replace-Loadp-Node
 
   (loop for inst in iseq
 	if (and

--- a/source/vm/package.lisp
+++ b/source/vm/package.lisp
@@ -38,7 +38,8 @@
    #:wfop-node
    #:wfop-sv4bw
    #:wfop-args
-   #:wfop-loadp))
+   #:wfop-loadp
+   #:read-loadp))
 
 (in-package :cl-waffe2/vm)
 

--- a/source/vm/package.lisp
+++ b/source/vm/package.lisp
@@ -37,7 +37,8 @@
    #:wfop-out-to
    #:wfop-node
    #:wfop-sv4bw
-   #:wfop-args))
+   #:wfop-args
+   #:wfop-loadp))
 
 (in-package :cl-waffe2/vm)
 


### PR DESCRIPTION
# Changes

Added a new IR:
- Load-Pointer: System instructions (e.g.: Reshape Permute) are now represented as just moving pointers, so that JIT Compilers can fuse more instructions:

![image](https://github.com/hikettei/cl-waffe2/assets/88639579/e764a676-d9a6-4fb0-a498-cfbdab954214)

- In addition, LazyTranspose/LazyCons is deleted after compiled.
- base-impl/attributes.lisp pays an important role how AbstractNodes are optimized by cl-waffe2.