### PR TITLE
fix some typos in comments/code for improving clarity and consistency

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,11 +26,11 @@
 > 
 > I actually have a repository [cl-waffe(DEPRECATED UNSUPPORTED!)](https://github.com/hikettei/cl-waffe) with a similar name. Note that cl-waffe**2** is the latest one and all features are inherited from the old one.
 
-cl-waffe2 provides fast, systematic, easy to optimize, customizable, device independent abstract matrix operations, and reverse mode tape-based Automatic Differentiation on Common Lisp. Plus, we also provide features for building and training neural network models, accelerated by JIT Compiler.
+cl-waffe2 provides fast, systematic, easy to optimize, customizable, device independent abstract matrix operations, and reverse mode tape-based Automatic Differentiation on Common Lisp. Plus, we also provide features for building and training neural network models, accelerated by a JIT Compiler.
 
-Roughly speaking, this is a framework for the graph and tensor abstraction without overheads. All features provided here can be extended by users without exception. And with the minimal code. In fact, cl-waffe2 is designed as the truly easiest framework to write extensions by users. There's no barrier between users and developers. There's no restriction imposed by framework ignoring the developing language is limited to Common Lisp.
+Roughly speaking, this is a framework for the graph and tensor abstraction without overheads. All features provided here can be extended by users without exceptions - and with minimal code. In fact, cl-waffe2 is designed as the truly easiest framework to write extensions by users. There is no barrier between users and developers. There is no restriction imposed by the framework ignoring the developing language is limited to Common Lisp.
 
-As of this writing, its abstraction layers are almost reaching the goals and working enough, but there is still a serious lack of backend functionality, and documentations. Contributions are welcome and I would appreciate if somebody who is interested in by project contact me: [hikettei](https://github.com/hikettei).
+As of this writing, its abstraction layers are almost reaching the goals and working enough, but there is still a serious lack of backend functionality, and documentation. Contributions are welcome and I would appreciate if somebody who is interested in by project contact me: [hikettei](https://github.com/hikettei).
 
 ## ✨Features
 
@@ -39,9 +39,9 @@ As of this writing, its abstraction layers are almost reaching the goals and wor
 - **Inlining**  Anyone can write an optimized loop calling foreign libraries; an order is collapsed and shuffled depending on the ranks and offsets. 
 - **Graph-Level Optimization** cl-waffe2 provides a powerful abstract graph optimization tool that can be used on any devices. For example, it optimizes the locality of memory, and make operations in-place as much as possible.
 - **Visualize** Super easy to know the bottleneck in your network, because a `proceed-bench` function profiles every instruction.
-- **Debugging** cl-waffe2 is enough clever that not only detecting all Shaping-Error before the execution but also suggests alternatives! In addition, All objects in cl-waffe2 are nicely rendered on your REPL.
+- **Debugging** cl-waffe2 is enough clever by not only detecting all Shaping-Error before the execution but it also suggests alternatives! In addition, all objects in cl-waffe2 are nicely rendered on your REPL.
 - **Systematic Nodes** AbstractNodes and Models are based on small and elegant macros.
-- **Symbolic Differentiation** In the first place, cl-waffe2 do not create nodes that are later modified. Compiler macros eliminate functions producing such nodes.
+- **Symbolic Differentiation** In the first place, cl-waffe2 does not create nodes that are later modified. Compiler macros eliminate functions producing such nodes.
 
 ## 🍃 Quicklook
 

--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -4,7 +4,7 @@
 # Requirements
 
 ```lisp
-$ pip instlal mkdocs
+$ pip install mkdocs
 $ pip install markdown-katex
 ```
 

--- a/docs/apis/nodes.lisp
+++ b/docs/apis/nodes.lisp
@@ -157,14 +157,14 @@ Predicted Output(s) : ((3 2))
 Here's a list of reports.
 
 1. Couldn't idenfity ~~: ~~ is determined as 3 
- butgot: 2.
- Excepted ~~ = (3 2), butgot: (2 4)
+ but got: 2.
+ Expected ~~ = (3 2), but got: (2 4)
 
 Also, these reports could be helpful for you (calculated ignoring the first errors.)
 
 2. Couldn't idenfity ~~: ~~ is determined as 2 
- butgot: 4.
- Excepted ~~ = (3 2), butgot: (2 4)
+ but got: 4.
+ Expected ~~ = (3 2), but got: (2 4)
 ```
 
 ### Determine Rules

--- a/docs/cl-waffe2-docs/docs/examples.md
+++ b/docs/cl-waffe2-docs/docs/examples.md
@@ -99,10 +99,10 @@ Several smaller nodes can be composed to create a larger function. Likewise Arro
 ;; Usage
 
 ;; MSELoss
-(criterion #'MSE pred excepted :reductions '(#'!sum #'->scal))
+(criterion #'MSE pred expected :reductions '(#'!sum #'->scal))
 
 ;; SoftmaxCrossEntropyLoss
-(criterion #'softmax-cross-entropy pred excepted :reductions '(#'!sum #'->scal))
+(criterion #'softmax-cross-entropy pred expected :reductions '(#'!sum #'->scal))
 ```
 
 ## Compiling Models

--- a/docs/cl-waffe2-docs/docs/install.md
+++ b/docs/cl-waffe2-docs/docs/install.md
@@ -13,7 +13,7 @@ See the `Readme.md` and install Roswell
 
 ### 2. Installing Common Lisp
 
-Common Lisp has several implementations on ANSI Common Lisp. The development is ongoing under SBCL for its performance and the good support of arithmetic operations. Differences between different implementations are absorbed by CFFI I guess, so it should work with other processors, but it has not been tested. (Modern Mode probably doesn't work.)
+Common Lisp has several implementations of ANSI Common Lisp. The development is ongoing under SBCL due to its performance and the good support of arithmetic operations. Differences between different implementations are handled by CFFI (I guess), so it should work with other processors, but it has not been tested. (Modern Mode probably doesn't work.)
 
 If you've installed Roswell:
 
@@ -27,7 +27,7 @@ should work and everything is done.
 
 ### 3. Setting up IDE (optional)
 
-The following editors are recommended as we're working with REPL:
+The following editors are recommended as we are working with the REPL:
 
 - [Emacs](https://www.gnu.org/software/emacs/) + [Slime](https://slime.common-lisp.dev/)
 
@@ -36,9 +36,9 @@ The following editors are recommended as we're working with REPL:
 
 ## Installing cl-waffe2
 
-As of this writing(2023/9/13), cl-waffe2 is not yet available on Quicklisp. So I'm sorry but you have to install it manually.
+As of this writing(2023/9/13), cl-waffe2 is not yet available on Quicklisp. So, I am sorry but you have to install it manually.
 
-With roswell, the latest cl-wafe2 repository can be fetch like:
+With roswell, the latest cl-waffe2 repository can be fetched like:
 
 ```sh
 $ ros install hikettei/cl-waffe2
@@ -46,7 +46,7 @@ $ ros install hikettei/cl-waffe2
 
 In this case, you have to note that SBCL also needs to be started via Roswell.
 
-Another valid option would be loading `cl-waffe2.asd` file manually after cloning cl-waffe2 github repos:
+Another valid option would be loading the `cl-waffe2.asd` file manually after cloning the cl-waffe2 github repos:
 
 ```sh
 $ git clone https://github.com/hikettei/cl-waffe2.git
@@ -54,25 +54,25 @@ $ cd ./cl-waffe2
 $ ros run # start repl
 $ (load "cl-waffe2.asd")
 $ (ql:quickload :cl-waffe2)
-$ (in-pacakge :cl-waffe2-repl) # or make repl
+$ (in-package :cl-waffe2-repl) # or make repl
 ```
 
-After you ensured it should work, move the `./cl-waffe2` directory to `~/quicklisp/local-projects/` and quicklisp can find the project!
+After you have ensured that it works, move the `./cl-waffe2` directory to `~/quicklisp/local-projects/` and quicklisp can find the project!
 
-The get the full performance of cl-waffe2, you also have to do the following steps:
+In order to get the full performance of cl-waffe2, you also have to do the following steps:
 
-### Setting BLAS
+### Setting up BLAS
 
 cl-waffe2 searches for and reads the `libblas` file by default. The following steps are only necessary if you get a warning when loading the library
 
-First, install the libopenblas
+First, install the libopenblas library
 
 ```sh
-# with ubuntu for example
+# with ubuntu, for example:
 $ apt install libopenblas
 
 # With macOS
-$ brew instlal libopenblas
+$ brew install libopenblas
 ```
 
 Load the package again:
@@ -83,7 +83,7 @@ $ (load "cl-waffe2.asd")
 $ (ql:quickload :cl-waffe2)
 ```
 
-If you've got no warning after loading cl-waffe2, `CPUTensor` is successfully enabled and can recognize the OpenBLAS. If you still get warnings, you have to step an additional configs because cl-waffe2 couldn't find out the location.
+If you get no warning after loading cl-waffe2, `CPUTensor` is successfully enabled and can recognize the OpenBLAS. If you still get warnings, you need to apply additional configs because cl-waffe2 could not find out the location.
 
 So, In your init file, (e.g.: `~/.roswell/init.lisp` or `~/.sbclrc`), add the code below for example. (Change the path depending on your environment. You can find where you've installed the library with `$ locate libblas` for example of macOS).
 
@@ -103,9 +103,9 @@ SIMD Extension is an extension for speeding up the execution of mathematical fun
 $ make build_simd_extension
 ```
 
-and everything is ok. Ensure that no warnings are displayed in your terminal after loaded cl-waffe2.
+and everything should be ok. Ensure that no warnings are displayed in your terminal after loaded cl-waffe2.
 
 ### Is GPU(CUDA/Metal/OpenCL etc...) supported?
 
-Currently, No. But cl-waffe2 is designed to be independent of which devices work on, and writing extension is easy. Personally, I don't have enough environment and equipment to do the test, so I plan to do it one day when I save up the money.
+Currently, no. But cl-waffe2 is designed to be independent of which devices work on, and writing extension is easy. Personally, I do not have enough environment and equipment to do the test, so I plan to do it one day when I save up the money.
 

--- a/docs/cl-waffe2-docs/docs/nn.md
+++ b/docs/cl-waffe2-docs/docs/nn.md
@@ -227,7 +227,7 @@ BatchNorm(x) = \frac{x - E[x]}{\sqrt{Var[x] + ε}}\times{γ}+β
 
 ### Inputs
 
-`in-features[fixnum]` - C from an excepted input size (N C H W)
+`in-features[fixnum]` - C from an expected input size (N C H W)
 
 `affine[bool]` Set T to apply affine transofmration to the output. In default, set to t.
 

--- a/docs/cl-waffe2-docs/docs/nodes.md
+++ b/docs/cl-waffe2-docs/docs/nodes.md
@@ -149,14 +149,14 @@ Predicted Output(s) : ((3 2))
 Here's a list of reports.
 
 1. Couldn't idenfity ~: ~ is determined as 3 
- butgot: 2.
- Excepted ~ = (3 2), butgot: (2 4)
+ but got: 2.
+ Expected ~ = (3 2), but got: (2 4)
 
 Also, these reports could be helpful for you (calculated ignoring the first errors.)
 
 2. Couldn't idenfity ~: ~ is determined as 2 
- butgot: 4.
- Excepted ~ = (3 2), butgot: (2 4)
+ but got: 4.
+ Expected ~ = (3 2), but got: (2 4)
 ```
 
 ### Determine Rules

--- a/docs/cl-waffe2-docs/docs/overview.md
+++ b/docs/cl-waffe2-docs/docs/overview.md
@@ -189,7 +189,7 @@ There's two ways to declare `MyTensor` is a valid device that cl-waffe2 can use:
 
 ;; Gemm with OpenBLAS
 ;; Set bench=t, and measures time
-;; As excepted, this one is 20~30times faster.
+;; As expected, this one is 20~30times faster.
 (defun test-gemm-cpu (&key (bench nil))
   (with-devices (CPUTensor)
     (let ((a (randn `(100 100)))
@@ -596,7 +596,7 @@ See also: [Converting AbstractTensor and other arrays](https://hikettei.github.i
 
 (TODO)
 
-cl-waffe2 is enough clever to detect Shape-Error and suggest an alternative arising from wrong inputs. In this case, both ranks are invaild because broadcasing rank-up rule is not applied in cl-waffe2:
+cl-waffe2 is enough clever to detect Shape-Error and suggest an alternative arising from wrong inputs. In this case, both ranks are invalid because broadcasing rank-up rule is not applied in cl-waffe2:
 
 ```lisp
 (!add (randn `(3 3)) (randn `(3)))
@@ -605,7 +605,7 @@ cl-waffe2 is enough clever to detect Shape-Error and suggest an alternative aris
 If you do this, you will get the following error before **running the operation**
 
 ```lisp
-[Shaping Error]: The AbstractNode ADDNODE-CPUTENSOR was called with invaild arguments.
+[Shaping Error]: The AbstractNode ADDNODE-CPUTENSOR was called with invalid arguments.
 
  The constraint:
     ADDNODE-CPUTENSOR: (A[~] B[~] -> A[~])
@@ -621,7 +621,7 @@ B:
     ─ the 1th shape is (3) but it violates ~ = (3 3)
     ─ The given rank 2 do not match declared: (3)
 
-Excepted:
+Expected:
     (forward
         (ADDNODE-CPUTENSOR ...)
         A(3 3)
@@ -672,7 +672,7 @@ When doing (!sqrt x) where x is a negative number:
          (!sin (ax+b `(3 3) 0 1))))))
 ```
 
-As excepted it produces FLOATING-POINT-INVAILD-OPERATION:
+As expected it produces FLOATING-POINT-INVALID-OPERATION:
 
 ```lisp
 cl-waffe2 VM: Encountered Runtime Error at 3th instruction.

--- a/docs/cl-waffe2-docs/docs/utils.md
+++ b/docs/cl-waffe2-docs/docs/utils.md
@@ -159,7 +159,7 @@ Powerful macros in Common Lisp enabled me to provide an advanced APIs for make t
 (asnode function &rest arguments)
 ```
 
-Wraps the given `function` which excepted to create computation nodes with the `Encapsulated-Node` composite. That is, functions are regarded as a `Composite` and be able to use a variety of APIs (e.g.: `call`, `call->`, `defmodel-as` ...).
+Wraps the given `function` which is expected to create computation nodes with the `Encapsulated-Node` composite. That is, functions are regarded as a `Composite` and be able to use a variety of APIs (e.g.: `call`, `call->`, `defmodel-as` ...).
 
 In principle, a function takes one argument and returns one value, but by adding more `arguments` the macro automatically wraps the function to satisfy it. For example, `(asnode #'!add 1.0) is transformed into: #'(lambda (x) (!add x 1.0))`. So the first arguments should receive AbstractTensor.
 
@@ -300,7 +300,7 @@ A convenient macro to hook AbstractOptimizers to each AbstractTensor. As the mos
      (hook-optimizer! ,bind ,optimizer))
 ```
 
-where `bind` is excepted to be AbstractTensor, optimizer is a creation form of `AbstractOptimizer`, and the function `hook-optimizer!` hooks the given optimizer into bind.
+where `bind` is expected to be AbstractTensor, optimizer is a creation form of `AbstractOptimizer`, and the function `hook-optimizer!` hooks the given optimizer into bind.
 
 In cl-waffe2, one independent Optimizer must be initialised per parameter. This macro can be used to concisely describe the process of initialising the same Optimiser for many parameters.
 

--- a/examples/concepts.lisp
+++ b/examples/concepts.lisp
@@ -84,7 +84,7 @@
 
 ;; Gemm with OpenBLAS
 ;; Set bench=t, and measures time
-;; As excepted, this one is 20~30times faster.
+;; As expected, this one is 20~30times faster.
 (defun test-gemm-cpu (&key (bench nil))
   (with-devices (CPUTensor)
     (let ((a (randn `(100 100)))

--- a/examples/mlp_sin_wave.lisp
+++ b/examples/mlp_sin_wave.lisp
@@ -3,7 +3,7 @@
 
 ;;
 ;; This example provides the smallest package for training neural network in cl-waffe2
-;; Excepted to be something like Project Template.
+;; Expected to be something like a Project Template.
 ;;
 
 (defpackage :mlp-sin-wave
@@ -23,7 +23,7 @@
 
 ;; Steps:
 ;;  1. Create your neural network with AbstractNode
-;;  2. Compile the network with build funciton
+;;  2. Compile the network with the build funciton
 ;;  3. Hook optimizers to all the parameters
 ;;  4. forward/backward to step the computation
 ;;  5. call-optimizer! to minimize the loss

--- a/source/backends/JITCPUTensor/compiler.lisp
+++ b/source/backends/JITCPUTensor/compiler.lisp
@@ -111,7 +111,7 @@
 		  (c-name (format nil "~a" (aloop-size loop)))
 		  index-char))
 		(T
-		 ;; Excepted one of: :apply :apply-flatten
+		 ;; Expected one of: :apply :apply-flatten
 		 (when (and (= *indent-width* 4)
 			    *use-open-mp*)
 		   (write-c-line "#pragma omp parallel for ~%"))

--- a/source/backends/lisp/iterator.lisp
+++ b/source/backends/lisp/iterator.lisp
@@ -73,7 +73,7 @@ apply - Set to (apply function array). nil to (dotimes (...) ... )"
 				      ,(lazy-aref-form tensor indices)))))))
 	 (assert (= (length ,results) (the fixnum ,(lli-reduced-to instruction)))
 		 nil
-		 "lazy-reduction: Assertion was failed. the function is excepted to be returning ~a arguments but got ~a"
+		 "lazy-reduction: Assertion was failed. the function is expected to be returning ~a arguments but got ~a"
 		 ,(lli-reduced-to instruction)
 		 (length ,results))
 	 (dotimes (,index-symbol ,(lli-reduced-to instruction))

--- a/source/base-impl/fundamental.lisp
+++ b/source/base-impl/fundamental.lisp
@@ -310,7 +310,7 @@ When attempting: ~a -> ~a" base-shape reshape-to)
 			      (>= x 1))))
 		 reshape-to)
 	  ()
-	  "!reshape: invaild operation.
+	  "!reshape: invalid operation.
 (!reshape tensor ~a)
                   L shapes should be consisted of:
                        - LazyAxis

--- a/source/base-impl/matrix-ops.lisp
+++ b/source/base-impl/matrix-ops.lisp
@@ -126,7 +126,7 @@ If the last backward of given arguments are `LazyTransposeNode` (created with th
 
     (when (not (shape-equal jx jy))
       (shaping-error
-       "!matmul failed because the last two shapes of the two given matrices are invaild.
+       "!matmul failed because the last two shapes of the two given matrices are invalid.
 The operation is: A[~~ i j] B[~~ j k] C[~~ i k] -> C[~~ i k]
                         ^      ^
                      j doesn't match: ~a and ~a
@@ -141,7 +141,7 @@ Shapes: A = ~a, B = ~a"
 	     (let ((last-two-view (last (tensor-view tensor) 2))
 		   (last-two-permute (last (cl-waffe2/vm.generic-tensor::tensor-permute-order tensor) 2))
 
-		   (excepted-permute (last (reverse (loop for i upfrom 0 below (dims tensor) collect i)) 2)))
+		   (expected-permute (last (reverse (loop for i upfrom 0 below (dims tensor) collect i)) 2)))
 
 	       (cond
 		 ;; transposed? True when last backward is LazyTranspsoe
@@ -156,7 +156,7 @@ Shapes: A = ~a, B = ~a"
 		       (every
 			#'=
 			last-two-permute
-			excepted-permute))
+			expected-permute))
 		  ;; Memory-layout is OK. (because last two axes are not polluted)
 		  ;; (values tensor nil) <=>
 		  (values tensor transposed?))

--- a/source/base-impl/reduction.lisp
+++ b/source/base-impl/reduction.lisp
@@ -65,7 +65,7 @@ Return:
 
       (assert (equal (shape out) shape)
 	      nil
-	      "!sum: Assertion Failed because the given out's shape is ~a, but excepted: ~a" (shape out) shape)
+	      "!sum: Assertion Failed because the given out's shape is ~a, but expected: ~a" (shape out) shape)
 
       ;; Main Parts
       (multiple-value-bind (out* reverser) (apply #'!view out view-args)

--- a/source/base-impl/t/package.lisp
+++ b/source/base-impl/t/package.lisp
@@ -46,8 +46,8 @@
 					(if (eql result t)
 					    t
 					    (if (eql result :backward)
-						(error "the result of backward is invaild")
-						(error "the result of forward is invaild")))))))))
+						(error "the result of backward is invalid")
+						(error "the result of forward is invalid")))))))))
 		 ',(case op-type
 		     (:sparse *sparse-types*)
 		     (:dense  *dense-types*)

--- a/source/network.lisp
+++ b/source/network.lisp
@@ -8,7 +8,7 @@
 (defmodel (Encapsulated-Node (self node-func)
 	   :slots ((node-func :initarg :node-func))
 	   :initargs (:node-func node-func)
-	   :documentation "(asnode ) dedicated Composite. Wraps the given node-func (excepted to construct networks) with no `:where` dependency"))
+	   :documentation "(asnode ) dedicated Composite. Wraps the given node-func (expected to construct networks) with no `:where` dependency"))
 
 (defmodel (RepeatN-Node (self node-func)
 	   :slots ((node-func :initarg :node-func)
@@ -44,7 +44,7 @@
 (asnode function &rest arguments)
 ```
 
-Wraps the given `function` which excepted to create computation nodes with the `Encapsulated-Node` composite. That is, functions are regarded as a `Composite` and be able to use a variety of APIs (e.g.: `call`, `call->`, `defmodel-as` ...).
+Wraps the given `function` which is expected to create computation nodes with the `Encapsulated-Node` composite. That is, functions are regarded as a `Composite` and be able to use a variety of APIs (e.g.: `call`, `call->`, `defmodel-as` ...).
 
 In principle, a function takes one argument and returns one value, but by adding more `arguments` the macro automatically wraps the function to satisfy it. For example, `(asnode #'!add 1.0) is transformed into: #'(lambda (x) (!add x 1.0))`. So the first arguments should receive AbstractTensor.
 

--- a/source/nn/norms.lisp
+++ b/source/nn/norms.lisp
@@ -10,7 +10,7 @@ BatchNorm(x) = \\frac{x - E[x]}{\\sqrt{Var[x] + ε}}\\times{γ}+β
 
 ### Inputs
 
-`in-features[fixnum]` - C from an excepted input size (N C H W)
+`in-features[fixnum]` - C from an expected input size (N C H W)
 
 `affine[bool]` Set T to apply affine transofmration to the output. In default, set to t.
 

--- a/source/nn/t/regression.lisp
+++ b/source/nn/t/regression.lisp
@@ -168,7 +168,7 @@
   (is (linear-non-composite-test-single-layer))
   (is (linear-non-composite-test-single-layer-no-bw)))
 
-;; Known Issue: Second call of this got invaild.
+;; Known Issue: Second call of this got invalid.
 ;; 問題は、Compositeを用いてモデルを初期化した時に、二回目以降のコンパイルがおかしくなる
 
 ;; Cache関数が悪いか、メモリプールが悪いか

--- a/source/trainer.lisp
+++ b/source/trainer.lisp
@@ -16,7 +16,7 @@ A convenient macro to hook AbstractOptimizers to each AbstractTensor. As the mos
      (hook-optimizer! ,bind ,optimizer))
 ```
 
-where `bind` is excepted to be AbstractTensor, optimizer is a creation form of `AbstractOptimizer`, and the function `hook-optimizer!` hooks the given optimizer into bind.
+where `bind` is expected to be an AbstractTensor, optimizer is a creation form of `AbstractOptimizer`, and the function `hook-optimizer!` hooks the given optimizer into bind.
 
 In cl-waffe2, one independent Optimizer must be initialised per parameter. This macro can be used to concisely describe the process of initialising the same Optimiser for many parameters.
 

--- a/source/vm/compile.lisp
+++ b/source/vm/compile.lisp
@@ -179,7 +179,7 @@ Tips: `disassemble-waffe2-ir` to display compiled Instruction Sequence.
   (declare (type AbstractTensor toplevel))
   
   ;; fuse-p is intentionally disabled forcibly for a while
-  ;; because it cause unexcepted behaviours
+  ;; because it cause unexpected behaviours
   (let ((*compile-option* (cl-waffe2/vm.generic-tensor::compile-option-form compile-mode)))
     (multiple-value-bind (iseq-forward leaves)
 	(node-compile-into-vm toplevel :fuse-p fuse-p)

--- a/source/vm/generic-tensor/acceptor.lisp
+++ b/source/vm/generic-tensor/acceptor.lisp
@@ -304,7 +304,7 @@ Before calling the forward method, set any value to these InputTensors first.
     (when input-args
       (assert (= (the fixnum (length input-args)) (the fixnum (length inputs)))
 	  nil
-	  "forward: Can't invoke the forward step of given Compiled-Composite because the number of arguments received is invaild.
+	  "forward: Can't invoke the forward step of given Compiled-Composite because the number of arguments received is invalid.
     (forward compiled-model~a)
                             └── the model is compiled as~a."
 	  (with-output-to-string (out)
@@ -328,8 +328,8 @@ At:
 ~a
 
 (forward compiled-model~a)
-                        └── Excepted:~a
-                            Butgot:  ~a"
+                        └── Expected:~a
+                            But got:  ~a"
 				  model
 				  (with-output-to-string (out)
 				    (dolist (arg places) (format out " ~a" (tensor-name arg))))
@@ -345,8 +345,8 @@ At:
 ~a
 
 (forward compiled-model~a)
-                        └── Excepted:~a
-                            Butgot:  ~a"
+                        └── Expected:~a
+                            But got:  ~a"
 				  model
 				  (with-output-to-string (out)
 				    (dolist (arg places) (format out " ~a" (tensor-name arg))))
@@ -435,7 +435,7 @@ Compiles the given computation node starting from `toplevel`. The docstring of `
   (when inputs
     (assert (every #'keywordp inputs)
 	nil
-	"build: Can't compile the tensor because the :inputs is malformed or invaild.
+	"build: Can't compile the tensor because the :inputs list is malformed or invalid.
     (build toplevel :inputs ( ... ) ...)
                               └── :inputs receive a list of keyword indicating the name of tensors created by make-input
                                   Set like `(:A :B) "))

--- a/source/vm/generic-tensor/cache.lisp
+++ b/source/vm/generic-tensor/cache.lisp
@@ -86,7 +86,7 @@
       (compile
        nil
        ;; [TODO]
-       ;; Excepted body: (lambda args body)
+       ;; Expected body: (lambda args body)
        ;;                            ^ Insert Compile-Option
        (let ((body (compiled-kernel-body compiled-function)))
 	 `(,(car body)

--- a/source/vm/generic-tensor/do-compiled-loop.lisp
+++ b/source/vm/generic-tensor/do-compiled-loop.lisp
@@ -70,7 +70,7 @@ If remaining loops are consisted of T or :broacast (i.e.: contiguous on memory),
 			      (views
 			       (nthcdr rank (wtensor-view tensor))))
 	   (or
-	    ;; T :broadcast is invaild for example;
+	    ;; T :broadcast is invalid for example;
 	    ;; Possible cases are: T T T... or broadcast broadcast ...
 	    ;;(not
 	    ;; (every #'(lambda (v)

--- a/source/vm/lazy-subscript.lisp
+++ b/source/vm/lazy-subscript.lisp
@@ -348,7 +348,7 @@ LazyAxis: f(IN N) = floor((1+((IN+(2*N)+0+-1)/2)))
 	   (setf (lazyaxis-read-as lazy-expression) out)
 	   out)))))
 
-;; [TODO] Under this mode=T, changing adjustable shape is a invaild operation.
+;; [TODO] Under this mode=T, changing adjustable shape is a invalid operation.
 (defparameter *observe-mode* nil "
 ## [parameter] *observe-mode*
 
@@ -383,7 +383,7 @@ If this parameter is set to nil, maybe-observe-axis can return LazyAxis.")
 
 (defun maybe-observe-axis (value)
   "Reads the given value as a fixnum.
-value is excepted as: LazyAxis, Symbol, Fixnum, rest...
+value is expected as: LazyAxis, Symbol, Fixnum, rest...
 If value is dynamic-shape -> observe it and returns as a fixnum
 Otherwise                 -> Return as it is."
   (if (typep value 'LazyAxis)

--- a/source/vm/nodes/conditions.lisp
+++ b/source/vm/nodes/conditions.lisp
@@ -9,7 +9,7 @@
    (target-symbol :initarg :target)
    (subscripts :initarg :subscript)
    (msg :initarg :msg :initform ""))
-  (:documentation "The Condition subscripts-format-error occurs when cl-waffe couldn't interpret the given subscript because of invaild format.")
+  (:documentation "The Condition subscripts-format-error occurs when cl-waffe couldn't interpret the given subscript because of invalid format.")
   (:report
    (lambda (c s)
      (case (slot-value c 'because)

--- a/source/vm/nodes/model-compiler.lisp
+++ b/source/vm/nodes/model-compiler.lisp
@@ -152,8 +152,8 @@ Note that this function isn't subject to lazy-evaluation, and all arguments need
 	   (toplevel (apply #'call composite trace-tensors)))
       
       (unless (typep toplevel 'AbstractTensor)
-	(error "defmodel-as: Attempted to compile the function ~(~a~) but failed because the composite didn't return any AbstractTensor. butgot: ~a
-excepted: AbstractTensor"
+	(error "defmodel-as: Attempted to compile the function ~(~a~) but failed because the composite did not return any AbstractTensor. but got: ~a
+expected: AbstractTensor"
 	       (or named "lambda")
 	       toplevel))
 
@@ -302,7 +302,7 @@ And manages its allocation not to cause conflicts in the threads."))
 		:get-model t)
 	      ,@in-names))
 
-	   ;; The node is excepted to be invoked via this function
+	   ;; The node is expected to be invoked via this function
 	   ;; Declaim+Inline
 	   (defun ,named (,@in-names)
 	     ""
@@ -366,7 +366,7 @@ Depending on the `device` and `dtype` used of arguments, several methods are com
 "
 
   (when (not (typep asif 'model-asif-options))
-    (error "defmodel-as got unexcepted option for :asif.
+    (error "defmodel-as got unexpected option for :asif.
 
 (defmodel-as target-model :where ... :asif ~a ...)
                                            └── could be one of :function or :node
@@ -399,7 +399,7 @@ Choose :asif option from:
   (when (and
 	 (not (null named))
 	 (not (typep named 'symbol)))
-    (error "defmodel-as: the option :named is invaild.
+    (error "defmodel-as: the option :named is invalid.
 
 (defmodel-as target-model ... :named ~a)
                                      └── :named could be a symbol, and this macro defines a function after `named`.

--- a/source/vm/nodes/node.lisp
+++ b/source/vm/nodes/node.lisp
@@ -32,7 +32,7 @@
 
    ;; Utils
    (ignore-shape-error :initform nil :accessor ignore-shape-error)
-   (excepted-output-shape :initform nil :type list :accessor node-output-shape) ;; <- Debug Information
+   (expected-output-shape :initform nil :type list :accessor node-output-shape) ;; <- Debug Information
    (passed-at-least-once :initform nil :accessor node-passed-p :type boolean)   ;;
 
    ;; [TODO] (tpsort-id :initform (gensym)) ...
@@ -142,7 +142,7 @@ butgot: ~a"
     ;; Input-State -> Output-State
     (multiple-value-bind (out-state detected-errors) (funcall transition-function input-states) ;; ... Finishes in < 1e-6 sec
       ;;(setq out-state (delete-broadcast out-state))
-      ;; FixME: ~ = nil isn't allowed. [~ x] with (10) is unexceptedly invaild.
+      ;; FixME: ~ = nil isn't allowed. [~ x] with (10) is unexpectedly invalid.
 
       (when detected-errors
 	;; If any errors occured, try again with removing ~ from subscripts. (I know this behaviour is ugly.)
@@ -158,7 +158,7 @@ butgot: ~a"
 
 	  (if (and detected-errors-1
 		   (not (ignore-shape-error node)))
-	      ;; There's no flexible tensor, then it is invaild.
+	      ;; There's no flexible tensor, then it is invalid.
 	      ;; If there's any flexible tensor, uprank it and try again.
 
 	      ;; The node is declared as uprankable
@@ -177,7 +177,7 @@ butgot: ~a"
 		    ;; inputs-top -> inputs-new nodes are continuous.
 		    ;; because inputs-new are made from inputs-top
 		    (return-from forward (apply #'forward node inputs-new)))
-		  ;; Otherwise the operation was invaild.
+		  ;; Otherwise the operation was invalid.
 		  (describe-problems node detected-errors inputs out-state))
 	      (setq out-state out-state1))))
 
@@ -218,7 +218,7 @@ butgot: ~a"
 			       ;; Exntend Permuted Stride Orders
 
 			       (when extend-from
-				 ;; FixME: A[i j] -> A[j i] is invaild beucase before and after the operation, indicates the same pointer but shapes arenot the same.
+				 ;; FixME: A[i j] -> A[j i] is invalid because before and after the operation, indicates the same pointer but shapes arenot the same.
 				 ;; Detect Errors
 				 (let ((input (nth extend-from inputs)))
 				   ;; Extend View Forms

--- a/source/vm/nodes/shape-error.lisp
+++ b/source/vm/nodes/shape-error.lisp
@@ -40,7 +40,7 @@
   "
 ShapeError Template:
 
-Shaping-Error: Can't forward/call the Node/Composite because shapings are invaild.
+Shaping-Error: Can't forward/call the Node/Composite because shapings are invalid.
 
 At: [A] [B]
      ----
@@ -52,7 +52,7 @@ Received: (call (MODEL ...) A(a) B(a) C(10))
                                    L(2) |
                                        (3)
 
-Excepted: (call (MODEL ...) A(10 10) B(10 10))
+Expected: (call (MODEL ...) A(10 10) B(10 10))
 
 <<Call Form Attempted>>
 
@@ -72,12 +72,12 @@ Suggestion"
 
   (with-output-to-string (out)
     (if (eql forward-or-call :call)
-	(format out "The Composite ~a was called with invaild arguments." model-name)
+	(format out "The Composite ~a was called with invalid arguments." model-name)
 	(case (checkpoint-state *shape-error-when*)
 	  (:forward
-	   (format out " The AbstractNode ~a was called with invaild arguments." model-name))
+	   (format out " The AbstractNode ~a was called with invalid arguments." model-name))
 	  (:backward
-	   (format out " The AbstractNode ~a inside backward definition was called with invaild arguments.
+	   (format out " The AbstractNode ~a inside backward definition was called with invalid arguments.
 
     (define-impl (~a (self ...)
         ...
@@ -107,7 +107,7 @@ Received:
         (~a ...)~a)
               └── Received Too ~a Arguments.
   
-Excepted:
+Expected:
     (~a (~a ...)~a)
 "
 		    caller-name model-name
@@ -139,7 +139,7 @@ Received:
         (~a ...)~a
         )
 ~a
-Excepted:
+Expected:
     (~a
         (~a ...)~a
         )

--- a/source/vm/nodes/shape.lisp
+++ b/source/vm/nodes/shape.lisp
@@ -126,19 +126,19 @@ At  : ~ath symbol, ~a"
 
   (let ((pointer 0)
 	(var-name-tmp nil)
-	(excepted-mode :variable-name)) ;; :symbol := :init-form
+	(expected-mode :variable-name)) ;; :symbol := :init-form
     (dolist (exp exps)
       (cond
-	((and (symbol-eq excepted-mode :variable-name)
+	((and (symbol-eq expected-mode :variable-name)
 	      (and (symbolp exp) ;; i.e.: exp is variable name
 		   (not (symbol-eq exp '=))))
 	 (setq var-name-tmp exp)
-	 (setq excepted-mode :=))
-	((and (symbol-eq excepted-mode :=)
+	 (setq expected-mode :=))
+	((and (symbol-eq expected-mode :=)
 	      (symbol-eq exp '=))
-	 (setq excepted-mode :init-form))
-	((symbol-eq excepted-mode :init-form)
-	 (setq excepted-mode :variable-name)
+	 (setq expected-mode :init-form))
+	((symbol-eq expected-mode :init-form)
+	 (setq expected-mode :variable-name)
 	 (push (list var-name-tmp exp) results))
 	(T
 	 (error 'subscripts-content-error
@@ -148,7 +148,7 @@ But got: ~a.
 
 Subscript: ~a
 At       : ~ath Token, ~a"
-			     excepted-mode
+			     expected-mode
 			     exp
 			     exps
 			     pointer
@@ -230,7 +230,7 @@ Return:
 
 	  (unless (symbol-eq (car output-part) '->)
 	    (error 'subscripts-format-error
-		   :because :invaild-template-order
+		   :because :invalid-template-order
 		   :target '->
 		   :subscript subscripts
 		   :msg "Please follow this template:
@@ -241,7 +241,7 @@ Return:
 	  (when (and (not (null let-part))
 		     (not (symbol-eq (car let-part) 'where)))
 	    (error 'subscripts-format-error
-		   :because :invaild-template-order
+		   :because :invalid-template-order
 		   :target 'where
 		   :subscript subscripts
 		   :msg "Please follow this template:
@@ -363,12 +363,12 @@ Return: (values names subscripts where)
 (defun get-common-symbols (symbols)
   (remove-duplicates (flatten symbols) :test #'symbol-eq))
 
-(defun build-subscript-note (nth-pos position called-as excepted butgot states)
+(defun build-subscript-note (nth-pos position called-as expected butgot states)
   (make-shape-error-message
    :position position
-   :in-short   (format nil "~a should be ~a but got ~a." called-as excepted butgot)
-   :content    (format nil "the ~ath shape is ~a. ~a should be ~a but got ~a." nth-pos states called-as excepted butgot)
-   :suggestion (format nil "In ~a, set ~a=~a." states called-as excepted)))
+   :in-short   (format nil "~a should be ~a but got ~a." called-as expected butgot)
+   :content    (format nil "the ~ath shape is ~a. ~a should be ~a but got ~a." nth-pos states called-as expected butgot)
+   :suggestion (format nil "In ~a, set ~a=~a." states called-as expected)))
 
 
 (defun find-symbols (list)
@@ -482,7 +482,7 @@ Example:
 
     (let* ((least-required-dims (loop for s in first-state
 				      collect (length (the list (remove '~ s :test #'symbol-eq)))))
-	   ;; (1 2 3) for [x y] is invaild on the other hand (1 2 3) for [~ x y] is ok.
+	   ;; (1 2 3) for [x y] is invalid on the other hand (1 2 3) for [~ x y] is ok.
 	   (max-required-dims (loop for s in first-state
 				    if (find '~ (the list s) :test #'symbol-eq)
 				      collect -1

--- a/source/vm/nodes/t/parser.lisp
+++ b/source/vm/nodes/t/parser.lisp
@@ -8,16 +8,16 @@
 ;; Support Scalar e.g.: Int, [x y] -> ...
 
 (defun test-bnf (subscript
-		 excepted1
-		 excepted2
-		 excepted3)
+		 expected1
+		 expected2
+		 expected3)
   (multiple-value-bind
 	(is bs x y z)
       (cl-waffe2/vm.nodes::parse-subscript subscript)
     (declare (ignore is bs))
-    (and (equal x excepted1)
-	 (equal y excepted2)
-	 (equal z excepted3))))
+    (and (equal x expected1)
+	 (equal y expected2)
+	 (equal z expected3))))
 
 (test bnf-parse-test
   (is (test-bnf `([x y] -> [z])

--- a/source/vm/nodes/utils.lisp
+++ b/source/vm/nodes/utils.lisp
@@ -92,7 +92,7 @@ This means: the first argument of :forward was the dtype of :float or :double, u
        (let ((dtype (nth ,nth inputs)))
 	 (not (find dtype ',dtypes)))))
 
-(defun invaild-t-usage-p (node inputs)
+(defun invalid-t-usage-p (node inputs)
   (and (some #'cl-waffe2/base-impl::transposed-p inputs)
        (not (subtypep (class-of node) 'cl-waffe2/base-impl:MatmulNode))))
 

--- a/source/vm/vm.lisp
+++ b/source/vm/vm.lisp
@@ -133,8 +133,8 @@ Instruction: ~a
     (when (or (null outs)
 	      (not (every #'(lambda (x) (typep x 'AbstractTensor)) outs)))
       (error "cl-waffe2 VM: Runtime Error.
-The instruction ~a returned an invaild typed result.
-All outputs must be AbstractTensor, but returned: ~a"
+The instruction ~a returned an invalid typed result.
+All outputs must be an AbstractTensor, but it returned: ~a"
 	     instruction
 	     outs))
     
@@ -150,7 +150,7 @@ All outputs must be AbstractTensor, but returned: ~a"
 		 (not (= (length outs) (length (wfop-out-to instruction)))))
 	(warn "cl-waffe2 VM: Runtime Warning
 The instruction: ~a
-should be return ~R arguments, but got ~R.
+should return ~R arguments, but provided ~R.
 
 out-to returned:
 
@@ -160,20 +160,20 @@ out-to returned:
 	      (length (wfop-out-to instruction))
 	      outs))
       
-      (mapc #'(lambda (excepted received)
-		(when (not (eql (the boolean (scalar-p excepted)) (scalar-p received)))
+      (mapc #'(lambda (expected received)
+		(when (not (eql (the boolean (scalar-p expected)) (scalar-p received)))
 		  (warn "cl-waffe2 VM: Runtime Warning
 The instruction: ~a
 ~a
-Excepted:
+Expected:
 ~a
-Butgot:
+But got:
 ~a"
 			instruction
 			(if (scalar-p received)
-			    "returned a ScalarTensor but Matrix is excepted:"
-			    "returned a Matrix but ScalarTensor is excepted:")
-			excepted
+			    "returned a ScalarTensor but Matrix is expected:"
+			    "returned a Matrix but ScalarTensor is expected:")
+			expected
 			received))
 
 		;; Under *opt-level* = 1, we do runtime shape inspection
@@ -185,20 +185,20 @@ Butgot:
 		(when (if (= *opt-level* 1)
 			  (not ;; Shape-Equal is slow op
 			   (cl-waffe2/vm.generic-tensor::shape-equal
-			    (shape excepted) (shape received)))
+			    (shape expected) (shape received)))
 			  (not
-			   (or (some #'symbolp (shape excepted))
+			   (or (some #'symbolp (shape expected))
 			       (some #'symbolp (shape received))
-			       (equal (shape excepted) (shape received)))))
+			       (equal (shape expected) (shape received)))))
 		  (warn "cl-waffe2 VM: Runtime Warning
 The instruction: ~a
 Shapes are incompatible.
-Excepted:
+Expected:
 ~a
-Butgot:
+But got:
 ~a"
 			instruction
-			excepted
+			expected
 			received)))
 	    (wfop-out-to instruction) outs))
     


### PR DESCRIPTION
This commit provides some minor edits in the cl-waffe2 code and docs. It should help to enhance the clarity and consistency throughout the code base as well as the documentation.