### PR TITLE
Enhancements on JITCPUBackend

### DIFF
--- a/source/backends/JITCPUTensor/blueprint.lisp
+++ b/source/backends/JITCPUTensor/blueprint.lisp
@@ -25,6 +25,8 @@ type:
   (displace-to displace-to :type AbstractTensor)
   (args function-arguments :type list))
 
+(defgeneric load-instructions (node &rest inputs))
+
 (defun collect-variables (instructions)
   (let ((result))
     (dolist (inst instructions)

--- a/source/backends/JITCPUTensor/blueprint.lisp
+++ b/source/backends/JITCPUTensor/blueprint.lisp
@@ -77,7 +77,12 @@ type:
   (declare (type AbstractTensor tensor))
   (let ((strides (map 'list #'(lambda (axis) (cStride tensor axis)) (range 0 (dims tensor)))))
     (flet ((index-of (rank index stride)
-	     (list (format nil "(~a+~a)*~a" (cOffset tensor rank) index stride)
+	     (list (format nil "(~a+~a)*~a"
+			   (if (= 0 (cl-waffe2/vm.generic-tensor::compute-visible-start-idx
+				     (force-list (nth rank (tensor-view tensor)))))
+			       "0"
+			       (cOffset tensor rank))
+			   index stride)
 		   "+")))
       (format nil "~a[~a]"
 	      (tensor-id tensor)
@@ -102,7 +107,7 @@ void function-name (int size, float * restrict x1, int stride, int offset, float
 		  ;; TENSOR_PTR OFFSET3 OFFSET2 OFFSET1
 		  do (cVar arg :restrict (= 1 (count (tensor-id arg) arguments :key #'tensor-id)) :comma t)
 		     (dotimes (rank (dims arg))
-		       (write-buff "uint32_t ~a~a"
+		       (write-buff "const uint32_t ~a~a"
 				   (cOffset arg rank)
 				   ;; Judge if the last or not
 				   (if (and (= rank (1- (dims arg)))

--- a/source/backends/JITCPUTensor/blueprint.lisp
+++ b/source/backends/JITCPUTensor/blueprint.lisp
@@ -92,7 +92,7 @@ type:
 		       (map 'list #'index-of
 			    (range 0 (dims tensor)) indices strides))))))))
 
-(defun cAref-with-ranks (tensor indices ranks)
+(defun cAref-with-ranks (tensor indices ranks &key (name nil))
   "Reading a id of the given tensor, places a form reading an arbitary position of elements."
   (declare (type AbstractTensor tensor))
   (let ((strides (map 'list #'(lambda (axis) (cStride tensor axis)) ranks)))
@@ -105,7 +105,7 @@ type:
 			   index stride)
 		   "+")))
       (format nil "~a[~a]"
-	      (tensor-id tensor)
+	      (or name (tensor-id tensor))
 	      (apply #'concatenate 'string
 		     (butlast
 		      (flatten

--- a/source/backends/JITCPUTensor/blueprint.lisp
+++ b/source/backends/JITCPUTensor/blueprint.lisp
@@ -93,13 +93,16 @@ type:
 		      char
 		      (format nil "~a*~a" char stride)))
 		"+"))))
-      (format nil "~a[~a]"
-	      (tensor-id tensor)
-	      (apply #'concatenate 'string
-		     (butlast
-		      (flatten
-		       (map 'list #'index-of
-			    (range 0 (dims tensor)) indices strides))))))))
+      (let ((index (apply #'concatenate 'string
+			  (butlast
+			   (flatten
+			    (map 'list #'index-of
+				 (range 0 (dims tensor)) indices strides))))))
+	(format nil "~a[~a]"
+		(tensor-id tensor)
+		(if (string= "" index)
+		    "0"
+		    index))))))
 
 (defun cAref-with-ranks (tensor indices ranks &key (name nil))
   "Reading a id of the given tensor, places a form reading an arbitary position of elements."
@@ -122,12 +125,15 @@ type:
 		      char
 		      (format nil "~a*~a" char stride)))
 		"+"))))
-      (format nil "~a[~a]"
-	      (or name (tensor-id tensor))
-	      (apply #'concatenate 'string
-		     (butlast
-		      (flatten
-		       (map 'list #'index-of ranks indices strides))))))))
+      (let ((index (apply #'concatenate 'string
+			  (butlast
+			   (flatten
+			    (map 'list #'index-of ranks indices strides))))))
+	(format nil "~a[~a]"
+		(or name (tensor-id tensor))
+		(if (string= index "")
+		    "0"
+		    index))))))
 
 
 (defun solve-depends-on (tensor)

--- a/source/backends/JITCPUTensor/blueprint.lisp
+++ b/source/backends/JITCPUTensor/blueprint.lisp
@@ -38,9 +38,9 @@ type:
 (defun cPointer (tensor)
   (symb (tensor-id tensor) '-ptr))
 
-(defun cVar (tensor &key (restrict nil) (comma nil))
+(defun cVar (tensor &key (restrict nil) (comma nil) (const nil))
   (declare (type AbstractTensor tensor))
-  (cType tensor :restrict restrict)
+  (cType tensor :restrict restrict :const const)
   (write-buff "~a~a"
 	      (tensor-id tensor)
 	      (if comma ", " "")))
@@ -77,13 +77,22 @@ type:
   (declare (type AbstractTensor tensor))
   (let ((strides (map 'list #'(lambda (axis) (cStride tensor axis)) (range 0 (dims tensor)))))
     (flet ((index-of (rank index stride)
-	     (list (format nil "(~a~a)*~a"
-			   (if (= 0 (cl-waffe2/vm.generic-tensor::compute-visible-start-idx
-				     (force-list (nth rank (tensor-view tensor)))))
-			       ""
-			       (format nil "~a+" (cOffset tensor rank)))
-			   index stride)
-		   "+")))
+	     (when (not (member index *solved-as-zero* :test #'string=))
+	       (list
+		(let ((char
+			(format nil "(~a~a)"
+				(if (= 0 (cl-waffe2/vm.generic-tensor::compute-visible-start-idx
+					  (force-list (nth rank (tensor-view tensor)))))
+				    ""
+			            (format nil "~a+"
+					    (cl-waffe2/vm.generic-tensor::compute-visible-start-idx
+					     (force-list (nth rank (tensor-view tensor))))))
+				index)))
+		  (if (and (numberp stride)
+			   (= stride 1))
+		      char
+		      (format nil "~a*~a" char stride)))
+		"+"))))
       (format nil "~a[~a]"
 	      (tensor-id tensor)
 	      (apply #'concatenate 'string
@@ -97,13 +106,22 @@ type:
   (declare (type AbstractTensor tensor))
   (let ((strides (map 'list #'(lambda (axis) (cStride tensor axis)) ranks)))
     (flet ((index-of (rank index stride)
-	     (list (format nil "(~a~a)*~a"
-			   (if (= 0 (cl-waffe2/vm.generic-tensor::compute-visible-start-idx
-				     (force-list (nth rank (tensor-view tensor)))))
-			       ""
-			       (format nil "~a+" (cOffset tensor rank)))
-			   index stride)
-		   "+")))
+	     (when (not (member index *solved-as-zero* :test #'string=))
+	       (list 
+		(let ((char
+			(format nil "(~a~a)"
+				(if (= 0 (cl-waffe2/vm.generic-tensor::compute-visible-start-idx
+					  (force-list (nth rank (tensor-view tensor)))))
+				    ""
+			            (format nil "~a+"
+					    (cl-waffe2/vm.generic-tensor::compute-visible-start-idx
+					     (force-list (nth rank (tensor-view tensor))))))
+				index)))
+		  (if (and (numberp stride)
+			   (= stride 1))
+		      char
+		      (format nil "~a*~a" char stride)))
+		"+"))))
       (format nil "~a[~a]"
 	      (or name (tensor-id tensor))
 	      (apply #'concatenate 'string
@@ -126,7 +144,7 @@ type:
       (loop for s in (map 'list #'index-of (range 0 (dims tensor)) strides)
 	    if s collect s))))
 
-(defun cFunction (function-name adjustable-shape arguments)
+(defun cFunction (function-name adjustable-shape arguments &key (displace-to-list nil))
   "Header:
 void function-name (int size, float * restrict x1, int stride, int offset, float* x2 ...)
 
@@ -139,15 +157,10 @@ void function-name (int size, float * restrict x1, int stride, int offset, float
 	    (loop for arg in arguments
 		  for nth upfrom 0
 		  ;; TENSOR_PTR OFFSET3 OFFSET2 OFFSET1
-		  do (cVar arg :restrict (= 1 (count (tensor-id arg) arguments :key #'tensor-id)) :comma t)
-		     (dotimes (rank (dims arg))
-		       (write-buff "const uint32_t ~a~a"
-				   (cOffset arg rank)
-				   ;; Judge if the last or not
-				   (if (and (= rank (1- (dims arg)))
-					    (= nth  (1- (length arguments))))
-				       ""
-				       ", "))))
+		  do (cVar arg :restrict (= 1 (count (tensor-id arg) arguments :key #'tensor-id))
+			       :comma (not (= nth (1- (length arguments))))
+			       :const (and (not (null displace-to-list))
+					   (not (member (tensor-id arg) displace-to-list)))))
 	    (write-buff ")"))))
     (format nil "void ~a~a" function-name arguments-form)))
 

--- a/source/backends/JITCPUTensor/compiler.lisp
+++ b/source/backends/JITCPUTensor/compiler.lisp
@@ -96,7 +96,7 @@
 			*use-open-mp*)
 	       (write-c-line (pragma-omp indices)))
 	     (write-c-line
-	      "for (int ~a=0;~a<~a;~a++) {~%"
+	      "for (uint32_t ~a=0;~a<~a;~a++) {~%"
 	      index-char
 	      index-char
 	      (c-name (format nil "~a" (aloop-size loop)))
@@ -108,7 +108,7 @@
 	       (write-c-line "#pragma omp parallel for ~%"))
 	     
 	     (write-c-line
-	      "for (int ~a=0;~a<~a;~a++) {~%"
+	      "for (uint32_t ~a=0;~a<~a;~a++) {~%"
 	      index-char
 	      index-char
 	      (c-name (format nil "~a" (aloop-element-n loop)))
@@ -142,7 +142,6 @@
     (write-c-line "~a { ~%" (cFunction function-name shapes variables))
     
     (with-indent 4
-
       (flet ((first-touch ()
 	       (when (and (= *indent-width* 4)
 			  *use-open-mp*)
@@ -162,12 +161,13 @@
 	;; disabled for a now
 	;;(first-touch)
 	)
-      
+
+      (print abstract-loop)
       
       (loop with indices = (iterator-symbols (length abstract-loop))
 	    for *indent-width* upfrom 4 by 4
-	    for index-char  in indices
-	    for loop        in abstract-loop do
+	    for index-char  in indices;;`(,@(reverse (butlast indices)) ,(car indices))
+	    for loop        in abstract-loop do;;`(,@(reverse (butlast abstract-loop)) ,(car abstract-loop)) do
 	      (case (aloop-mode loop)
 		(:batch
 		 ;; If *use-open-mp* is set to T and the currently processing loop is the first one
@@ -176,7 +176,7 @@
 			    *use-open-mp*)
 		   (write-c-line (pragma-omp indices)))
 		 (write-c-line
-		  "for (int ~a=0;~a<~a;~a++) {~%"
+		  "for (uint32_t ~a=0;~a<~a;~a++) {~%"
 		  index-char
 		  index-char
 		  (c-name (format nil "~a" (aloop-size loop)))
@@ -188,7 +188,7 @@
 		   (write-c-line "#pragma omp parallel for ~%"))
 		 
 		 (write-c-line
-		  "for (int ~a=0;~a<~a;~a++) {~%"
+		  "for (uint32_t ~a=0;~a<~a;~a++) {~%"
 		  index-char
 		  index-char
 		  (c-name (format nil "~a" (aloop-element-n loop)))

--- a/source/backends/JITCPUTensor/compiler.lisp
+++ b/source/backends/JITCPUTensor/compiler.lisp
@@ -136,7 +136,7 @@ int get_threads() { return omp_get_max_threads(); }
       T))
 
 (defparameter *solved-as-zero* nil)
-;; [Fix] private変数にしないとthreadでconflictssuru kamo
+;; [Fix] set private variables
 (defun generate-c-kernel (function-name shapes variables abstract-loop instructions
 			  &aux
 			    (multi-threading-thresholds 128)
@@ -329,14 +329,15 @@ int get_threads() { return omp_get_max_threads(); }
 			;; [Fix] Private Var?
 			(let ((name (format nil "~(~a~)" (gensym))))			
 			  (write-c-line
-			   "    ~a ~a = ~a;~%"
+			   "    ~a* ~a = &~a;~%"
 			   (dtype->ctype (dtype (loopvariable-tensor v)))
 			   name
 			   (cAref-with-ranks
 			    (loopvariable-tensor v)
 			    (map 'list #'iteration-index loop-stacks)
 			    (map 'list #'iteration-rank  loop-stacks)))
-			  (setf (gethash (tensor-id (loopvariable-tensor v)) placed) name))))
+			  (setf (gethash (tensor-id (loopvariable-tensor v)) placed)
+				(format nil "~a[0]" name)))))
 
 		    ;; Finally, rendering instructings
 		    (when (= nth (1- (length loop-strategy)))

--- a/source/backends/JITCPUTensor/dtype.lisp
+++ b/source/backends/JITCPUTensor/dtype.lisp
@@ -19,15 +19,16 @@
     (T (error "dtype->ctype: Attempted to generate C codes
 but failed because cl-waffe2 encountered an unsupported dtype: ~a" dtype))))
 
-(defun cType (tensor &key (restrict nil))
+(defun cType (tensor &key (restrict nil) (const nil))
   (declare (type AbstractTensor tensor)
 	   (type boolean restrict))
   (typecase tensor
     (JITCPUTensor
-     (write-buff "~a~a"
+     (write-buff "~a~a~a"
+		 (if const "const " "")
 		 (dtype->ctype (dtype tensor))
 		 (if restrict
-		     " * restrict "
+		     "* restrict "
 		     "* ")))
     (T
      (error "cType: the given tensor isn't JITAble.

--- a/source/backends/JITCPUTensor/foreign-function.lisp
+++ b/source/backends/JITCPUTensor/foreign-function.lisp
@@ -64,7 +64,7 @@ Tips: Modify cl-waffe2/backends.jit.cpu:*default-c-compiler* to switch compilers
   (with-slots ((name name) (dynamic-symbols dynamic-symbols) (args args)) jit-compiled-kernel
     `(lambda (,@(map 'list #'tensor-id args))
        (with-tensor-ptrs (,@(loop for arg in args
-				  collect `(,(cPointer arg) ,arg)))
+				  collect `(,(cPointer arg) ,(tensor-id arg))))
 	 (cffi:foreign-funcall
 	  ,name
 	  ,@(loop for symbol in dynamic-symbols

--- a/source/backends/JITCPUTensor/foreign-function.lisp
+++ b/source/backends/JITCPUTensor/foreign-function.lisp
@@ -73,12 +73,6 @@ Tips: Modify cl-waffe2/backends.jit.cpu:*default-c-compiler* to switch compilers
 	  ,@(loop for arg in args
 		  append
 		  (append
-		   `(:pointer ,(cPointer arg))
-		   (loop for rank upfrom 0 below (dims arg)
-			 append
-			 `(:uint32
-			   (cl-waffe2/vm.generic-tensor::compute-visible-start-idx
-			    (force-list
-			     (nth ,rank (tensor-view ,(tensor-id arg)))))))))
+		   `(:pointer ,(cPointer arg))))
 	  :void)))))
 

--- a/source/backends/JITCPUTensor/impls/arithmetic.lisp
+++ b/source/backends/JITCPUTensor/impls/arithmetic.lisp
@@ -1,33 +1,35 @@
 
 (in-package :cl-waffe2/backends.jit.cpu)
 
+;; AbstractNodes which extends CPUJIT-Blueprint
+;;  => Later JIT-Compiled by the event of on-finalizing-compiling.
+;; It :forward slot gives no vaild ops
+;; Instead, load-instructions gives an implementation that can be fused or deleted later.
 (macrolet ((define-arith-impl (name fname)
 	     `(progn
 		(define-impl (,name
 			      :device JITCPUTensor
 			      :extends (CPUJIT-Blueprint))
 			     :forward ((self x y)
-				       (let ((f (invoke-compiler
-						 (symbol-name (gensym (symbol-name ',name)))
-						 (list
-						  (make-inst :modify ,fname x (list y))))))
-					 `(progn
-					    (funcall ,(jit-funcall-form f) ,@(jit-args f))
-					    ,x)))))))
+				       (declare (ignore y))
+				       ;; Its actual forward definition is described in load-instructions:
+				       ;; Later compiled
+				       `(progn ,x)))
+		(defmethod load-instructions ((node ,name) &rest inputs)
+		  (list
+		   (make-inst :modify ,fname (car inputs) (cdr inputs)))))))
   (define-arith-impl AddNode "+=")
   (define-arith-impl SubNode "-=")
   (define-arith-impl MulNode "*=")
   (define-arith-impl DivNode "/="))
 
-
 (define-impl (MoveTensorNode :device JITCPUTensor :extends (CPUJIT-Blueprint))
 	     :forward ((self out target)
+		       (declare (ignore target))
 		       ;; Move: out <- target
-		       (let ((f (invoke-compiler
-				 (symbol-name (gensym "MOVE"))
-				 (list
-				  (make-inst :modify "=" out (list target))))))
-			 `(progn
-			    (funcall ,(jit-funcall-form f) ,@(jit-args f))
-			    ,out))))
+		       `(progn ,out)))
+
+(defmethod load-instructions ((node MoveTensorNode) &rest inputs)
+  (list
+   (make-inst :modify "=" (car inputs) (cdr inputs))))
 

--- a/source/backends/JITCPUTensor/impls/math.lisp
+++ b/source/backends/JITCPUTensor/impls/math.lisp
@@ -1,5 +1,6 @@
 
 (in-package :cl-waffe2/backends.jit.cpu)
 
-;; (TODO)
+;; Nothing here.
+
 

--- a/source/backends/JITCPUTensor/ir.lisp
+++ b/source/backends/JITCPUTensor/ir.lisp
@@ -13,7 +13,7 @@
 	(:modify
 	 ;; modify: A fname B
 	 (write-c-line "~a ~a ~a;~%"
-		       (cAref displace-to indices)
+		       (or (place-holder-p displace-to) (cAref displace-to indices))
 		       fname		     
 		       (apply
 			#'concatenate
@@ -25,7 +25,7 @@
 	(:apply
 	 ;; apply: A = fname(B)
 	 (write-c-line "~a ~a ~a;~%"
-		       (cAref displace-to indices)
+		       (or (place-holder-p displace-to) (cAref displace-to indices))
 		       fname
 		       (apply
 			#'concatenate

--- a/source/backends/JITCPUTensor/ir.lisp
+++ b/source/backends/JITCPUTensor/ir.lisp
@@ -11,7 +11,7 @@
        ;; modify: A fname B
        (write-c-line "~a ~a ~a;~%"
 		     (cAref displace-to indices)
-		     fname
+		     fname		     
 		     (apply
 		      #'concatenate
 		      'string

--- a/source/backends/JITCPUTensor/ir.lisp
+++ b/source/backends/JITCPUTensor/ir.lisp
@@ -8,7 +8,12 @@
   (with-slots ((type type) (displace-to displace-to) (args args) (fname fname)) instruction
     (flet ((place-holder-p (tensor)
 	     (and place-holders
-		  (gethash (tensor-id tensor) place-holders))))
+		  (let ((result (gethash (tensor-id tensor) place-holders)))
+		    (and
+		     result
+		     (if (functionp result)
+			 (funcall result)
+			 result))))))
       (case type
 	(:modify
 	 ;; modify: A fname B

--- a/source/backends/JITCPUTensor/ir.lisp
+++ b/source/backends/JITCPUTensor/ir.lisp
@@ -1,36 +1,39 @@
 
 (in-package :cl-waffe2/backends.jit.cpu)
 
-(defun render-instruction (instruction indices)
+(defun render-instruction (instruction indices &optional (place-holders nil))
   (declare (type Instruction instruction)
 	   (type list indices))
 
   (with-slots ((type type) (displace-to displace-to) (args args) (fname fname)) instruction
-    (case type
-      (:modify
-       ;; modify: A fname B
-       (write-c-line "~a ~a ~a;~%"
-		     (cAref displace-to indices)
-		     fname		     
-		     (apply
-		      #'concatenate
-		      'string
-		      (butlast
-		       (loop for arg in args
-			     append
-			     (list (cAref arg indices) ", "))))))
-      (:apply
-       ;; apply: A = fname(B)
-       (write-c-line "~a ~a ~a;~%"
-		     (cAref displace-to indices)
-		     fname
-		     (apply
-		      #'concatenate
-		      'string
-		      (butlast
-		       (loop for arg in args
-			     append
-			     (list (cAref arg indices) ", "))))))
-      (T
-       (error "Unknown instruction type: ~a" instruction)))))
+    (flet ((place-holder-p (tensor)
+	     (and place-holders
+		  (gethash (tensor-id tensor) place-holders))))
+      (case type
+	(:modify
+	 ;; modify: A fname B
+	 (write-c-line "~a ~a ~a;~%"
+		       (cAref displace-to indices)
+		       fname		     
+		       (apply
+			#'concatenate
+			'string
+			(butlast
+			 (loop for arg in args
+			       append
+			       (list (or (place-holder-p arg) (cAref arg indices)) ", "))))))
+	(:apply
+	 ;; apply: A = fname(B)
+	 (write-c-line "~a ~a ~a;~%"
+		       (cAref displace-to indices)
+		       fname
+		       (apply
+			#'concatenate
+			'string
+			(butlast
+			 (loop for arg in args
+			       append
+			       (list (or (place-holder-p arg) (cAref arg indices)) ", "))))))
+	(T
+	 (error "Unknown instruction type: ~a" instruction))))))
 

--- a/source/backends/JITCPUTensor/on-finalizing.lisp
+++ b/source/backends/JITCPUTensor/on-finalizing.lisp
@@ -52,7 +52,7 @@
 
 		  ;; [TODO]
 		  ;; compilers should be reluctant to insert a new c line which is not worth it.		  
-		  (setf (wfop-op inst) (make-jit-compiled-op (symbol-name (gensym)) ir))
+		  (setf (wfop-op inst) (make-jit-compiled-op (symbol-name (gensym "FOREIGN_")) ir))
 		  (push inst out)))
 	       (T
 		(push inst out))))

--- a/source/backends/JITCPUTensor/on-finalizing.lisp
+++ b/source/backends/JITCPUTensor/on-finalizing.lisp
@@ -1,14 +1,31 @@
 
 (in-package :cl-waffe2/backends.jit.cpu)
 
-(defparameter *lazy-c-source* "")
+;; Env in my macbook:
+;; (cpujit-set-config
+;;    :compiler "/usr/local/bin/gcc-13"
+;;    :viz-compiled-code nil
+;;    :openmp t)
+
+(defparameter *lazy-c-source* "
+(gensym).c
+#pragma simd
+<<Headers>>
+
+<<Definitions>>
+")
+
 (defparameter *compiling-ntime-count* 0)
 
 ;; [Fix] 何回も同じコードをコンパイルするの？
 ;; [TODO] Im2Col Col2Im Fusion
 ;; [TODO] OpenMP
-;;  1. 最適化関数 A-=...が動いていない？
-;;  2. OpのArgs Outs関連
+
+;; Workloads:
+;;  - [Fix] 何回も同じコードをコンパイルするのか？
+;;  - [Opt] Im2Col Col2Im
+;;  - [Add] OpenMP (thresholds, nested)
+;;  - [Add]
 
 ;; This is a toplevel of JIT-Compiling Backend
 ;; After High-Level IR compiling is finished, the method on-finalizing-compiling will be invoked.
@@ -32,6 +49,9 @@
 		  ;; So just replacing op is ok and wfop-args cause no conflicts
 		  ;; But If the instruction is created by fusion several ops
 		  ;; we have to note that create a new WfINstruction
+
+		  ;; [TODO]
+		  ;; compilers should be reluctant to insert a new c line which is not worth it.		  
 		  (setf (wfop-op inst) (make-jit-compiled-op (symbol-name (gensym)) ir))
 		  (push inst out)))
 	       (T

--- a/source/backends/JITCPUTensor/package.lisp
+++ b/source/backends/JITCPUTensor/package.lisp
@@ -4,11 +4,11 @@
 (defpackage :cl-waffe2/backends.jit.cpu
   (:documentation ":cl-waffe2/backends.jit.cpu provides JIT compiler from cl-waffe2 codes to well vectorized C codes.")
   (:use :cl
-	:alexandria
+        :alexandria
 	:cl-waffe2/distributions
-	:cl-waffe2/vm
+        :cl-waffe2/vm
         :cl-waffe2/vm.generic-tensor
-	:cl-waffe2/vm.nodes
+        :cl-waffe2/vm.nodes
         :cl-waffe2/base-impl)
   (:export
    #:*default-c-compiler*

--- a/source/backends/JITCPUTensor/tensor.lisp
+++ b/source/backends/JITCPUTensor/tensor.lisp
@@ -4,10 +4,16 @@
 (defclass JITCPUTensor (cl-waffe2/backends.cpu:CPUTensor) nil
   (:documentation "
 ## [AbstractTensor] JITCPUTensor
+
+```lisp
+(with-devices (JITCPUTensor CPUTensor LispTensor)
+    ;; Your code follows...
+    )
+```
 "))
 
 (defmethod current-backend-state ((backend-name (eql 'JITCPUTensor)))
-  (format nil "compiler=~a flags=~a viz=~a openMP=~a"
+  (format nil "compiler=~a flags=~a viz=~a OpenMP=~a"
 	  *default-c-compiler*
 	  *compiler-flags*
 	  *viz-compiled-code*
@@ -39,16 +45,16 @@ Declares configurations about JITCPUTensor.
 
 `compiler[string]` a compiler to use. in default set to gcc
 
-`viz-compiled-code[boolean]` set t to display generated C codes.
+`viz-compiled-code[boolean]` Set t to display generated C codes.
 
-`openmp[boolean]` set to use OpenMP
+`openmp[boolean]` Set t to use OpenMP.
 
 `flags[list]` additional compiler flags.
 "
   (setf *default-c-compiler* compiler
-	*viz-compiled-code* viz-compiled-code
-	*use-open-mp* openMP
-	*compiler-flags* flags)
+	*viz-compiled-code*  viz-compiled-code
+	*use-open-mp*        openMP
+	*compiler-flags*     flags)
   t)
 
 (defmacro with-cpu-jit ((&rest more-devices) &body body)

--- a/source/backends/JITCPUTensor/tensor.lisp
+++ b/source/backends/JITCPUTensor/tensor.lisp
@@ -54,7 +54,7 @@ Declares configurations about JITCPUTensor.
   (setf *default-c-compiler* compiler
 	*viz-compiled-code*  viz-compiled-code
 	*use-open-mp*        openMP
-	*compiler-flags*     flags)
+	*compiler-flags*     `(,@flags ,(when openMP "-fopenmp")))
   t)
 
 (defmacro with-cpu-jit ((&rest more-devices) &body body)

--- a/source/nn/t/regression.lisp
+++ b/source/nn/t/regression.lisp
@@ -459,7 +459,7 @@
   (is (cl-waffe2::with-row-major (grad-decay-test))))
 
 (defun jit-test ()
-  (with-devices (JITCPUTensor CPUTEnsor cl-waffe2/backends.lisp:LispTensor)
+  (with-devices (JITCPUTensor CPUTensor cl-waffe2/backends.lisp:LispTensor)
     (grad-decay-test)))
 
 (test jit-grad-decay-test

--- a/source/vm/compile.lisp
+++ b/source/vm/compile.lisp
@@ -217,8 +217,11 @@ Tips: `disassemble-waffe2-ir` to display compiled Instruction Sequence.
 	(let ((forward  (reverse iseq-forward))
 	      (backward (if (and need-backward out-symbol-p (not (scalar-p toplevel)))
 			    (append
-			     (reverse
-			      (node-compile-into-vm dout))
+			     (let ((out
+				     (reverse
+				      (node-compile-into-vm dout))))
+			       (setf (wfop-comment (car out)) "dout += 1")
+			       out)
 			     backward-iseq)
 			    backward-iseq)))
 	  

--- a/source/vm/compile.lisp
+++ b/source/vm/compile.lisp
@@ -39,20 +39,22 @@
      ;; Has reached out the end of nodes.
      nil)
     (T
-     (let ((result
-	     (make-wfop
-	      (apply
-	       #'find-cached-function
-	       (statecontainer-forward-out-form (tensor-state tensor))
-	       *compile-option*
-	       (tensor-variables tensor))
-	      tensor
-	      (tensor-backward tensor)
-	      (tensor-variables tensor)
-	      :out-to (node-out-to (tensor-backward tensor))
-	      :sv4bw  (node-sv4bw (tensor-backward tensor)))))
-       (setf (tensor-compiled-instruction-cache-fw tensor) result)
-       result))))
+     (multiple-value-bind (f lut-p) (apply
+				     #'find-cached-function
+				     (statecontainer-forward-out-form (tensor-state tensor))
+				     *compile-option*
+				     (tensor-variables tensor))
+       (let ((result
+	       (make-wfop
+		f
+		tensor
+		(tensor-backward tensor)
+		(tensor-variables tensor)
+		:lut-cache-p lut-p
+		:out-to (node-out-to (tensor-backward tensor))
+		:sv4bw  (node-sv4bw (tensor-backward tensor)))))
+	 (setf (tensor-compiled-instruction-cache-fw tensor) result)
+	 result)))))
 
 ;;
 ;; Avoid duplicate compilation:

--- a/source/vm/generic-tensor/cache.lisp
+++ b/source/vm/generic-tensor/cache.lisp
@@ -118,6 +118,7 @@
 	(apply target args))))
 
 (defun find-cached-function (kernel-function compile-option &rest args)
+  "Return: (values result is-the-result-from-lut?)"
   (declare (type Compiled-Kernel kernel-function))
 
   (let* ((function-name (compiled-kernel-name kernel-function))
@@ -137,6 +138,6 @@
 	     function-name
 	     args
 	     :setme compiled-function))
-	  compiled-function)
-	target)))
+	  (values compiled-function nil))
+	(values target t))))
 

--- a/source/vm/ir.lisp
+++ b/source/vm/ir.lisp
@@ -10,7 +10,7 @@
 
 (defstruct (WfInstruction
 	    (:conc-name wfop-)
-	    (:constructor make-wfop (op self node args &key (sv4bw nil) (out-to nil) (block-iseq nil) (grad-adder-p nil) (loadp nil))))
+	    (:constructor make-wfop (op self node args &key (sv4bw nil) (out-to nil) (block-iseq nil) (grad-adder-p nil) (loadp nil) (comment nil))))
   "
 ## [struct] WfInstruction
 
@@ -48,6 +48,10 @@ SV4BW (i.e: save-for-backward) is a temporary tensor to compute backwards and cl
 `wfop-args[list of AbstractTensor]` corresponds with `(tensor-variable wfop-self)`. tensors to be called with: `arg1 arg2 arg3...`.
 
 `wfop-sv4bw[list of AbstractTensor]` indicates list of tensors storing save-for-backward tensors. if the corresponding position is `save-for-backward=nil`, the corresponding position also become nil.
+
+`wfop-comment[string or null]` If any, the value of slot is displayed when printing IR.
+
+`wfop-loadp[boolean]` If set to t, the operation is interpreted as `load-pointer`. See also: (read-loadp instruction)
 "
   (op   op   :type function)  
   (node node :type (or function string null AbstractNode))
@@ -60,7 +64,8 @@ SV4BW (i.e: save-for-backward) is a temporary tensor to compute backwards and cl
   (error-check-p nil :type boolean) ;; Indicates the first shape-inspection has done?
   (bw-is-leaf-p nil :type boolean)
   (grad-adder-p grad-adder-p :type boolean)
-  (loadp loadp :type boolean))
+  (loadp loadp :type boolean)
+  (comment comment :type (or null string)))
 
 (defparameter *omit-args-n* 5)
 (defparameter *opname-indent-to* 0 "Adds a space for this param times")
@@ -75,12 +80,15 @@ SV4BW (i.e: save-for-backward) is a temporary tensor to compute backwards and cl
       (multiple-value-bind (from to) (read-loadp inst)
 	(format
 	 stream
-	 "~a~a : ~a* = ~a*>~a"
+	 "~a~a : ~a* = ~a*>~a~a"
 	 opname
 	 (with-output-to-string (out)
 	   (dotimes (i (- *opname-indent-to* (length opname))) (princ " " out)))
 	 (tensor-id from)
 	 (tensor-id to)
+	 (if (wfop-comment inst)
+	     (format nil " ;; ~a" (wfop-comment inst))
+	     "")
 	 (if *no-newline*
 	     ""
 	     (format nil "~%"))))
@@ -90,7 +98,7 @@ SV4BW (i.e: save-for-backward) is a temporary tensor to compute backwards and cl
   (let ((ignored-p (and (movetensor-p (wfop-node inst))
 			(movetensor-ignore-me (wfop-node inst)))))
     (format stream
-	    "~a~a : ~a<= op(~a)>~a"
+	    "~a~a : ~a<= op(~a)>~a~a"
 	    (instruction-opname inst)
 	    (with-output-to-string (out)
 	      (dotimes (i (- *opname-indent-to* (length (instruction-opname inst)))) (princ " " out)))
@@ -129,6 +137,9 @@ SV4BW (i.e: save-for-backward) is a temporary tensor to compute backwards and cl
 				  (if (nth (1+ i) (wfop-args inst))
 				      " "
 				      "")))))))
+	    (if (wfop-comment inst)
+		(format nil " ;; ~a" (wfop-comment inst))
+		"")
 	    (if *no-newline*
 		""
 		(format nil "~%")))))

--- a/source/vm/ir.lisp
+++ b/source/vm/ir.lisp
@@ -10,7 +10,7 @@
 
 (defstruct (WfInstruction
 	    (:conc-name wfop-)
-	    (:constructor make-wfop (op self node args &key (sv4bw nil) (out-to nil) (block-iseq nil) (grad-adder-p nil) (loadp nil) (comment nil))))
+	    (:constructor make-wfop (op self node args &key (sv4bw nil) (out-to nil) (block-iseq nil) (grad-adder-p nil) (loadp nil) (comment nil) (lut-cache-p nil))))
   "
 ## [struct] WfInstruction
 
@@ -52,6 +52,8 @@ SV4BW (i.e: save-for-backward) is a temporary tensor to compute backwards and cl
 `wfop-comment[string or null]` If any, the value of slot is displayed when printing IR.
 
 `wfop-loadp[boolean]` If set to t, the operation is interpreted as `load-pointer`. See also: (read-loadp instruction)
+
+`wfop-lut-cache-p[boolean]` If set to T, indicates `wfop-op` is already compiled and cached in LUT.
 "
   (op   op   :type function)  
   (node node :type (or function string null AbstractNode))
@@ -65,6 +67,7 @@ SV4BW (i.e: save-for-backward) is a temporary tensor to compute backwards and cl
   (bw-is-leaf-p nil :type boolean)
   (grad-adder-p grad-adder-p :type boolean)
   (loadp loadp :type boolean)
+  (lut-cache-p lut-cache-p :type boolean)
   (comment comment :type (or null string)))
 
 (defparameter *omit-args-n* 5)

--- a/source/vm/package.lisp
+++ b/source/vm/package.lisp
@@ -40,7 +40,8 @@
    #:wfop-args
    #:wfop-loadp
    #:read-loadp
-   #:wfop-comment))
+   #:wfop-comment
+   #:wfop-lut-cache-p))
 
 (in-package :cl-waffe2/vm)
 

--- a/source/vm/package.lisp
+++ b/source/vm/package.lisp
@@ -39,7 +39,8 @@
    #:wfop-sv4bw
    #:wfop-args
    #:wfop-loadp
-   #:read-loadp))
+   #:read-loadp
+   #:wfop-comment))
 
 (in-package :cl-waffe2/vm)
 


### PR DESCRIPTION
# Changes

## JITCPUTensor

- [Optimize] Increased the stability of OpenMP Support
- [Optimize] Tiling, Unrolling, Loop Reordering to maximize the use of L1/L2 caches
    - `!permute` actually works 2x~3x times faster than Numpy
    - This is the only case of smaller batch-size(2~10) but Conv2D works 5x times faster than PyTorch
- [Optimize] Simplify the computation of strides
- [Optimize] The backend is now able to detect reduction.

## What's still missing?
- Im2Col, Col2Im nodes are remained to be optimized:
    - It is possible for me to write an optimized kernel, but it violates the concepts of cl-waffe2
    - Its implementation should be realized by combining !move and !view but it beyonds cl-waffe2 due to:
        - 1. The implementation of `view.lisp` `call-with-view.lisp` `do-compiled-loop.lisp` should be much more polished!
        - 2. I wish !view can handle `(range X Y Z)` like Petalisp
     - or should I adapt Petalisp on cl-waffe2 backends?