### PR TITLE
[BugFix] Compiled and cached functions produces any unexpected side-effects

### DIFF
--- a/examples/mnist/mlp.lisp
+++ b/examples/mnist/mlp.lisp
@@ -66,7 +66,7 @@
 
 (defun train-and-valid-mlp (&key (epoch-num 10) (benchmark-p t))
   (multiple-value-bind (compiled-model model)
-      (with-backend :jit
+      (with-backend :cpu
 	(build-mlp-model :in-class 784 :out-class 10 :lr 1e-3))
     (let* ((train-img *reshaped-train-img-data*)
 	   (test-img  *reshaped-test-img-data*)

--- a/source/base-impl/fundamental.lisp
+++ b/source/base-impl/fundamental.lisp
@@ -742,8 +742,8 @@ CL-WAFFE2-REPL> (proceed-bench (!sum (randn `(3 3))))
       (cl-waffe2/vm:compile-forward-and-backward tensor :compile-mode compile-mode :fuse-p fuse-p)
     (declare (ignore leaves dout))
     (let ((cl-waffe2/vm.generic-tensor::*runtime-mode-p* t))
-      (cl-waffe2/vm.generic-tensor::with-adjustable-symbol-scope
-	(cl-waffe2/vm::with-static-allocation (allocation)
+      (wf/t:with-adjustable-symbol-scope
+	(wf/vm::with-static-allocation (allocation)
 	  (let ((result))
 	    (setq result
 		  (cl-waffe2/vm:benchmark-accept-instructions fw-iseq

--- a/source/optimizers/impls/adam.lisp
+++ b/source/optimizers/impls/adam.lisp
@@ -98,7 +98,6 @@ See the [original paper](https://arxiv.org/abs/1412.6980) for detailed algorithm
 	 (param (read-parameter optimizer))
 	 (grad  (grad param)))
     (with-no-grad
-      ;; TODO: Cache?
       (apply-adam-step-m
        (adam-m optimizer)
        grad ;; the gradient involved in in-place op

--- a/source/vm/generic-tensor/cache.lisp
+++ b/source/vm/generic-tensor/cache.lisp
@@ -55,15 +55,19 @@
 
 
 (defparameter *compiled-function-cache* (make-hash-table :test #'equal))
-(defparameter *compiled-jit-function-cache* (make-hash-table))
 
 (defun reset-compiled-function-cache! ()
   "
 ## [function] reset-compiled-function-cache!
 "
   (setf *compiled-function-cache* (make-hash-table :test #'equal))
-  (setf *compiled-jit-function-cache* (make-hash-table))
   t)
+
+(defmacro with-empty-cached-function-table (&body body)
+  "Under the body execution, this macro sets *compiled-function-cache* = nil indicating no previous compiled functions before this macro are reused during `build` and `proceed` compilation."
+  `(let ((*compiled-function-cache*
+	   (make-hash-table :test #'equal)))
+     ,@body))
 
 (defstruct Compiled-Kernel
   "All forward method must return this structure. Compiled-Kernel is an blueprint (or stores compiled functions) to generate cl-waffe2 IR"

--- a/source/vm/generic-tensor/package.lisp
+++ b/source/vm/generic-tensor/package.lisp
@@ -27,6 +27,7 @@
   
   (:export
    ;;#:*cache-directory*
+   #:with-empty-cached-function-table
    #:with-memory-pool
    #:make-clone
    #:print-current-memory-pool

--- a/source/vm/nodes/model-compiler.lisp
+++ b/source/vm/nodes/model-compiler.lisp
@@ -163,7 +163,6 @@ expected: AbstractTensor"
 								:fuse-ops t
 								:defmodel-as-from named
 								:dout-add1 nil))) ;; <- Embodied by AbstractNode
-	
 	(values compiled-model trace-tensors)))))
 
 (defun expand-define->function-form (composite where defun-p named


### PR DESCRIPTION
This PR is basically the bugfix of an issue reported in #148; calling the function `build` is now accompanies with a cache reset.